### PR TITLE
Refactor agents into individual modules

### DIFF
--- a/pa_core/agents/__init__.py
+++ b/pa_core/agents/__init__.py
@@ -1,77 +1,17 @@
-from __future__ import annotations
-from dataclasses import dataclass
-from typing import Dict, Any
-import numpy as np
+from .types import AgentParams, Agent, Array
+from .base import BaseAgent
+from .external_pa import ExternalPAAgent
+from .active_ext import ActiveExtensionAgent
+from .internal_beta import InternalBetaAgent
+from .internal_pa import InternalPAAgent
 
-Array = np.ndarray
-
-@dataclass
-class AgentParams:
-    name: str
-    capital_mm: float
-    beta_share: float
-    alpha_share: float
-    extra_args: Dict[str, Any] | None = None
-
-
-class Agent:
-    """Abstract sleeve. Child classes implement ``monthly_returns``."""
-
-    def __init__(self, p: AgentParams) -> None:
-        self.p = p
-        self.extra = p.extra_args or {}
-
-    def monthly_returns(
-        self,
-        r_beta: Array,
-        alpha_stream: Array,
-        financing: Array,
-    ) -> Array:
-        raise NotImplementedError
-
-
-class BaseAgent(Agent):
-    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
-        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
-            raise ValueError("shape mismatch")
-        return (
-            self.p.beta_share * (r_beta - financing)
-            + self.p.alpha_share * alpha_stream
-        )
-
-
-class ExternalPAAgent(Agent):
-    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
-        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
-            raise ValueError("shape mismatch")
-        theta = float(self.extra.get("theta_extpa", 0.0))
-        return (
-            self.p.beta_share * (r_beta - financing)
-            + (self.p.beta_share * theta) * alpha_stream
-        )
-
-
-class ActiveExtensionAgent(Agent):
-    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
-        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
-            raise ValueError("shape mismatch")
-        active_share = float(self.extra.get("active_share", 0.5))
-        return (
-            self.p.beta_share * (r_beta - financing)
-            + (self.p.beta_share * active_share) * alpha_stream
-        )
-
-
-class InternalBetaAgent(Agent):
-    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
-        if r_beta.shape != financing.shape:
-            raise ValueError("shape mismatch")
-        return self.p.beta_share * (r_beta - financing)
-
-
-class InternalPAAgent(Agent):
-    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
-        if r_beta.shape != alpha_stream.shape:
-            raise ValueError("shape mismatch")
-        return self.p.alpha_share * alpha_stream
-
+__all__ = [
+    "AgentParams",
+    "Agent",
+    "Array",
+    "BaseAgent",
+    "ExternalPAAgent",
+    "ActiveExtensionAgent",
+    "InternalBetaAgent",
+    "InternalPAAgent",
+]

--- a/pa_core/agents/active_ext.py
+++ b/pa_core/agents/active_ext.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from .types import Agent, Array
+
+class ActiveExtensionAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        active_share = float(self.extra.get("active_share", 0.5))
+        return (
+            self.p.beta_share * (r_beta - financing)
+            + (self.p.beta_share * active_share) * alpha_stream
+        )

--- a/pa_core/agents/base.py
+++ b/pa_core/agents/base.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from .types import Agent, Array
+
+class BaseAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        return (
+            self.p.beta_share * (r_beta - financing)
+            + self.p.alpha_share * alpha_stream
+        )

--- a/pa_core/agents/external_pa.py
+++ b/pa_core/agents/external_pa.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+from .types import Agent, Array
+
+class ExternalPAAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape or r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        theta = float(self.extra.get("theta_extpa", 0.0))
+        return (
+            self.p.beta_share * (r_beta - financing)
+            + (self.p.beta_share * theta) * alpha_stream
+        )

--- a/pa_core/agents/internal_beta.py
+++ b/pa_core/agents/internal_beta.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+from .types import Agent, Array
+
+class InternalBetaAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != financing.shape:
+            raise ValueError("shape mismatch")
+        return self.p.beta_share * (r_beta - financing)

--- a/pa_core/agents/internal_pa.py
+++ b/pa_core/agents/internal_pa.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+from .types import Agent, Array
+
+class InternalPAAgent(Agent):
+    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
+        if r_beta.shape != alpha_stream.shape:
+            raise ValueError("shape mismatch")
+        return self.p.alpha_share * alpha_stream

--- a/pa_core/agents/registry.py
+++ b/pa_core/agents/registry.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 from typing import Iterable, List
 
-from . import (
-    Agent,
-    AgentParams,
-    BaseAgent,
-    ExternalPAAgent,
-    ActiveExtensionAgent,
-    InternalBetaAgent,
-    InternalPAAgent,
-)
-
+from .types import Agent, AgentParams
+from .base import BaseAgent
+from .external_pa import ExternalPAAgent
+from .active_ext import ActiveExtensionAgent
+from .internal_beta import InternalBetaAgent
+from .internal_pa import InternalPAAgent
 
 _AGENT_MAP = {
     "Base": BaseAgent,
@@ -30,4 +26,3 @@ def build_all(params_list: Iterable[AgentParams]) -> List[Agent]:
             raise KeyError(f"Unknown agent name: {p.name}")
         agents.append(cls(p))
     return agents
-

--- a/pa_core/agents/types.py
+++ b/pa_core/agents/types.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Any
+import numpy as np
+
+Array = np.ndarray
+
+@dataclass
+class AgentParams:
+    name: str
+    capital_mm: float
+    beta_share: float
+    alpha_share: float
+    extra_args: Dict[str, Any] | None = None
+
+class Agent:
+    """Abstract sleeve. Child classes implement ``monthly_returns``."""
+
+    def __init__(self, p: AgentParams) -> None:
+        self.p = p
+        self.extra = p.extra_args or {}
+
+    def monthly_returns(
+        self,
+        r_beta: Array,
+        alpha_stream: Array,
+        financing: Array,
+    ) -> Array:
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- split each agent class into its own file per the architecture guide
- centralize the Agent and AgentParams definitions in `agents/types.py`
- update registry imports
- expose the same interface from `agents/__init__.py`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b77b264c8331b431075ddd79bdc6