### PR TITLE
Fix lint and type issues

### DIFF
--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 import argparse
-from pathlib import Path
-
-import numpy as np
 import pandas as pd
 
 from . import (
-    select_csv_file,
     load_parameters,
     get_num,
     load_index_returns,
@@ -48,8 +44,8 @@ def main() -> None:
 
     raw_params = load_parameters(args.params, LABEL_MAP)
     idx_series = load_index_returns(args.index)
-    mu_idx = idx_series.mean()
-    idx_sigma = idx_series.std(ddof=1)
+    mu_idx = float(idx_series.mean())
+    idx_sigma = float(idx_series.std(ddof=1))
 
     mu_H = get_num(raw_params, "mu_H", 0.04)
     sigma_H = get_num(raw_params, "sigma_H", 0.01)
@@ -58,7 +54,7 @@ def main() -> None:
     mu_M = get_num(raw_params, "mu_M", 0.03)
     sigma_M = get_num(raw_params, "sigma_M", 0.02)
 
-    cov = build_cov_matrix(
+    _ = build_cov_matrix(
         get_num(raw_params, "rho_idx_H", 0.05),
         get_num(raw_params, "rho_idx_E", 0.0),
         get_num(raw_params, "rho_idx_M", 0.0),

--- a/pa_core/io.py
+++ b/pa_core/io.py
@@ -103,10 +103,10 @@ def build_range_int(raw_params, key_base, default_midpoint):
     k_max = get_num(raw_params, f"{key_base}_max", None)
     k_step = get_num(raw_params, f"{key_base}_step", None)
     if (k_min is not None) and (k_max is not None):
-        step = k_step if (k_step is not None) else (k_max - k_min)
+        step = int(k_step if (k_step is not None) else (k_max - k_min))
         if step <= 0:
             raise RuntimeError(f"Step for '{key_base}' must be positive.")
-        return list(range(k_min, k_max + 1, step))
+        return list(range(int(k_min), int(k_max) + 1, step))
     flat_list = raw_params.get(f"{key_base}_list", None)
     if isinstance(flat_list, list):
         return flat_list

--- a/pa_core/reporting.py
+++ b/pa_core/reporting.py
@@ -7,9 +7,10 @@ __all__ = ["export_to_excel"]
 def export_to_excel(inputs_dict, summary_df, raw_returns_dict, filename="Outputs.xlsx"):
     """Write inputs, summary, and raw returns into an Excel workbook."""
     with pd.ExcelWriter(filename, engine="openpyxl") as writer:
-        df_inputs = pd.DataFrame.from_dict(inputs_dict, orient="index", columns=["Value"])
-        df_inputs.index.name = "Parameter"
-        df_inputs.reset_index(inplace=True)
+        df_inputs = pd.DataFrame({
+            "Parameter": list(inputs_dict.keys()),
+            "Value": list(inputs_dict.values()),
+        })
         df_inputs.to_excel(writer, sheet_name="Inputs", index=False)
         summary_df.to_excel(writer, sheet_name="Summary", index=False)
         for sheet_name, df in raw_returns_dict.items():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import openpyxl
 from pathlib import Path
-import tempfile
 from pa_core.reporting import export_to_excel
 
 


### PR DESCRIPTION
## Summary
- clean up unused imports
- cast float values to satisfy type checks
- make reporting helper build dataframe explicitly
- tighten build_range_int logic
- remove unused imports in tests

## Testing
- `ruff check pa_core tests`
- `pyright`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861521f8edc8331be5c5f2677bca097