### PR TITLE
Add agent parameter fields

### DIFF
--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -150,20 +150,26 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     agents = build_all(
         [
-            AgentParams("Base", total_cap, 0.5, 0.5, {}),
+            AgentParams(
+                "Base",
+                total_cap,
+                cfg.w_beta_H,
+                cfg.w_alpha_H,
+                {},
+            ),
             AgentParams(
                 "ExternalPA",
                 ext_cap,
                 ext_cap / total_cap,
                 0.0,
-                {"theta_extpa": 0.5},
+                {"theta_extpa": cfg.theta_extpa},
             ),
             AgentParams(
                 "ActiveExt",
                 act_cap,
                 act_cap / total_cap,
                 0.0,
-                {"active_share": 0.5},
+                {"active_share": cfg.active_share},
             ),
         ]
     )

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -149,20 +149,26 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     agents = build_all(
         [
-            AgentParams("Base", total_cap, 0.5, 0.5, {}),
+            AgentParams(
+                "Base",
+                total_cap,
+                cfg.w_beta_H,
+                cfg.w_alpha_H,
+                {},
+            ),
             AgentParams(
                 "ExternalPA",
                 ext_cap,
                 ext_cap / total_cap,
                 0.0,
-                {"theta_extpa": 0.5},
+                {"theta_extpa": cfg.theta_extpa},
             ),
             AgentParams(
                 "ActiveExt",
                 act_cap,
                 act_cap / total_cap,
                 0.0,
-                {"active_share": 0.5},
+                {"active_share": cfg.active_share},
             ),
         ]
     )

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -25,6 +25,11 @@ class ModelConfig(BaseModel):
     internal_pa_capital: float = 0.0
     total_fund_capital: float = 1000.0
 
+    w_beta_H: float = 0.5
+    w_alpha_H: float = 0.5
+    theta_extpa: float = 0.5
+    active_share: float = 0.5
+
     mu_H: float = 0.04
     sigma_H: float = 0.01
     mu_E: float = 0.05


### PR DESCRIPTION
## Summary
- expose Base agent weights and sleeve options in `ModelConfig`
- use those configuration fields when constructing agents in CLI and module entry point

## Testing
- `ruff check pa_core`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686287f7211c83319a979132f47d908f