### PR TITLE
Add CLI seed option for reproducible simulations

### DIFF
--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import argparse
 from typing import Sequence, Optional
 import pandas as pd
+import numpy as np
 
 from . import (
     load_parameters,
@@ -51,9 +52,17 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         default="numpy",
         help="Computation backend",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducible simulations",
+    )
     args = parser.parse_args(argv)
 
     set_backend(args.backend)
+
+    rng = np.random.default_rng(args.seed)
 
     if args.config:
         cfg = load_config(args.config)
@@ -120,11 +129,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
+        rng=rng,
     )
     f_int, f_ext, f_act = draw_financing_series(
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
+        rng=rng,
     )
 
     base_returns = r_beta - f_int


### PR DESCRIPTION
## Summary
- support reproducible results with new `--seed` flag
- pass RNG with the given seed to all simulation draws

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861fa3ee7c483319cf12894cf27d4ee