### PR TITLE
Add RNG substream helper

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -16,6 +16,7 @@ from .simulations import (
     draw_financing_series,
     simulate_alpha_streams,
 )
+from .random import spawn_rngs
 from .reporting import export_to_excel
 from .metrics import tracking_error, value_at_risk
 from .agents import (
@@ -42,6 +43,7 @@ __all__ = [
     "draw_joint_returns",
     "draw_financing_series",
     "simulate_alpha_streams",
+    "spawn_rngs",
     "export_to_excel",
     "tracking_error",
     "value_at_risk",

--- a/pa_core/random.py
+++ b/pa_core/random.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.random import Generator, SeedSequence
+
+__all__ = ["spawn_rngs"]
+
+
+def spawn_rngs(seed: int, n: int) -> list[Generator]:
+    """Return ``n`` independent generators derived from ``seed``."""
+    if n <= 0:
+        raise ValueError("n must be positive")
+    ss = SeedSequence(seed)
+    return [np.random.default_rng(s) for s in ss.spawn(n)]
+

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+from pa_core.random import spawn_rngs
+
+def test_spawn_rngs_reproducible():
+    r1, r2 = spawn_rngs(123, 2)
+    a1 = r1.normal(size=5)
+    a2 = r2.normal(size=5)
+    r1b, r2b = spawn_rngs(123, 2)
+    assert np.allclose(a1, r1b.normal(size=5))
+    assert np.allclose(a2, r2b.normal(size=5))
+
+def test_spawn_rngs_independent():
+    r1, r2 = spawn_rngs(42, 2)
+    assert not np.allclose(r1.normal(size=3), r2.normal(size=3))
+


### PR DESCRIPTION
## Summary
- add `spawn_rngs` helper to create reproducible RNG substreams
- export the new function from `pa_core`
- test RNG spawning for determinism and independence

## Testing
- `ruff check pa_core tests`
- `pyright`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686187a5ebe08331a6b50c2b3cc48310