### PR TITLE
Add ModelConfig and move covariance

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -11,14 +11,15 @@ from .io import (
 from .simulations import (
     simulate_financing,
     prepare_mc_universe,
-    build_cov_matrix,
     draw_joint_returns,
     draw_financing_series,
     simulate_alpha_streams,
 )
+from .covariance import build_cov_matrix
 from .random import spawn_rngs
 from .reporting import export_to_excel
 from .metrics import tracking_error, value_at_risk
+from .config import ModelConfig, load_config
 from .agents import (
     Agent,
     AgentParams,
@@ -54,5 +55,7 @@ __all__ = [
     "ActiveExtensionAgent",
     "InternalBetaAgent",
     "InternalPAAgent",
+    "ModelConfig",
+    "load_config",
     "build_agents",
 ]

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -6,11 +6,11 @@ from . import (
     load_parameters,
     get_num,
     load_index_returns,
-    build_cov_matrix,
     draw_joint_returns,
     draw_financing_series,
     export_to_excel,
 )
+from .covariance import build_cov_matrix
 
 LABEL_MAP = {
     "Analysis mode": "analysis_mode",

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+__all__ = ["ModelConfig", "load_config"]
+
+
+class ModelConfig(BaseModel):
+    """Validated simulation parameters."""
+
+    N_SIMULATIONS: int = Field(gt=0, alias="N_SIMULATIONS")
+    N_MONTHS: int = Field(gt=0, alias="N_MONTHS")
+    mu_H: float = 0.04
+    sigma_H: float = 0.01
+
+    class Config:
+        allow_population_by_field_name = True
+        frozen = True
+
+
+def load_config(path: str | Path | dict[str, Any]) -> ModelConfig:
+    """Return ``ModelConfig`` parsed from YAML/CSV dictionary."""
+    if isinstance(path, dict):
+        data = path
+    else:
+        data = yaml.safe_load(Path(path).read_text())
+    try:
+        return ModelConfig(**data)
+    except ValidationError as e:  # pragma: no cover - explicit failure
+        raise ValueError(str(e)) from e

--- a/pa_core/covariance.py
+++ b/pa_core/covariance.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ["build_cov_matrix"]
+
+
+def build_cov_matrix(
+    rho_idx_H: float,
+    rho_idx_E: float,
+    rho_idx_M: float,
+    rho_H_E: float,
+    rho_H_M: float,
+    rho_E_M: float,
+    idx_sigma: float,
+    sigma_H: float,
+    sigma_E: float,
+    sigma_M: float,
+) -> NDArray[np.float64]:
+    """Return 4×4 covariance matrix for (Index, H, E, M).
+
+    Volatilities are clipped at zero to avoid negative variances and the
+    resulting matrix is symmetrised to guard against numerical drift.
+    """
+    sds = np.clip(np.array([idx_sigma, sigma_H, sigma_E, sigma_M]), 0.0, None)
+    rho = np.array(
+        [
+            [1.0, rho_idx_H, rho_idx_E, rho_idx_M],
+            [rho_idx_H, 1.0, rho_H_E, rho_H_M],
+            [rho_idx_E, rho_H_E, 1.0, rho_E_M],
+            [rho_idx_M, rho_H_M, rho_E_M, 1.0],
+        ]
+    )
+    cov = np.outer(sds, sds) * rho
+    return 0.5 * (cov + cov.T)

--- a/pa_core/simulations.py
+++ b/pa_core/simulations.py
@@ -7,7 +7,6 @@ from numpy.typing import NDArray
 __all__ = [
     "simulate_financing",
     "prepare_mc_universe",
-    "build_cov_matrix",
     "draw_joint_returns",
     "draw_financing_series",
     "simulate_alpha_streams",
@@ -63,27 +62,6 @@ def prepare_mc_universe(
     return z @ L.T + mu
 
 
-def build_cov_matrix(
-    rho_idx_H: float,
-    rho_idx_E: float,
-    rho_idx_M: float,
-    rho_H_E: float,
-    rho_H_M: float,
-    rho_E_M: float,
-    idx_sigma: float,
-    sigma_H: float,
-    sigma_E: float,
-    sigma_M: float,
-) -> NDArray[Any]:
-    """Build the 4×4 covariance matrix for (Index, H, E, M)."""
-    sds = np.array([idx_sigma, sigma_H, sigma_E, sigma_M])
-    rho = np.array([
-        [1.0, rho_idx_H, rho_idx_E, rho_idx_M],
-        [rho_idx_H, 1.0, rho_H_E, rho_H_M],
-        [rho_idx_E, rho_H_E, 1.0, rho_E_M],
-        [rho_idx_M, rho_H_M, rho_E_M, 1.0],
-    ])
-    return np.outer(sds, sds) * rho
 
 
 def draw_joint_returns(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest
 hypothesis
 ruff
 pyright
+pydantic

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+from pa_core.config import ModelConfig, load_config
+import yaml
+
+
+def test_load_yaml(tmp_path):
+    data = {
+        "N_SIMULATIONS": 10,
+        "N_MONTHS": 6,
+        "mu_H": 0.04,
+        "sigma_H": 0.01,
+    }
+    path = tmp_path / "conf.yaml"
+    path.write_text(yaml.safe_dump(data))
+    cfg = load_config(path)
+    assert isinstance(cfg, ModelConfig)
+    assert cfg.N_SIMULATIONS == 10
+    assert cfg.N_MONTHS == 6

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,5 +1,6 @@
 import numpy as np
-from pa_core.simulations import build_cov_matrix, simulate_financing
+from pa_core.covariance import build_cov_matrix
+from pa_core.simulations import simulate_financing
 
 def test_build_cov_matrix_shape():
     cov = build_cov_matrix(0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.2, 0.1, 0.1, 0.1)


### PR DESCRIPTION
## Summary
- add `ModelConfig` with pydantic validation
- refactor `build_cov_matrix` into new module `covariance.py`
- update exports and imports throughout package
- add tests for new config loader
- update requirements with pydantic

## Testing
- `ruff check pa_core tests`
- `pyright`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686190c7ca288331847e17e3fbf59ccf