### PR TITLE
Implement agent classes and registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .ipynb_checkpoints/
+.hypothesis/
+__pycache__/
+pa_core/**/__pycache__/
+tests/__pycache__/
 .ipynb_checkpoints/

--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -18,6 +18,16 @@ from .simulations import (
 )
 from .reporting import export_to_excel
 from .metrics import tracking_error, value_at_risk
+from .agents import (
+    Agent,
+    AgentParams,
+    BaseAgent,
+    ExternalPAAgent,
+    ActiveExtensionAgent,
+    InternalBetaAgent,
+    InternalPAAgent,
+)
+from .agents.registry import build_all as build_agents
 
 __all__ = [
     "select_csv_file",
@@ -35,4 +45,12 @@ __all__ = [
     "export_to_excel",
     "tracking_error",
     "value_at_risk",
+    "Agent",
+    "AgentParams",
+    "BaseAgent",
+    "ExternalPAAgent",
+    "ActiveExtensionAgent",
+    "InternalBetaAgent",
+    "InternalPAAgent",
+    "build_agents",
 ]

--- a/pa_core/agents/__init__.py
+++ b/pa_core/agents/__init__.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Any
+import numpy as np
+
+Array = np.ndarray
+
+@dataclass
+class AgentParams:
+    name: str
+    capital_mm: float
+    beta_share: float
+    alpha_share: float
+    extra_args: Dict[str, Any] | None = None
+
+
+class Agent:
+    """Abstract sleeve. Child classes implement ``monthly_returns``."""
+
+    def __init__(self, p: AgentParams) -> None:
+        self.p = p
+        self.extra = p.extra_args or {}
+
+    def monthly_returns(
+        self,
+        r_beta: Array,
+        alpha_stream: Array,
+        financing: Array,
+    ) -> Array:
+        raise NotImplementedError
+
+
+class BaseAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        return (
+            self.p.beta_share * (r_beta - financing)
+            + self.p.alpha_share * alpha_stream
+        )
+
+
+class ExternalPAAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        theta = float(self.extra.get("theta_extpa", 0.0))
+        return (
+            self.p.beta_share * (r_beta - financing)
+            + (self.p.beta_share * theta) * alpha_stream
+        )
+
+
+class ActiveExtensionAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        active_share = float(self.extra.get("active_share", 0.5))
+        return (
+            self.p.beta_share * (r_beta - financing)
+            + (self.p.beta_share * active_share) * alpha_stream
+        )
+
+
+class InternalBetaAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        return self.p.beta_share * (r_beta - financing)
+
+
+class InternalPAAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape:
+            raise ValueError("shape mismatch")
+        return self.p.alpha_share * alpha_stream
+

--- a/pa_core/agents/registry.py
+++ b/pa_core/agents/registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from typing import Iterable, List
+
+from . import (
+    Agent,
+    AgentParams,
+    BaseAgent,
+    ExternalPAAgent,
+    ActiveExtensionAgent,
+    InternalBetaAgent,
+    InternalPAAgent,
+)
+
+
+_AGENT_MAP = {
+    "Base": BaseAgent,
+    "ExternalPA": ExternalPAAgent,
+    "ActiveExt": ActiveExtensionAgent,
+    "InternalBeta": InternalBetaAgent,
+    "InternalPA": InternalPAAgent,
+}
+
+
+def build_all(params_list: Iterable[AgentParams]) -> List[Agent]:
+    """Instantiate agents from a list of AgentParams."""
+    agents: List[Agent] = []
+    for p in params_list:
+        cls = _AGENT_MAP.get(p.name)
+        if cls is None:
+            raise KeyError(f"Unknown agent name: {p.name}")
+        agents.append(cls(p))
+    return agents
+

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,67 @@
+import numpy as np
+from pa_core.agents import (
+    AgentParams,
+    BaseAgent,
+    ExternalPAAgent,
+    ActiveExtensionAgent,
+    InternalBetaAgent,
+    InternalPAAgent,
+)
+from pa_core.agents.registry import build_all
+
+
+def _mock_inputs(shape=(5, 12)):
+    r_beta = np.random.normal(size=shape)
+    r_H = np.random.normal(size=shape)
+    r_E = np.random.normal(size=shape)
+    r_M = np.random.normal(size=shape)
+    f_int = np.abs(np.random.normal(scale=0.01, size=shape))
+    f_ext = np.abs(np.random.normal(scale=0.01, size=shape))
+    f_act = np.abs(np.random.normal(scale=0.01, size=shape))
+    return r_beta, r_H, r_E, r_M, f_int, f_ext, f_act
+
+
+def test_base_agent_shape():
+    r_beta, r_H, *_ = _mock_inputs()
+    p = AgentParams("Base", 100.0, 0.5, 0.5, {})
+    agent = BaseAgent(p)
+    out = agent.monthly_returns(r_beta, r_H, np.zeros_like(r_beta))
+    assert out.shape == r_beta.shape
+    assert np.all(np.isfinite(out))
+
+
+def test_external_pa_agent_shape():
+    r_beta, _, _, r_M, _, f_ext, _ = _mock_inputs()
+    p = AgentParams("ExternalPA", 200.0, 0.1, 0.0, {"theta_extpa": 0.3})
+    agent = ExternalPAAgent(p)
+    out = agent.monthly_returns(r_beta, r_M, f_ext)
+    assert out.shape == r_beta.shape
+
+
+def test_active_extension_agent_shape():
+    r_beta, _, r_E, _, _, _, f_act = _mock_inputs()
+    p = AgentParams("ActiveExt", 150.0, 0.1, 0.0, {"active_share": 0.5})
+    agent = ActiveExtensionAgent(p)
+    out = agent.monthly_returns(r_beta, r_E, f_act)
+    assert out.shape == r_beta.shape
+
+
+def test_internal_agents_shape():
+    r_beta, r_H, *_ = _mock_inputs()
+    int_beta = InternalBetaAgent(AgentParams("InternalBeta", 50.0, 0.05, 0.0, {}))
+    int_pa = InternalPAAgent(AgentParams("InternalPA", 75.0, 0.0, 0.05, {}))
+    out_beta = int_beta.monthly_returns(r_beta, r_H, np.zeros_like(r_beta))
+    out_pa = int_pa.monthly_returns(r_beta, r_H, np.zeros_like(r_beta))
+    assert out_beta.shape == r_beta.shape
+    assert out_pa.shape == r_beta.shape
+
+
+def test_registry_build_all():
+    params_list = [
+        AgentParams("Base", 100.0, 0.5, 0.5, {}),
+        AgentParams("ExternalPA", 100.0, 0.1, 0.0, {}),
+    ]
+    agents = build_all(params_list)
+    assert len(agents) == 2
+    assert isinstance(agents[0], BaseAgent)
+    assert isinstance(agents[1], ExternalPAAgent)


### PR DESCRIPTION
## Summary
- add agent base classes and concrete agent implementations
- introduce registry for dynamic agent construction
- expose new API via `pa_core.__init__`
- include tests verifying agent return shapes
- extend `.gitignore`

## Testing
- `ruff check pa_core tests`
- `pyright`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861815d74ac833183efe0d5bfa3b854