### PR TITLE
Load parameters via ModelConfig dataclass

### DIFF
--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -69,27 +69,28 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     if args.config:
         cfg = load_config(args.config)
-        raw_params = cfg.dict()
     else:
         raw_params = load_parameters(args.params, LABEL_MAP)
+        cfg = load_config(raw_params)
+    raw_params = cfg.dict()
     idx_series = load_index_returns(args.index)
     mu_idx = float(idx_series.mean())
     idx_sigma = float(idx_series.std(ddof=1))
 
-    mu_H = get_num(raw_params, "mu_H", 0.04)
-    sigma_H = get_num(raw_params, "sigma_H", 0.01)
-    mu_E = get_num(raw_params, "mu_E", 0.05)
-    sigma_E = get_num(raw_params, "sigma_E", 0.02)
-    mu_M = get_num(raw_params, "mu_M", 0.03)
-    sigma_M = get_num(raw_params, "sigma_M", 0.02)
+    mu_H = cfg.mu_H
+    sigma_H = cfg.sigma_H
+    mu_E = cfg.mu_E
+    sigma_E = cfg.sigma_E
+    mu_M = cfg.mu_M
+    sigma_M = cfg.sigma_M
 
     _ = build_cov_matrix(
-        get_num(raw_params, "rho_idx_H", 0.05),
-        get_num(raw_params, "rho_idx_E", 0.0),
-        get_num(raw_params, "rho_idx_M", 0.0),
-        get_num(raw_params, "rho_H_E", 0.10),
-        get_num(raw_params, "rho_H_M", 0.10),
-        get_num(raw_params, "rho_E_M", 0.0),
+        cfg.rho_idx_H,
+        cfg.rho_idx_E,
+        cfg.rho_idx_M,
+        cfg.rho_H_E,
+        cfg.rho_H_M,
+        cfg.rho_E_M,
         idx_sigma,
         sigma_H,
         sigma_E,
@@ -105,28 +106,28 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         "default_sigma_H": sigma_H / 12,
         "default_sigma_E": sigma_E / 12,
         "default_sigma_M": sigma_M / 12,
-        "rho_idx_H": get_num(raw_params, "rho_idx_H", 0.05),
-        "rho_idx_E": get_num(raw_params, "rho_idx_E", 0.0),
-        "rho_idx_M": get_num(raw_params, "rho_idx_M", 0.0),
-        "rho_H_E": get_num(raw_params, "rho_H_E", 0.10),
-        "rho_H_M": get_num(raw_params, "rho_H_M", 0.10),
-        "rho_E_M": get_num(raw_params, "rho_E_M", 0.0),
-        "internal_financing_mean_month": 0.0,
-        "internal_financing_sigma_month": 0.0,
-        "internal_spike_prob": 0.0,
-        "internal_spike_factor": 0.0,
-        "ext_pa_financing_mean_month": 0.0,
-        "ext_pa_financing_sigma_month": 0.0,
-        "ext_pa_spike_prob": 0.0,
-        "ext_pa_spike_factor": 0.0,
-        "act_ext_financing_mean_month": 0.0,
-        "act_ext_financing_sigma_month": 0.0,
-        "act_ext_spike_prob": 0.0,
-        "act_ext_spike_factor": 0.0,
+        "rho_idx_H": cfg.rho_idx_H,
+        "rho_idx_E": cfg.rho_idx_E,
+        "rho_idx_M": cfg.rho_idx_M,
+        "rho_H_E": cfg.rho_H_E,
+        "rho_H_M": cfg.rho_H_M,
+        "rho_E_M": cfg.rho_E_M,
+        "internal_financing_mean_month": cfg.internal_financing_mean_month,
+        "internal_financing_sigma_month": cfg.internal_financing_sigma_month,
+        "internal_spike_prob": cfg.internal_spike_prob,
+        "internal_spike_factor": cfg.internal_spike_factor,
+        "ext_pa_financing_mean_month": cfg.ext_pa_financing_mean_month,
+        "ext_pa_financing_sigma_month": cfg.ext_pa_financing_sigma_month,
+        "ext_pa_spike_prob": cfg.ext_pa_spike_prob,
+        "ext_pa_spike_factor": cfg.ext_pa_spike_factor,
+        "act_ext_financing_mean_month": cfg.act_ext_financing_mean_month,
+        "act_ext_financing_sigma_month": cfg.act_ext_financing_sigma_month,
+        "act_ext_spike_prob": cfg.act_ext_spike_prob,
+        "act_ext_spike_factor": cfg.act_ext_spike_factor,
     }
 
