### PR TITLE
Add per-agent RNG handling

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -16,7 +16,7 @@ from .sim import (
     simulate_alpha_streams,
 )
 from .sim.covariance import build_cov_matrix
-from .random import spawn_rngs
+from .random import spawn_rngs, spawn_agent_rngs
 from .backend import set_backend, get_backend
 from .reporting import export_to_excel, print_summary
 from .sim.metrics import (
@@ -53,6 +53,7 @@ __all__ = [
     "draw_financing_series",
     "simulate_alpha_streams",
     "spawn_rngs",
+    "spawn_agent_rngs",
     "set_backend",
     "get_backend",
     "export_to_excel",

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -16,7 +16,7 @@ from .sim.metrics import (
 )
 from .sim.covariance import build_cov_matrix
 from .backend import set_backend
-from .random import spawn_rngs
+from .random import spawn_rngs, spawn_agent_rngs
 from .agents.registry import build_from_config
 from .simulations import simulate_agents
 
@@ -65,7 +65,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     set_backend(args.backend)
 
-    rng_returns, rng_fin = spawn_rngs(args.seed, 2)
+    rng_returns = spawn_rngs(args.seed, 1)[0]
+    fin_rngs = spawn_agent_rngs(
+        args.seed,
+        ["internal", "external_pa", "active_ext"],
+    )
 
     if args.config:
         cfg = load_config(args.config)
@@ -139,7 +143,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
-        rng=rng_fin,
+        rngs=fin_rngs,
     )
 
     # Build agents from configuration

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -14,7 +14,7 @@ from . import (
 )
 from .sim.covariance import build_cov_matrix
 from .backend import set_backend
-from .random import spawn_rngs
+from .random import spawn_rngs, spawn_agent_rngs
 from .agents.registry import build_from_config
 from .simulations import simulate_agents
 from .sim.metrics import summary_table
@@ -70,7 +70,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     set_backend(args.backend)
 
-    rng_returns, rng_fin = spawn_rngs(args.seed, 2)
+    rng_returns = spawn_rngs(args.seed, 1)[0]
+    fin_rngs = spawn_agent_rngs(
+        args.seed,
+        ["internal", "external_pa", "active_ext"],
+    )
 
     if args.config:
         cfg = load_config(args.config)
@@ -144,7 +148,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         n_months=N_MONTHS,
         n_sim=N_SIMULATIONS,
         params=params,
-        rng=rng_fin,
+        rngs=fin_rngs,
     )
 
     # Build agents based on the configuration

