### PR TITLE
Add YAML configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Execute this once before running any notebooks or other scripts.
 After setting up the environment you can run the command line interface:
 
 ```bash
+# CSV parameters
 python -m pa_core --params parameters.csv --index sp500tr_fred_divyield.csv
+
+# or YAML configuration
+python -m pa_core --config params.yaml --index sp500tr_fred_divyield.csv
 ```
 
 This writes results to `Outputs.xlsx` in the current directory.

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import argparse
+from typing import Sequence, Optional
 import pandas as pd
 
 from . import (
@@ -9,6 +10,7 @@ from . import (
     draw_joint_returns,
     draw_financing_series,
     export_to_excel,
+    load_config,
 )
 from .covariance import build_cov_matrix
 
@@ -35,14 +37,20 @@ LABEL_MAP = {
 }
 
 
-def main() -> None:
+def main(argv: Optional[Sequence[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Portable Alpha simulation")
-    parser.add_argument("--params", required=True, help="Parameters CSV")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--params", help="Parameters CSV")
+    group.add_argument("--config", help="YAML config file")
     parser.add_argument("--index", required=True, help="Index returns CSV")
     parser.add_argument("--output", default="Outputs.xlsx", help="Output workbook")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    raw_params = load_parameters(args.params, LABEL_MAP)
+    if args.config:
+        cfg = load_config(args.config)
+        raw_params = cfg.dict()
+    else:
+        raw_params = load_parameters(args.params, LABEL_MAP)
     idx_series = load_index_returns(args.index)
     mu_idx = float(idx_series.mean())
     idx_sigma = float(idx_series.std(ddof=1))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import yaml
+from pa_core.__main__ import main
+
+
+def test_main_with_yaml(tmp_path):
+    cfg = {"N_SIMULATIONS": 2, "N_MONTHS": 1}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    idx_csv = Path(__file__).resolve().parents[1] / "sp500tr_fred_divyield.csv"
+    out_file = tmp_path / "out.xlsx"
+    main([
+        "--config",
+        str(cfg_path),
+        "--index",
+        str(idx_csv),
+        "--output",
+        str(out_file),
+    ])
+    assert out_file.exists()
+
+


### PR DESCRIPTION
## Summary
- support YAML configs via `--config` in CLI
- document YAML usage in README
- test CLI with YAML file

## Testing
- `ruff check pa_core tests`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861bdf8a1d883319164a2019103f352