### PR TITLE
Implement agent factory from ModelConfig

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -37,7 +37,7 @@ from .agents import (
     InternalBetaAgent,
     InternalPAAgent,
 )
-from .agents.registry import build_all as build_agents
+from .agents.registry import build_all as build_agents, build_from_config
 
 __all__ = [
     "select_csv_file",
@@ -73,4 +73,5 @@ __all__ = [
     "ModelConfig",
     "load_config",
     "build_agents",
+    "build_from_config",
 ]

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -17,8 +17,7 @@ from .sim.metrics import (
 from .sim.covariance import build_cov_matrix
 from .backend import set_backend
 from .random import spawn_rngs
-from .agents import AgentParams
-from .agents.registry import build_all
+from .agents.registry import build_from_config
 from .simulations import simulate_agents
 
 LABEL_MAP = {
@@ -143,36 +142,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         rng=rng_fin,
     )
 
-    # Build agents based on simple capital weights
-    total_cap = cfg.total_fund_capital
-    ext_cap = cfg.external_pa_capital
-    act_cap = cfg.active_ext_capital
-
-    agents = build_all(
-        [
-            AgentParams(
-                "Base",
-                total_cap,
-                cfg.w_beta_H,
-                cfg.w_alpha_H,
-                {},
-            ),
-            AgentParams(
-                "ExternalPA",
-                ext_cap,
-                ext_cap / total_cap,
-                0.0,
-                {"theta_extpa": cfg.theta_extpa},
-            ),
-            AgentParams(
-                "ActiveExt",
-                act_cap,
-                act_cap / total_cap,
-                0.0,
-                {"active_share": cfg.active_share},
-            ),
-        ]
-    )
+    # Build agents from configuration
+    agents = build_from_config(cfg)
 
     returns = simulate_agents(agents, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act)
 

--- a/pa_core/agents/registry.py
+++ b/pa_core/agents/registry.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Iterable, List
 
+from ..config import ModelConfig
+
 from .types import Agent, AgentParams
 from .base import BaseAgent
 from .external_pa import ExternalPAAgent
@@ -26,3 +28,60 @@ def build_all(params_list: Iterable[AgentParams]) -> List[Agent]:
             raise KeyError(f"Unknown agent name: {p.name}")
         agents.append(cls(p))
     return agents
+
+
+def build_from_config(cfg: ModelConfig) -> List[Agent]:
+    """Instantiate agents based on ``ModelConfig`` values."""
+    total_cap = cfg.total_fund_capital
+
+    params: list[AgentParams] = [
+        AgentParams("Base", total_cap, cfg.w_beta_H, cfg.w_alpha_H, {})
+    ]
+
+    if cfg.external_pa_capital > 0:
+        params.append(
+            AgentParams(
+                "ExternalPA",
+                cfg.external_pa_capital,
+                cfg.external_pa_capital / total_cap,
+                0.0,
+                {"theta_extpa": cfg.theta_extpa},
+            )
+        )
+
+    if cfg.active_ext_capital > 0:
+        params.append(
+            AgentParams(
+                "ActiveExt",
+                cfg.active_ext_capital,
+                cfg.active_ext_capital / total_cap,
+                0.0,
+                {"active_share": cfg.active_share},
+            )
+        )
+
+    if cfg.internal_pa_capital > 0:
+        params.append(
+            AgentParams(
+                "InternalPA",
+                cfg.internal_pa_capital,
+                0.0,
+                cfg.internal_pa_capital / total_cap,
+                {},
+            )
+        )
+
+    leftover_beta = (
+        total_cap
+        - cfg.external_pa_capital
+        - cfg.active_ext_capital
+        - cfg.internal_pa_capital
+    )
+    if leftover_beta > 0:
+        params.append(
+            AgentParams(
+                "InternalBeta", leftover_beta, leftover_beta / total_cap, 0.0, {}
+            )
+        )
+
+    return build_all(params)

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -14,8 +14,7 @@ from . import (
 from .sim.covariance import build_cov_matrix
 from .backend import set_backend
 from .random import spawn_rngs
-from .agents import AgentParams
-from .agents.registry import build_all
+from .agents.registry import build_from_config
 from .simulations import simulate_agents
 from .sim.metrics import summary_table
 
@@ -142,36 +141,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         rng=rng_fin,
     )
 
-    # Build agents using a simple capital allocation
-    total_cap = cfg.total_fund_capital
-    ext_cap = cfg.external_pa_capital
-    act_cap = cfg.active_ext_capital
-
-    agents = build_all(
-        [
-            AgentParams(
-                "Base",
-                total_cap,
-                cfg.w_beta_H,
-                cfg.w_alpha_H,
-                {},
-            ),
-            AgentParams(
-                "ExternalPA",
-                ext_cap,
-                ext_cap / total_cap,
-                0.0,
-                {"theta_extpa": cfg.theta_extpa},
-            ),
-            AgentParams(
-                "ActiveExt",
-                act_cap,
-                act_cap / total_cap,
-                0.0,
-                {"active_share": cfg.active_share},
-            ),
-        ]
-    )
+    # Build agents based on the configuration
+    agents = build_from_config(cfg)
 
     returns = simulate_agents(agents, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,7 +7,8 @@ from pa_core.agents import (
     InternalBetaAgent,
     InternalPAAgent,
 )
-from pa_core.agents.registry import build_all
+from pa_core.agents.registry import build_all, build_from_config
+from pa_core.config import ModelConfig
 
 
 def _mock_inputs(shape=(5, 12)):
@@ -108,3 +109,11 @@ def test_agent_math_identity():
     pa_agent = InternalPAAgent(pa_p)
     expected_pa = pa_p.alpha_share * r_H
     np.testing.assert_allclose(pa_agent.monthly_returns(r_beta, r_H, f), expected_pa)
+
+
+def test_build_from_config_basic():
+    cfg = ModelConfig(N_SIMULATIONS=1, N_MONTHS=1)
+    agents = build_from_config(cfg)
+    names = {type(a).__name__ for a in agents}
+    assert "BaseAgent" in names
+    assert len(agents) >= 1


### PR DESCRIPTION
## Summary
- create `build_from_config` in agents.registry
- wire CLI and __main__ to use new agent factory
- export new factory via package __init__
- test `build_from_config`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633260b4048331a258534df7eb8165