### PR TITLE
Add test suite, metrics module and CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements.txt
+      - run: python -m pip install ruff pyright
+      - run: ruff pa_core tests
+      - run: pyright
+      - run: pytest -q

--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -17,6 +17,7 @@ from .simulations import (
     simulate_alpha_streams,
 )
 from .reporting import export_to_excel
+from .metrics import tracking_error, value_at_risk
 
 __all__ = [
     "select_csv_file",
@@ -32,4 +33,6 @@ __all__ = [
     "draw_financing_series",
     "simulate_alpha_streams",
     "export_to_excel",
+    "tracking_error",
+    "value_at_risk",
 ]

--- a/pa_core/metrics.py
+++ b/pa_core/metrics.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+import numpy as np
+
+__all__ = ["tracking_error", "value_at_risk"]
+
+
+def tracking_error(strategy: np.ndarray, benchmark: np.ndarray) -> float:
+    """Return the standard deviation of active returns."""
+    if strategy.shape != benchmark.shape:
+        raise ValueError("shape mismatch")
+    diff = np.asarray(strategy) - np.asarray(benchmark)
+    return float(np.std(diff, ddof=1))
+
+
+def value_at_risk(returns: np.ndarray, confidence: float = 0.95) -> float:
+    """Return the empirical VaR at the given confidence level."""
+    if not 0 < confidence < 1:
+        raise ValueError("confidence must be between 0 and 1")
+    flat = np.asarray(returns).reshape(-1)
+    percentile = 100 * (1 - confidence)
+    return float(np.percentile(flat, percentile))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+line-length = 88
+extend-ignore = ["E501"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+    "include": ["pa_core"],
+    "reportMissingImports": false
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ numpy
 pandas
 openpyxl
 jupyter
+pytest
+hypothesis
+ruff
+pyright

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,29 @@
+import numpy as np
+from pa_core.metrics import tracking_error, value_at_risk
+
+
+def test_tracking_error_constant_series():
+    strat = np.full(12, 0.05)
+    bench = np.full(12, 0.05)
+    assert tracking_error(strat, bench) == 0.0
+
+
+def test_value_at_risk_constant_series():
+    returns = np.full(20, -0.01)
+    assert value_at_risk(returns, 0.95) == -0.01
+
+
+def test_value_at_risk_extreme():
+    returns = np.array([-0.5] * 10 + [0.1] * 90)
+    var = value_at_risk(returns, 0.99)
+    assert var <= -0.5
+
+
+def test_metrics_shape_mismatch():
+    try:
+        tracking_error(np.arange(5), np.arange(6))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError")
+

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,0 +1,13 @@
+from hypothesis import given, strategies as st
+import numpy as np
+from pa_core.simulations import simulate_financing
+
+@given(
+    T=st.integers(min_value=1, max_value=24),
+    n_scenarios=st.integers(min_value=1, max_value=10),
+)
+def test_simulate_financing_shapes(T, n_scenarios):
+    out = simulate_financing(T, 0.0, 0.01, 0.0, 1.0, n_scenarios=n_scenarios)
+    expected_shape = (T,) if n_scenarios == 1 else (n_scenarios, T)
+    assert out.shape == expected_shape
+    assert np.all(np.isfinite(out))

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import openpyxl
+from pathlib import Path
+import tempfile
+from pa_core.reporting import export_to_excel
+
+
+def test_export_to_excel_sheets(tmp_path: Path):
+    inputs = {"a": 1, "b": 2}
+    summary = pd.DataFrame({"Base": [0.1]})
+    raw = {"Base": pd.DataFrame([[0.1, 0.2]], columns=[0, 1])}
+    file_path = tmp_path / "out.xlsx"
+    export_to_excel(inputs, summary, raw, filename=str(file_path))
+    wb = openpyxl.load_workbook(file_path)
+    assert set(wb.sheetnames) == {"Inputs", "Summary", "Base"}

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -11,3 +11,17 @@ def test_simulate_financing_shape():
     out = simulate_financing(12, 0.0, 0.01, 0.0, 2.0, n_scenarios=5)
     assert out.shape == (5, 12)
     assert np.all(out >= 0)
+
+
+def test_build_cov_matrix_near_singular():
+    cov = build_cov_matrix(0.99, 0.99, 0.99, 0.99, 0.99, 0.99, 0.2, 0.2, 0.2, 0.2)
+    # matrix should remain symmetric
+    assert cov.shape == (4, 4)
+    assert np.allclose(cov, cov.T)
+
+
+def test_simulate_financing_spikes():
+    out = simulate_financing(6, 0.0, 1.0, 1.0, 5.0, seed=42)
+    # with spike_prob=1 all months should include spike component
+    assert np.all(out >= 0)
+    assert np.all(out > 0)


### PR DESCRIPTION
## Summary
- add `metrics.py` with basic tracking error and VaR helpers
- expose metrics in `pa_core.__init__`
- expand requirements for testing and linting
- implement property-based and edge case tests
- add reporting test for Excel export
- provide Ruff/Pyright configuration and CI workflow

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614bcb5d908331b5297ebd13dacdd1