--- a/pa_core/sim/paths.py
+++ b/pa_core/sim/paths.py
@@ -129,13 +129,30 @@ def draw_financing_series(
     ``rng`` will be used for all sleeves.
     """
     if rngs is not None:
-        r_int = rngs.get("internal") or np.random.default_rng()
-        r_ext = rngs.get("external_pa") or np.random.default_rng()
-        r_act = rngs.get("active_ext") or np.random.default_rng()
+        tmp_int = rngs.get("internal")
+        if isinstance(tmp_int, Generator):
+            r_int: Generator = tmp_int
+        else:
+            r_int = np.random.default_rng()
+
+        tmp_ext = rngs.get("external_pa")
+        if isinstance(tmp_ext, Generator):
+            r_ext: Generator = tmp_ext
+        else:
+            r_ext = np.random.default_rng()
+
+        tmp_act = rngs.get("active_ext")
+        if isinstance(tmp_act, Generator):
+            r_act: Generator = tmp_act
+        else:
+            r_act = np.random.default_rng()
     else:
         if rng is None:
             rng = np.random.default_rng()
-        r_int = r_ext = r_act = rng
+        assert isinstance(rng, Generator)
+        r_int = rng
+        r_ext = rng
+        r_act = rng
 
     def _sim(
         mean_key: str,

--- a/pa_core/sim/paths.py
+++ b/pa_core/sim/paths.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Any
+from typing import Optional, Any, Mapping
 import numpy.typing as npt
 from numpy.random import Generator
 
@@ -120,17 +120,43 @@ def draw_financing_series(
     n_sim: int,
     params: dict,
     rng: Optional[Generator] = None,
+    rngs: Optional[Mapping[str, Generator]] = None,
 ) -> tuple[npt.NDArray[Any], npt.NDArray[Any], npt.NDArray[Any]]:
-    """Return three matrices of monthly financing spreads."""
-    if rng is None:
-        rng = np.random.default_rng()
+    """Return three matrices of monthly financing spreads.
 
-    def _sim(mean_key: str, sigma_key: str, p_key: str, k_key: str) -> npt.NDArray[Any]:
+    ``rngs`` may provide dedicated generators for each sleeve under the keys
+    ``"internal"``, ``"external_pa"``, and ``"active_ext"``. If not supplied,
+    ``rng`` will be used for all sleeves.
+    """
+    if rngs is not None:
+        r_int = rngs.get("internal") or np.random.default_rng()
+        r_ext = rngs.get("external_pa") or np.random.default_rng()
+        r_act = rngs.get("active_ext") or np.random.default_rng()
+    else:
+        if rng is None:
+            rng = np.random.default_rng()
+        r_int = r_ext = r_act = rng
+
+    def _sim(
+        mean_key: str,
+        sigma_key: str,
+        p_key: str,
+        k_key: str,
+        rng_local: Generator,
+    ) -> npt.NDArray[Any]:
         mean = params[mean_key]
         sigma = params[sigma_key]
         p = params[p_key]
         k = params[k_key]
-        vec = simulate_financing(n_months, mean, sigma, p, k, n_scenarios=1, rng=rng)[0]
+        vec = simulate_financing(
+            n_months,
+            mean,
+            sigma,
+            p,
+            k,
+            n_scenarios=1,
+            rng=rng_local,
+        )[0]
         return np.broadcast_to(vec, (n_sim, n_months))
 
     f_int_mat = _sim(
@@ -138,18 +164,21 @@ def draw_financing_series(
         "internal_financing_sigma_month",
         "internal_spike_prob",
         "internal_spike_factor",
+        r_int,
     )
     f_ext_pa_mat = _sim(
         "ext_pa_financing_mean_month",
         "ext_pa_financing_sigma_month",
         "ext_pa_spike_prob",
         "ext_pa_spike_factor",
+        r_ext,
     )
     f_act_ext_mat = _sim(
         "act_ext_financing_mean_month",
         "act_ext_financing_sigma_month",
         "act_ext_spike_prob",
         "act_ext_spike_factor",
+        r_act,
     )
     return f_int_mat, f_ext_pa_mat, f_act_ext_mat
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,6 +1,8 @@
 import numpy as np
 from pa_core.sim.covariance import build_cov_matrix
 from pa_core.simulations import simulate_financing, simulate_agents
+from pa_core.sim.paths import draw_financing_series
+from pa_core.random import spawn_agent_rngs
 from pa_core.agents import (
     AgentParams,
     BaseAgent,
@@ -50,3 +52,26 @@ def test_simulate_agents_vectorised():
     assert set(results) == {"Base", "ExternalPA", "InternalBeta"}
     for arr in results.values():
         assert arr.shape == (n_sim, n_months)
+
+
+def test_draw_financing_series_rngs():
+    params = {
+        "internal_financing_mean_month": 0.0,
+        "internal_financing_sigma_month": 0.01,
+        "internal_spike_prob": 0.0,
+        "internal_spike_factor": 0.0,
+        "ext_pa_financing_mean_month": 0.0,
+        "ext_pa_financing_sigma_month": 0.01,
+        "ext_pa_spike_prob": 0.0,
+        "ext_pa_spike_factor": 0.0,
+        "act_ext_financing_mean_month": 0.0,
+        "act_ext_financing_sigma_month": 0.01,
+        "act_ext_spike_prob": 0.0,
+        "act_ext_spike_factor": 0.0,
+    }
+    rngs = spawn_agent_rngs(123, ["internal", "external_pa", "active_ext"])
+    out1 = draw_financing_series(n_months=3, n_sim=2, params=params, rngs=rngs)
+    rngs2 = spawn_agent_rngs(123, ["internal", "external_pa", "active_ext"])
+    out2 = draw_financing_series(n_months=3, n_sim=2, params=params, rngs=rngs2)
+    for a, b in zip(out1, out2):
+        assert np.allclose(a, b)


### PR DESCRIPTION
## Summary
- allow draw_financing_series to use dedicated RNGs per sleeve
- spawn per-sleeve RNGs in CLI and `__main__`
- expose `spawn_agent_rngs`
- test deterministic financing draws with explicit RNGs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635de5ee00833190825e0efa9407ee