### PR TITLE
Add pivot flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ python -m pa_core --params parameters.csv --index sp500tr_fred_divyield.csv
 
 # or YAML configuration
 python -m pa_core --config params.yaml --index sp500tr_fred_divyield.csv
+
+# optional pivot-style output
+python -m pa_core --config params.yaml --index sp500tr_fred_divyield.csv --pivot
 ```
 
 This writes results to `Outputs.xlsx` in the current directory.

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -50,6 +50,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     parser.add_argument("--index", required=True, help="Index returns CSV")
     parser.add_argument("--output", default="Outputs.xlsx", help="Output workbook")
     parser.add_argument(
+        "--pivot",
+        action="store_true",
+        help="Write all raw returns in a single long-format sheet",
+    )
+    parser.add_argument(
         "--backend",
         choices=["numpy", "cupy"],
         default="numpy",
@@ -151,6 +156,12 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     inputs_dict = {k: raw_params.get(k, "") for k in raw_params}
     raw_returns_dict = {k: pd.DataFrame(v) for k, v in returns.items()}
     print_summary(summary)
-    export_to_excel(inputs_dict, summary, raw_returns_dict, filename=args.output)
+    export_to_excel(
+        inputs_dict,
+        summary,
+        raw_returns_dict,
+        filename=args.output,
+        pivot=args.pivot,
+    )
 
 


### PR DESCRIPTION
## Summary
- expose a `--pivot` option in CLI to write raw returns in long format
- document the new flag in README

## Testing
- `ruff check pa_core`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635bbd74248331a01b80b95113591e