### PR TITLE
Implement summary metrics and CLI integration

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -19,7 +19,14 @@ from .covariance import build_cov_matrix
 from .random import spawn_rngs
 from .backend import set_backend, get_backend
 from .reporting import export_to_excel, print_summary
-from .metrics import tracking_error, value_at_risk
+from .metrics import (
+    tracking_error,
+    value_at_risk,
+    compound,
+    annualised_return,
+    annualised_vol,
+    summary_table,
+)
 from .config import ModelConfig, load_config
 from .agents import (
     Agent,
@@ -52,6 +59,10 @@ __all__ = [
     "print_summary",
     "tracking_error",
     "value_at_risk",
+    "compound",
+    "annualised_return",
+    "annualised_vol",
+    "summary_table",
     "Agent",
     "AgentParams",
     "BaseAgent",

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -12,9 +12,13 @@ from . import (
     draw_financing_series,
     export_to_excel,
     load_config,
+    summary_table,
 )
 from .covariance import build_cov_matrix
 from .backend import set_backend
+from .agents import AgentParams
+from .agents.registry import build_all
+from .simulations import simulate_agents
 
 LABEL_MAP = {
     "Analysis mode": "analysis_mode",
@@ -138,12 +142,36 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         rng=rng,
     )
 
-    base_returns = r_beta - f_int
-    summary = pd.DataFrame({
-        "Base": [base_returns.mean() * 12],
-    })
+    # Build agents based on simple capital weights
+    total_cap = float(raw_params.get("total_fund_capital", 1000.0))
+    ext_cap = float(raw_params.get("external_pa_capital", 0.0))
+    act_cap = float(raw_params.get("active_ext_capital", 0.0))
+
+    agents = build_all(
+        [
+            AgentParams("Base", total_cap, 0.5, 0.5, {}),
+            AgentParams(
+                "ExternalPA",
+                ext_cap,
+                ext_cap / total_cap,
+                0.0,
+                {"theta_extpa": 0.5},
+            ),
+            AgentParams(
+                "ActiveExt",
+                act_cap,
+                act_cap / total_cap,
+                0.0,
+                {"active_share": 0.5},
+            ),
+        ]
+    )
+
+    returns = simulate_agents(agents, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act)
+
+    summary = summary_table(returns, benchmark="Base")
     inputs_dict = {k: raw_params.get(k, "") for k in raw_params}
-    raw_returns_dict = {"Base": pd.DataFrame(base_returns)}
+    raw_returns_dict = {k: pd.DataFrame(v) for k, v in returns.items()}
     export_to_excel(inputs_dict, summary, raw_returns_dict, filename=args.output)
 
 

--- a/pa_core/metrics.py
+++ b/pa_core/metrics.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 from .backend import xp as np
 import numpy as npt
 from numpy.typing import NDArray
+import pandas as pd
 
-__all__ = ["tracking_error", "value_at_risk"]
+__all__ = [
+    "tracking_error",
+    "value_at_risk",
+    "compound",
+    "annualised_return",
+    "annualised_vol",
+    "summary_table",
+]
 
 
 def tracking_error(strategy: NDArray[npt.float64], benchmark: NDArray[npt.float64]) -> float:
@@ -21,3 +29,57 @@ def value_at_risk(returns: NDArray[npt.float64], confidence: float = 0.95) -> fl
     flat = np.asarray(returns).reshape(-1)
     percentile = 100 * (1 - confidence)
     return float(np.percentile(flat, percentile))
+
+
+def compound(returns: NDArray[npt.float64]) -> NDArray[npt.float64]:
+    """Return cumulative compounded returns along axis 1."""
+    arr = np.asarray(returns, dtype=np.float64)
+    return np.cumprod(1.0 + arr, axis=1) - 1.0
+
+
+def annualised_return(
+    returns: NDArray[npt.float64], periods_per_year: int = 12
+) -> float:
+    """Return annualised compound return from monthly series."""
+    comp = compound(returns)
+    total_return = comp[:, -1]
+    years = returns.shape[1] / periods_per_year
+    return float(np.power(1.0 + np.mean(total_return), 1.0 / years) - 1.0)
+
+
+def annualised_vol(returns: NDArray[npt.float64], periods_per_year: int = 12) -> float:
+    """Return annualised volatility from monthly returns."""
+    arr = np.asarray(returns, dtype=np.float64)
+    return float(np.std(arr, ddof=1) * np.sqrt(periods_per_year))
+
+
+def summary_table(
+    returns_map: dict[str, NDArray[npt.float64]],
+    *,
+    periods_per_year: int = 12,
+    var_conf: float = 0.95,
+    benchmark: str | None = None,
+) -> pd.DataFrame:
+    """Return a summary DataFrame of key metrics for each agent."""
+
+    rows = []
+    bench_arr = returns_map.get(benchmark) if benchmark else None
+    for name, arr in returns_map.items():
+        ann_ret = annualised_return(arr, periods_per_year)
+        ann_vol = annualised_vol(arr, periods_per_year)
+        var = value_at_risk(arr, confidence=var_conf)
+        te = (
+            tracking_error(arr, bench_arr)
+            if bench_arr is not None and name != benchmark
+            else None
+        )
+        rows.append({
+            "Agent": name,
+            "AnnReturn": ann_ret,
+            "AnnVol": ann_vol,
+            "VaR": var,
+            "TE": te,
+        })
+
+    df = pd.DataFrame(rows)
+    return df

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,12 @@
 import numpy as np
-from pa_core.metrics import tracking_error, value_at_risk
+from pa_core.metrics import (
+    tracking_error,
+    value_at_risk,
+    compound,
+    annualised_return,
+    annualised_vol,
+    summary_table,
+)
 
 
 def test_tracking_error_constant_series():
@@ -26,4 +33,16 @@ def test_metrics_shape_mismatch():
         pass
     else:
         raise AssertionError("Expected ValueError")
+
+
+def test_compound_and_summary():
+    arr = np.array([[0.01, -0.02, 0.03]])
+    comp = compound(arr)
+    assert comp.shape == arr.shape
+    ann_ret = annualised_return(arr)
+    ann_vol = annualised_vol(arr)
+    stats = summary_table({"Base": arr})
+    assert "AnnReturn" in stats.columns
+    assert np.isfinite(ann_ret)
+    assert np.isfinite(ann_vol)
 


### PR DESCRIPTION
## Summary
- add compound and annualised metrics
- provide summary_table for agent returns
- integrate summary_table into CLI
- test metrics helpers

## Testing
- `ruff check pa_core tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620139e5b48331869c7ea404e1a626