### PR TITLE
Add per-agent RNG utility

### DIFF
--- a/pa_core/random.py
+++ b/pa_core/random.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .backend import xp as np
 from numpy.random import Generator, SeedSequence
 
-__all__ = ["spawn_rngs"]
+__all__ = ["spawn_rngs", "spawn_agent_rngs"]
 
 
 def spawn_rngs(seed: int | None, n: int) -> list[Generator]:
@@ -15,4 +15,14 @@ def spawn_rngs(seed: int | None, n: int) -> list[Generator]:
         raise ValueError("n must be positive")
     ss = SeedSequence(seed)
     return [np.random.default_rng(s) for s in ss.spawn(n)]
+
+
+def spawn_agent_rngs(seed: int | None, agent_names: list[str]) -> dict[str, Generator]:
+    """Return a dedicated RNG for each agent name derived from ``seed``."""
+    if not agent_names:
+        raise ValueError("agent_names must not be empty")
+    ss = SeedSequence(seed)
+    spawned = ss.spawn(len(agent_names))
+    rngs = [np.random.default_rng(s) for s in spawned]
+    return dict(zip(agent_names, rngs))
 

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pa_core.random import spawn_rngs
+from pa_core.random import spawn_rngs, spawn_agent_rngs
 
 def test_spawn_rngs_reproducible():
     r1, r2 = spawn_rngs(123, 2)
@@ -17,4 +17,23 @@ def test_spawn_rngs_independent():
 def test_spawn_rngs_none_seed():
     rngs = spawn_rngs(None, 3)
     assert len(rngs) == 3
+
+
+def test_spawn_agent_rngs_reproducible():
+    names = ["A", "B"]
+    rngs = spawn_agent_rngs(42, names)
+    vals_a = rngs["A"].normal(size=3)
+    vals_b = rngs["B"].normal(size=3)
+    rngs2 = spawn_agent_rngs(42, names)
+    assert np.allclose(vals_a, rngs2["A"].normal(size=3))
+    assert np.allclose(vals_b, rngs2["B"].normal(size=3))
+
+
+def test_spawn_agent_rngs_error():
+    try:
+        spawn_agent_rngs(0, [])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for empty list")
 


### PR DESCRIPTION
## Summary
- add `spawn_agent_rngs` helper for reproducible per-agent streams
- test new RNG helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634bfed6148331b0be23bbdf67f06d