### PR TITLE
Implement deterministic RNG streams via spawn_rngs

### DIFF
--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import argparse
 from typing import Sequence, Optional
 import pandas as pd
-import numpy as np
 
 from . import (
     load_parameters,
@@ -17,6 +16,7 @@ from .sim.metrics import (
 )
 from .covariance import build_cov_matrix
 from .backend import set_backend
+from .random import spawn_rngs
 from .agents import AgentParams
 from .agents.registry import build_all
 from .simulations import simulate_agents
@@ -66,7 +66,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     set_backend(args.backend)
 
-    rng = np.random.default_rng(args.seed)
+    rng_returns, rng_fin = spawn_rngs(args.seed, 2)
 
     if args.config:
         cfg = load_config(args.config)
@@ -134,13 +134,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
-        rng=rng,
+        rng=rng_returns,
     )
     f_int, f_ext, f_act = draw_financing_series(
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
-        rng=rng,
+        rng=rng_fin,
     )
 
     # Build agents based on simple capital weights

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -13,6 +13,7 @@ from . import (
 )
 from .covariance import build_cov_matrix
 from .backend import set_backend
+from .random import spawn_rngs
 
 LABEL_MAP = {
     "Analysis mode": "analysis_mode",
@@ -50,9 +51,17 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         default="numpy",
         help="Computation backend",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducible simulations",
+    )
     args = parser.parse_args(argv)
 
     set_backend(args.backend)
+
+    rng_returns, rng_fin = spawn_rngs(args.seed, 2)
 
     if args.config:
         cfg = load_config(args.config)
@@ -120,11 +129,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
+        rng=rng_returns,
     )
     f_int, f_ext, f_act = draw_financing_series(
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
+        rng=rng_fin,
     )
 
     base_returns = r_beta - f_int

--- a/pa_core/random.py
+++ b/pa_core/random.py
@@ -6,8 +6,11 @@ from numpy.random import Generator, SeedSequence
 __all__ = ["spawn_rngs"]
 
 
-def spawn_rngs(seed: int, n: int) -> list[Generator]:
-    """Return ``n`` independent generators derived from ``seed``."""
+def spawn_rngs(seed: int | None, n: int) -> list[Generator]:
+    """Return ``n`` independent generators derived from ``seed``.
+
+    Passing ``None`` uses unpredictable entropy from the OS.
+    """
     if n <= 0:
         raise ValueError("n must be positive")
     ss = SeedSequence(seed)

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -13,3 +13,8 @@ def test_spawn_rngs_independent():
     r1, r2 = spawn_rngs(42, 2)
     assert not np.allclose(r1.normal(size=3), r2.normal(size=3))
 
+
+def test_spawn_rngs_none_seed():
+    rngs = spawn_rngs(None, 3)
+    assert len(rngs) == 3
+


### PR DESCRIPTION
## Summary
- allow optional seed in `spawn_rngs`
- use separate RNG streams for returns and financing in CLI and `__main__`
- test RNG helper accepts `None` seed

## Testing
- `ruff check pa_core tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627ddb01d48331901e63ef6296c0c3