-    N_SIMULATIONS = int(get_num(raw_params, "N_SIMULATIONS", 1000))
-    N_MONTHS = int(get_num(raw_params, "N_MONTHS", 12))
+    N_SIMULATIONS = cfg.N_SIMULATIONS
+    N_MONTHS = cfg.N_MONTHS
 
     r_beta, r_H, r_E, r_M = draw_joint_returns(
         n_months=N_MONTHS,
@@ -142,9 +143,9 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     )
 
     # Build agents based on simple capital weights
-    total_cap = float(raw_params.get("total_fund_capital", 1000.0))
-    ext_cap = float(raw_params.get("external_pa_capital", 0.0))
-    act_cap = float(raw_params.get("active_ext_capital", 0.0))
+    total_cap = cfg.total_fund_capital
+    ext_cap = cfg.external_pa_capital
+    act_cap = cfg.active_ext_capital
 
     agents = build_all(
         [

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -57,27 +57,28 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     if args.config:
         cfg = load_config(args.config)
-        raw_params = cfg.dict()
     else:
         raw_params = load_parameters(args.params, LABEL_MAP)
+        cfg = load_config(raw_params)
+    raw_params = cfg.dict()
     idx_series = load_index_returns(args.index)
     mu_idx = float(idx_series.mean())
     idx_sigma = float(idx_series.std(ddof=1))
 
-    mu_H = get_num(raw_params, "mu_H", 0.04)
-    sigma_H = get_num(raw_params, "sigma_H", 0.01)
-    mu_E = get_num(raw_params, "mu_E", 0.05)
-    sigma_E = get_num(raw_params, "sigma_E", 0.02)
-    mu_M = get_num(raw_params, "mu_M", 0.03)
-    sigma_M = get_num(raw_params, "sigma_M", 0.02)
+    mu_H = cfg.mu_H
+    sigma_H = cfg.sigma_H
+    mu_E = cfg.mu_E
+    sigma_E = cfg.sigma_E
+    mu_M = cfg.mu_M
+    sigma_M = cfg.sigma_M
 
     _ = build_cov_matrix(
-        get_num(raw_params, "rho_idx_H", 0.05),
-        get_num(raw_params, "rho_idx_E", 0.0),
-        get_num(raw_params, "rho_idx_M", 0.0),
-        get_num(raw_params, "rho_H_E", 0.10),
-        get_num(raw_params, "rho_H_M", 0.10),
-        get_num(raw_params, "rho_E_M", 0.0),
+        cfg.rho_idx_H,
+        cfg.rho_idx_E,
+        cfg.rho_idx_M,
+        cfg.rho_H_E,
+        cfg.rho_H_M,
+        cfg.rho_E_M,
         idx_sigma,
         sigma_H,
         sigma_E,
@@ -93,28 +94,28 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         "default_sigma_H": sigma_H / 12,
         "default_sigma_E": sigma_E / 12,
         "default_sigma_M": sigma_M / 12,
-        "rho_idx_H": get_num(raw_params, "rho_idx_H", 0.05),
-        "rho_idx_E": get_num(raw_params, "rho_idx_E", 0.0),
-        "rho_idx_M": get_num(raw_params, "rho_idx_M", 0.0),
-        "rho_H_E": get_num(raw_params, "rho_H_E", 0.10),
-        "rho_H_M": get_num(raw_params, "rho_H_M", 0.10),
-        "rho_E_M": get_num(raw_params, "rho_E_M", 0.0),
-        "internal_financing_mean_month": 0.0,
-        "internal_financing_sigma_month": 0.0,
-        "internal_spike_prob": 0.0,
-        "internal_spike_factor": 0.0,
-        "ext_pa_financing_mean_month": 0.0,
-        "ext_pa_financing_sigma_month": 0.0,
-        "ext_pa_spike_prob": 0.0,
-        "ext_pa_spike_factor": 0.0,
-        "act_ext_financing_mean_month": 0.0,
-        "act_ext_financing_sigma_month": 0.0,
-        "act_ext_spike_prob": 0.0,
-        "act_ext_spike_factor": 0.0,
+        "rho_idx_H": cfg.rho_idx_H,
+        "rho_idx_E": cfg.rho_idx_E,
+        "rho_idx_M": cfg.rho_idx_M,
+        "rho_H_E": cfg.rho_H_E,
+        "rho_H_M": cfg.rho_H_M,
+        "rho_E_M": cfg.rho_E_M,
+        "internal_financing_mean_month": cfg.internal_financing_mean_month,
+        "internal_financing_sigma_month": cfg.internal_financing_sigma_month,
+        "internal_spike_prob": cfg.internal_spike_prob,
+        "internal_spike_factor": cfg.internal_spike_factor,
+        "ext_pa_financing_mean_month": cfg.ext_pa_financing_mean_month,
+        "ext_pa_financing_sigma_month": cfg.ext_pa_financing_sigma_month,
+        "ext_pa_spike_prob": cfg.ext_pa_spike_prob,
+        "ext_pa_spike_factor": cfg.ext_pa_spike_factor,
+        "act_ext_financing_mean_month": cfg.act_ext_financing_mean_month,
+        "act_ext_financing_sigma_month": cfg.act_ext_financing_sigma_month,
+        "act_ext_spike_prob": cfg.act_ext_spike_prob,
+        "act_ext_spike_factor": cfg.act_ext_spike_factor,
     }
 
-    N_SIMULATIONS = int(get_num(raw_params, "N_SIMULATIONS", 1000))
-    N_MONTHS = int(get_num(raw_params, "N_MONTHS", 12))
+    N_SIMULATIONS = cfg.N_SIMULATIONS
+    N_MONTHS = cfg.N_MONTHS
 
     r_beta, r_H, r_E, r_M = draw_joint_returns(
         n_months=N_MONTHS,

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -27,6 +27,32 @@ class ModelConfig(BaseModel):
 
     mu_H: float = 0.04
     sigma_H: float = 0.01
+    mu_E: float = 0.05
+    sigma_E: float = 0.02
+    mu_M: float = 0.03
+    sigma_M: float = 0.02
+
+    rho_idx_H: float = 0.05
+    rho_idx_E: float = 0.0
+    rho_idx_M: float = 0.0
+    rho_H_E: float = 0.10
+    rho_H_M: float = 0.10
+    rho_E_M: float = 0.0
+
+    internal_financing_mean_month: float = 0.0
+    internal_financing_sigma_month: float = 0.0
+    internal_spike_prob: float = 0.0
+    internal_spike_factor: float = 0.0
+
+    ext_pa_financing_mean_month: float = 0.0
+    ext_pa_financing_sigma_month: float = 0.0
+    ext_pa_spike_prob: float = 0.0
+    ext_pa_spike_factor: float = 0.0
+
+    act_ext_financing_mean_month: float = 0.0
+    act_ext_financing_sigma_month: float = 0.0
+    act_ext_spike_prob: float = 0.0
+    act_ext_spike_factor: float = 0.0
 
     class Config:
         allow_population_by_field_name = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,3 +20,20 @@ def test_main_with_yaml(tmp_path):
     assert out_file.exists()
 
 
+def test_main_with_csv(tmp_path):
+    csv_path = tmp_path / "params.csv"
+    csv_content = "Parameter,Value\nNumber of simulations,2\nNumber of months,1\n"
+    csv_path.write_text(csv_content)
+    idx_csv = Path(__file__).resolve().parents[1] / "sp500tr_fred_divyield.csv"
+    out_file = tmp_path / "out.xlsx"
+    main([
+        "--params",
+        str(csv_path),
+        "--index",
+        str(idx_csv),
+        "--output",
+        str(out_file),
+    ])
+    assert out_file.exists()
+
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,14 @@ def test_load_yaml(tmp_path):
     assert cfg.total_fund_capital == 1000.0
 
 
+def test_load_dict():
+    data = {"N_SIMULATIONS": 5, "N_MONTHS": 3, "mu_H": 0.05}
+    cfg = load_config(data)
+    assert cfg.N_SIMULATIONS == 5
+    assert cfg.N_MONTHS == 3
+    assert cfg.mu_H == 0.05
+
+
 def test_invalid_capital(tmp_path):
     data = {
         "N_SIMULATIONS": 1,


### PR DESCRIPTION
## Summary
- expand `ModelConfig` to include all CLI parameters
- load CSV configs through `ModelConfig` in `pa_core.cli` and `__main__`
- adjust agent driver to use dataclass values directly
- test CLI with CSV files
- test `load_config` on dictionaries

## Testing
- `pip install -e .`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68621c6217148331af31d9ed9246fe4a