### PR TITLE
Enhance agent validation

### DIFF
--- a/pa_core/agents/internal_beta.py
+++ b/pa_core/agents/internal_beta.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 from .types import Agent, Array
 
 class InternalBetaAgent(Agent):
-    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
-        if r_beta.shape != financing.shape:
+    def monthly_returns(
+        self,
+        r_beta: Array,
+        alpha_stream: Array,
+        financing: Array,
+    ) -> Array:
+        """Return margin sleeve returns with input validation."""
+        if r_beta.shape != financing.shape or r_beta.shape != alpha_stream.shape:
             raise ValueError("shape mismatch")
         return self.p.beta_share * (r_beta - financing)

--- a/pa_core/agents/internal_pa.py
+++ b/pa_core/agents/internal_pa.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 from .types import Agent, Array
 
 class InternalPAAgent(Agent):
-    def monthly_returns(self, r_beta: Array, alpha_stream: Array, financing: Array) -> Array:
-        if r_beta.shape != alpha_stream.shape:
+    def monthly_returns(
+        self,
+        r_beta: Array,
+        alpha_stream: Array,
+        financing: Array,
+    ) -> Array:
+        """Return pure in-house alpha with input validation."""
+        if (
+            r_beta.shape != alpha_stream.shape
+            or r_beta.shape != financing.shape
+        ):
             raise ValueError("shape mismatch")
         return self.p.alpha_share * alpha_stream

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -117,3 +117,33 @@ def test_build_from_config_basic():
     names = {type(a).__name__ for a in agents}
     assert "BaseAgent" in names
     assert len(agents) >= 1
+
+
+def test_dimension_mismatch_errors():
+    r_beta = np.zeros((2, 2))
+    r_H = np.zeros((2, 3))  # mismatched shape
+    f = np.zeros((2, 2))
+
+    base = BaseAgent(AgentParams("Base", 1.0, 0.5, 0.5, {}))
+    try:
+        base.monthly_returns(r_beta, r_H, f)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for shape mismatch")
+
+    beta = InternalBetaAgent(AgentParams("InternalBeta", 1.0, 1.0, 0.0, {}))
+    try:
+        beta.monthly_returns(r_beta, r_H, f)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for shape mismatch")
+
+    pa = InternalPAAgent(AgentParams("InternalPA", 1.0, 0.0, 0.1, {}))
+    try:
+        pa.monthly_returns(r_beta, r_H, f)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for shape mismatch")


### PR DESCRIPTION
## Summary
- validate shapes for internal agents
- test that mismatched shapes raise ValueError

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633db0f5c083318722639c2df86e74