### PR TITLE
Implement pydantic validation for capital totals

### DIFF
--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    model_validator,
+)
 
 __all__ = ["ModelConfig", "load_config"]
 
@@ -14,12 +19,31 @@ class ModelConfig(BaseModel):
 
     N_SIMULATIONS: int = Field(gt=0, alias="N_SIMULATIONS")
     N_MONTHS: int = Field(gt=0, alias="N_MONTHS")
+
+    external_pa_capital: float = 0.0
+    active_ext_capital: float = 0.0
+    internal_pa_capital: float = 0.0
+    total_fund_capital: float = 1000.0
+
     mu_H: float = 0.04
     sigma_H: float = 0.01
 
     class Config:
         allow_population_by_field_name = True
         frozen = True
+
+    @model_validator(mode="after")
+    def check_capital(self) -> "ModelConfig":
+        cap_sum = (
+            self.external_pa_capital
+            + self.active_ext_capital
+            + self.internal_pa_capital
+        )
+        if cap_sum > self.total_fund_capital:
+            raise ValueError(
+                "Capital allocation exceeds total_fund_capital"
+            )
+        return self
 
 
 def load_config(path: str | Path | dict[str, Any]) -> ModelConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,10 @@ def test_load_yaml(tmp_path):
         "N_MONTHS": 6,
         "mu_H": 0.04,
         "sigma_H": 0.01,
+        "external_pa_capital": 100.0,
+        "active_ext_capital": 200.0,
+        "internal_pa_capital": 300.0,
+        "total_fund_capital": 1000.0,
     }
     path = tmp_path / "conf.yaml"
     path.write_text(yaml.safe_dump(data))
@@ -15,3 +19,26 @@ def test_load_yaml(tmp_path):
     assert isinstance(cfg, ModelConfig)
     assert cfg.N_SIMULATIONS == 10
     assert cfg.N_MONTHS == 6
+    assert cfg.external_pa_capital == 100.0
+    assert cfg.active_ext_capital == 200.0
+    assert cfg.internal_pa_capital == 300.0
+    assert cfg.total_fund_capital == 1000.0
+
+
+def test_invalid_capital(tmp_path):
+    data = {
+        "N_SIMULATIONS": 1,
+        "N_MONTHS": 1,
+        "external_pa_capital": 800.0,
+        "active_ext_capital": 800.0,
+        "internal_pa_capital": 800.0,
+        "total_fund_capital": 1000.0,
+    }
+    path = tmp_path / "bad.yaml"
+    path.write_text(yaml.safe_dump(data))
+    try:
+        load_config(path)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected validation failure")


### PR DESCRIPTION
## Summary
- extend `ModelConfig` with capital parameters
- validate capital allocations using pydantic's `model_validator`
- test YAML loading and invalid capital scenarios

## Testing
- `ruff check pa_core tests`
- `pyright`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f5b8777483318e2c03172b8288f6