### PR TITLE
Add backend module for optional CuPy

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -17,6 +17,7 @@ from .simulations import (
 )
 from .covariance import build_cov_matrix
 from .random import spawn_rngs
+from .backend import set_backend, get_backend
 from .reporting import export_to_excel, print_summary
 from .metrics import tracking_error, value_at_risk
 from .config import ModelConfig, load_config
@@ -45,6 +46,8 @@ __all__ = [
     "draw_financing_series",
     "simulate_alpha_streams",
     "spawn_rngs",
+    "set_backend",
+    "get_backend",
     "export_to_excel",
     "print_summary",
     "tracking_error",

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -13,6 +13,7 @@ from . import (
     load_config,
 )
 from .covariance import build_cov_matrix
+from .backend import set_backend
 
 LABEL_MAP = {
     "Analysis mode": "analysis_mode",
@@ -44,7 +45,15 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     group.add_argument("--config", help="YAML config file")
     parser.add_argument("--index", required=True, help="Index returns CSV")
     parser.add_argument("--output", default="Outputs.xlsx", help="Output workbook")
+    parser.add_argument(
+        "--backend",
+        choices=["numpy", "cupy"],
+        default="numpy",
+        help="Computation backend",
+    )
     args = parser.parse_args(argv)
+
+    set_backend(args.backend)
 
     if args.config:
         cfg = load_config(args.config)

--- a/pa_core/agents/types.py
+++ b/pa_core/agents/types.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Any
 from ..backend import xp as np
+import numpy as npt
+from numpy.typing import NDArray
 
-Array = np.ndarray
+Array = NDArray[npt.float64]
 
 @dataclass
 class AgentParams:

--- a/pa_core/agents/types.py
+++ b/pa_core/agents/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Any
-import numpy as np
+from ..backend import xp as np
 
 Array = np.ndarray
 

--- a/pa_core/backend.py
+++ b/pa_core/backend.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import importlib
+
+__all__ = ["xp", "set_backend", "get_backend"]
+
+xp = importlib.import_module("numpy")
+
+
+def set_backend(name: str) -> None:
+    """Set numeric backend to 'numpy' or 'cupy'."""
+    global xp
+    if name == "numpy":
+        xp = importlib.import_module("numpy")
+    elif name == "cupy":
+        try:
+            xp = importlib.import_module("cupy")
+        except Exception as e:  # pragma: no cover - depends on optional dep
+            raise ImportError("CuPy backend requested but not installed") from e
+    else:
+        raise ValueError(f"Unknown backend: {name}")
+
+
+def get_backend() -> str:
+    """Return the current backend name."""
+    return "cupy" if xp.__name__.startswith("cupy") else "numpy"

--- a/pa_core/covariance.py
+++ b/pa_core/covariance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from .backend import xp as np
 from numpy.typing import NDArray
 
 __all__ = ["build_cov_matrix"]

--- a/pa_core/io.py
+++ b/pa_core/io.py
@@ -1,7 +1,7 @@
 import csv
 from pathlib import Path
 from tkinter import filedialog, Tk
-import numpy as np
+from .backend import xp as np
 import pandas as pd
 
 __all__ = [

--- a/pa_core/metrics.py
+++ b/pa_core/metrics.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import numpy as np
+from .backend import xp as np
 
 __all__ = ["tracking_error", "value_at_risk"]
 

--- a/pa_core/metrics.py
+++ b/pa_core/metrics.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 from .backend import xp as np
+import numpy as npt
+from numpy.typing import NDArray
 
 __all__ = ["tracking_error", "value_at_risk"]
 
 
-def tracking_error(strategy: np.ndarray, benchmark: np.ndarray) -> float:
+def tracking_error(strategy: NDArray[npt.float64], benchmark: NDArray[npt.float64]) -> float:
     """Return the standard deviation of active returns."""
     if strategy.shape != benchmark.shape:
         raise ValueError("shape mismatch")
@@ -12,7 +14,7 @@ def tracking_error(strategy: np.ndarray, benchmark: np.ndarray) -> float:
     return float(np.std(diff, ddof=1))
 
 
-def value_at_risk(returns: np.ndarray, confidence: float = 0.95) -> float:
+def value_at_risk(returns: NDArray[npt.float64], confidence: float = 0.95) -> float:
     """Return the empirical VaR at the given confidence level."""
     if not 0 < confidence < 1:
         raise ValueError("confidence must be between 0 and 1")

--- a/pa_core/random.py
+++ b/pa_core/random.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+from .backend import xp as np
 from numpy.random import Generator, SeedSequence
 
 __all__ = ["spawn_rngs"]

--- a/pa_core/simulations.py
+++ b/pa_core/simulations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Optional, Any, Iterable
 
-import numpy as np
+from .backend import xp as np
 from numpy.typing import NDArray
 
 from .agents import (

--- a/pa_core/simulations.py
+++ b/pa_core/simulations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Optional, Any, Iterable
+import numpy as npt
 
 from .backend import xp as np
 from numpy.typing import NDArray
@@ -32,7 +33,7 @@ def simulate_financing(
     *,
     seed: Optional[int] = None,
     n_scenarios: int = 1,
-    rng: Optional[np.random.Generator] = None,
+    rng: Optional[npt.random.Generator] = None,
 ) -> NDArray[Any]:
     if T <= 0:
         raise ValueError("T must be positive")
@@ -55,7 +56,7 @@ def prepare_mc_universe(
     mu_M: float,
     cov_mat: NDArray[Any],
     seed: Optional[int] = None,
-    rng: Optional[np.random.Generator] = None,
+    rng: Optional[npt.random.Generator] = None,
 ) -> NDArray[Any]:
     if N_SIMULATIONS <= 0 or N_MONTHS <= 0:
         raise ValueError("N_SIMULATIONS and N_MONTHS must be positive")
@@ -79,7 +80,7 @@ def draw_joint_returns(
     n_months: int,
     n_sim: int,
     params: dict,
-    rng: Optional[np.random.Generator] = None,
+    rng: Optional[npt.random.Generator] = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Vectorised draw of (index, H, E, M) returns."""
     if rng is None:
@@ -118,7 +119,7 @@ def draw_financing_series(
     n_months: int,
     n_sim: int,
     params: dict,
-    rng: Optional[np.random.Generator] = None,
+    rng: Optional[npt.random.Generator] = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Return three matrices of monthly financing spreads."""
     if rng is None:


### PR DESCRIPTION
## Summary
- introduce `pa_core.backend` for dynamic numpy/cupy imports
- expose `set_backend` and `get_backend` in `pa_core.__init__`
- support `--backend` CLI flag
- update modules to use backend alias

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e1292454833187ea1b91b7da67ed