### PR TITLE
Move covariance builder to sim package

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -15,7 +15,7 @@ from .sim import (
     draw_financing_series,
     simulate_alpha_streams,
 )
-from .covariance import build_cov_matrix
+from .sim.covariance import build_cov_matrix
 from .random import spawn_rngs
 from .backend import set_backend, get_backend
 from .reporting import export_to_excel, print_summary

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -14,7 +14,7 @@ from . import (
 from .sim.metrics import (
     summary_table,
 )
-from .covariance import build_cov_matrix
+from .sim.covariance import build_cov_matrix
 from .backend import set_backend
 from .random import spawn_rngs
 from .agents import AgentParams

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -11,7 +11,7 @@ from . import (
     export_to_excel,
     load_config,
 )
-from .covariance import build_cov_matrix
+from .sim.covariance import build_cov_matrix
 from .backend import set_backend
 from .random import spawn_rngs
 

--- a/pa_core/sim/__init__.py
+++ b/pa_core/sim/__init__.py
@@ -7,10 +7,12 @@ from .paths import (
     draw_financing_series,
     simulate_alpha_streams,
 )
+from .covariance import build_cov_matrix
 
 __all__ = [
     "simulate_financing",
     "prepare_mc_universe",
+    "build_cov_matrix",
     "draw_joint_returns",
     "draw_financing_series",
     "simulate_alpha_streams",

--- a/pa_core/sim/covariance.py
+++ b/pa_core/sim/covariance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .backend import xp as np
+from ..backend import xp as np
 import numpy as npt
 from numpy.typing import NDArray
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pa_core.covariance import build_cov_matrix
+from pa_core.sim.covariance import build_cov_matrix
 from pa_core.simulations import simulate_financing, simulate_agents
 from pa_core.agents import (
     AgentParams,


### PR DESCRIPTION
## Summary
- place `covariance.py` inside `pa_core.sim`
- adjust imports throughout package and tests
- expose `build_cov_matrix` via `pa_core.sim`

## Testing
- `pip install -e .`
- `pip install hypothesis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686280b2e518833197858edb2398849b