### PR TITLE
Implement data module per Agents spec

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -1,6 +1,6 @@
 """Core portable alpha utilities."""
 
-from .io import (
+from .data import (
     select_csv_file,
     load_parameters,
     get_num,

--- a/pa_core/agents/types.py
+++ b/pa_core/agents/types.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Any
-from ..backend import xp as np
 import numpy as npt
 from numpy.typing import NDArray
 

--- a/pa_core/covariance.py
+++ b/pa_core/covariance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .backend import xp as np
+import numpy as npt
 from numpy.typing import NDArray
 
 __all__ = ["build_cov_matrix"]
@@ -17,7 +18,7 @@ def build_cov_matrix(
     sigma_H: float,
     sigma_E: float,
     sigma_M: float,
-) -> NDArray[np.float64]:
+) -> NDArray[npt.float64]:
     """Return 4×4 covariance matrix for (Index, H, E, M).
 
     Volatilities are clipped at zero to avoid negative variances and the

--- a/pa_core/data/__init__.py
+++ b/pa_core/data/__init__.py
@@ -1,7 +1,7 @@
 import csv
 from pathlib import Path
 from tkinter import filedialog, Tk
-from .backend import xp as np
+from ..backend import xp as np
 import pandas as pd
 
 __all__ = [

--- a/pa_core/simulations.py
+++ b/pa_core/simulations.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Legacy wrapper module for simulation utilities."""
+from __future__ import annotations
 
 from typing import Iterable, Any
 from numpy.typing import NDArray

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -1,7 +1,15 @@
 from hypothesis import given, strategies as st
+from hypothesis.extra import numpy as nps
 import numpy as np
 from pa_core.simulations import simulate_financing
-from pa_core.agents import (AgentParams, BaseAgent, ExternalPAAgent, ActiveExtensionAgent, InternalBetaAgent, InternalPAAgent)
+from pa_core.agents import (
+    AgentParams,
+    BaseAgent,
+    ExternalPAAgent,
+    ActiveExtensionAgent,
+    InternalBetaAgent,
+    InternalPAAgent,
+)
 
 @given(
     T=st.integers(min_value=1, max_value=24),
@@ -12,8 +20,6 @@ def test_simulate_financing_shapes(T, n_scenarios):
     expected_shape = (T,) if n_scenarios == 1 else (n_scenarios, T)
     assert out.shape == expected_shape
     assert np.all(np.isfinite(out))
-from hypothesis.extra import numpy as nps
-
 @st.composite
 def _env(draw):
     n_sim = draw(st.integers(min_value=1, max_value=5))

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -5,9 +5,7 @@ from pa_core.agents import (
     AgentParams,
     BaseAgent,
     ExternalPAAgent,
-    ActiveExtensionAgent,
     InternalBetaAgent,
-    InternalPAAgent,
 )
 
 def test_build_cov_matrix_shape():


### PR DESCRIPTION
## Summary
- move io helpers into a new `pa_core.data` package
- update imports to use the new data module
- clean up agent type hints and fix pyright issues
- adjust simulations utilities for stricter typing
- fix lint warnings and tests

## Testing
- `ruff check pa_core tests`
- `pyright`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ef5c9e2c8331b8158e3a65075f28