### PR TITLE
Add pivot option to export_to_excel

### DIFF
--- a/pa_core/reporting.py
+++ b/pa_core/reporting.py
@@ -4,8 +4,32 @@ import pandas as pd
 __all__ = ["export_to_excel"]
 
 
-def export_to_excel(inputs_dict, summary_df, raw_returns_dict, filename="Outputs.xlsx"):
-    """Write inputs, summary, and raw returns into an Excel workbook."""
+def export_to_excel(
+    inputs_dict,
+    summary_df,
+    raw_returns_dict,
+    filename: str = "Outputs.xlsx",
+    *,
+    pivot: bool = False,
+) -> None:
+    """Write inputs, summary, and raw returns into an Excel workbook.
+
+    Parameters
+    ----------
+    inputs_dict : dict
+        Mapping of input parameter names to values.
+    summary_df : pandas.DataFrame
+        Summary metrics to write to the ``Summary`` sheet.
+    raw_returns_dict : dict[str, pandas.DataFrame]
+        Per-agent returns matrices.
+    filename : str, optional
+        Destination Excel file name. Defaults to ``"Outputs.xlsx"``.
+    pivot : bool, optional
+        If ``True``, collapse all raw returns into a single ``AllReturns`` sheet
+        in long format (``Sim``, ``Month``, ``Agent``, ``Return``). Otherwise a
+        separate sheet is written per agent. Defaults to ``False``.
+    """
+
     with pd.ExcelWriter(filename, engine="openpyxl") as writer:
         df_inputs = pd.DataFrame({
             "Parameter": list(inputs_dict.keys()),
@@ -13,7 +37,19 @@ def export_to_excel(inputs_dict, summary_df, raw_returns_dict, filename="Outputs
         })
         df_inputs.to_excel(writer, sheet_name="Inputs", index=False)
         summary_df.to_excel(writer, sheet_name="Summary", index=False)
-        for sheet_name, df in raw_returns_dict.items():
-            safe_name = sheet_name if len(sheet_name) <= 31 else sheet_name[:31]
-            df.to_excel(writer, sheet_name=safe_name, index=True)
+
+        if pivot:
+            frames = []
+            for name, df in raw_returns_dict.items():
+                long_df = df.stack().rename("Return").reset_index()
+                long_df.columns = ["Sim", "Month", "Return"]
+                long_df["Agent"] = name
+                frames.append(long_df[["Sim", "Month", "Agent", "Return"]])
+            all_returns = pd.concat(frames, ignore_index=True)
+            all_returns.to_excel(writer, sheet_name="AllReturns", index=False)
+        else:
+            for sheet_name, df in raw_returns_dict.items():
+                safe_name = sheet_name if len(sheet_name) <= 31 else sheet_name[:31]
+                df.to_excel(writer, sheet_name=safe_name, index=True)
+
     print(f"Exported results to {filename}")

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -12,3 +12,19 @@ def test_export_to_excel_sheets(tmp_path: Path):
     export_to_excel(inputs, summary, raw, filename=str(file_path))
     wb = openpyxl.load_workbook(file_path)
     assert set(wb.sheetnames) == {"Inputs", "Summary", "Base"}
+
+
+def test_export_to_excel_pivot(tmp_path: Path):
+    inputs = {"x": 1}
+    summary = pd.DataFrame({"Total": [0.2]})
+    raw = {
+        "Base": pd.DataFrame([[0.1, 0.2]], columns=[0, 1]),
+        "Ext": pd.DataFrame([[0.3, 0.4]], columns=[0, 1]),
+    }
+    file_path = tmp_path / "pivot.xlsx"
+    export_to_excel(inputs, summary, raw, filename=str(file_path), pivot=True)
+    wb = openpyxl.load_workbook(file_path)
+    assert set(wb.sheetnames) == {"Inputs", "Summary", "AllReturns"}
+    ws = wb["AllReturns"]
+    header = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+    assert header == ["Sim", "Month", "Agent", "Return"]


### PR DESCRIPTION
## Summary
- allow collapsing raw returns into single sheet via `export_to_excel(..., pivot=True)`
- cover the pivot logic in the reporting test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618952d2088331b1e4f2a94e43567e