### PR TITLE
Implement agent dispatch in simulation driver

### DIFF
--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,6 +1,14 @@
 import numpy as np
 from pa_core.covariance import build_cov_matrix
-from pa_core.simulations import simulate_financing
+from pa_core.simulations import simulate_financing, simulate_agents
+from pa_core.agents import (
+    AgentParams,
+    BaseAgent,
+    ExternalPAAgent,
+    ActiveExtensionAgent,
+    InternalBetaAgent,
+    InternalPAAgent,
+)
 
 def test_build_cov_matrix_shape():
     cov = build_cov_matrix(0.1, 0.2, 0.3, 0.1, 0.1, 0.1, 0.2, 0.1, 0.1, 0.1)
@@ -26,3 +34,21 @@ def test_simulate_financing_spikes():
     # with spike_prob=1 all months should include spike component
     assert np.all(out >= 0)
     assert np.all(out > 0)
+
+
+def test_simulate_agents_vectorised():
+    n_sim, n_months = 4, 3
+    r_beta = np.random.normal(size=(n_sim, n_months))
+    r_H = np.random.normal(size=(n_sim, n_months))
+    r_E = np.random.normal(size=(n_sim, n_months))
+    r_M = np.random.normal(size=(n_sim, n_months))
+    f = np.abs(np.random.normal(size=(n_sim, n_months))) * 0.01
+    agents = [
+        BaseAgent(AgentParams("Base", 100, 0.5, 0.5, {})),
+        ExternalPAAgent(AgentParams("ExternalPA", 80, 0.2, 0.0, {})),
+        InternalBetaAgent(AgentParams("InternalBeta", 20, 1.0, 0.0, {})),
+    ]
+    results = simulate_agents(agents, r_beta, r_H, r_E, r_M, f, f, f)
+    assert set(results) == {"Base", "ExternalPA", "InternalBeta"}
+    for arr in results.values():
+        assert arr.shape == (n_sim, n_months)


### PR DESCRIPTION
## Summary
- add `simulate_agents` driver for vectorized agent returns
- expose new helper in module exports
- test driver works with sample agents

## Testing
- `ruff check .` *(fails: unrecognized subcommand)*
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d91a97688331a0e98f25da753f34