### PR TITLE
Implement visualisation layer

### DIFF
--- a/config_thresholds.yaml
+++ b/config_thresholds.yaml
@@ -1,0 +1,9 @@
+shortfall_green: 0.05
+shortfall_amber: 0.10
+drawdown_limit: 0.05
+te_cap: 0.03
+excess_return_target: 0.05
+excess_return_floor: 0.03
+sharpe_green: 0.5
+sharpe_amber: 0.4
+confidence: 0.95

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+from pathlib import Path
+
+from pa_core.viz import risk_return, fan, path_dist
+
+
+_DEF_XLSX = "Outputs.xlsx"
+
+
+def load_data(xlsx: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    summary = pd.read_excel(xlsx, sheet_name="Summary")
+    paths = pd.read_parquet(Path(xlsx).with_suffix(".parquet"))
+    return summary, paths
+
+
+def main() -> None:
+    st.title("Portable Alpha Dashboard")
+    xlsx = st.sidebar.text_input("Results file", _DEF_XLSX)
+    if not Path(xlsx).exists():
+        st.warning(f"File {xlsx} not found")
+        st.stop()
+    summary, paths = load_data(xlsx)
+
+    tab1, tab2, tab3, tab4 = st.tabs([
+        "Headline",
+        "Funding fan",
+        "Path dist",
+        "Diagnostics",
+    ])
+    with tab1:
+        st.plotly_chart(risk_return.make(summary), use_container_width=True)
+    with tab2:
+        st.plotly_chart(fan.make(paths), use_container_width=True)
+    with tab3:
+        st.plotly_chart(path_dist.make(paths), use_container_width=True)
+    with tab4:
+        st.dataframe(summary)
+
+    png = risk_return.make(summary).to_image(format="png")
+    st.download_button(
+        label="Download PNG",
+        data=png,
+        file_name="risk_return.png",
+        mime="image/png",
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -19,6 +19,7 @@ from .sim.covariance import build_cov_matrix
 from .random import spawn_rngs, spawn_agent_rngs
 from .backend import set_backend, get_backend
 from .reporting import export_to_excel, print_summary
+from . import viz
 from .sim.metrics import (
     tracking_error,
     value_at_risk,
@@ -75,4 +76,5 @@ __all__ = [
     "load_config",
     "build_agents",
     "build_from_config",
+    "viz",
 ]

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -1,0 +1,17 @@
+"""Plotly visualization helpers."""
+
+from . import theme
+from . import risk_return
+from . import fan
+from . import path_dist
+from . import corr_heatmap
+from . import sharpe_ladder
+
+__all__ = [
+    "theme",
+    "risk_return",
+    "fan",
+    "path_dist",
+    "corr_heatmap",
+    "sharpe_ladder",
+]

--- a/pa_core/viz/corr_heatmap.py
+++ b/pa_core/viz/corr_heatmap.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(paths_map: dict[str, pd.DataFrame | np.ndarray]) -> go.Figure:
+    """Return heatmap of monthly return correlations."""
+    arrays = [np.asarray(v) for v in paths_map.values()]
+    # flatten along sims
+    monthly = [arr.reshape(-1, arr.shape[-1]) for arr in arrays]
+    returns = np.concatenate(monthly, axis=0)
+    corr = np.corrcoef(returns.T)
+    fig = go.Figure(
+        data=go.Heatmap(z=corr, x=range(corr.shape[0]), y=range(corr.shape[0])),
+        layout_template=theme.TEMPLATE,
+    )
+    fig.update_layout(xaxis_title="Month", yaxis_title="Month")
+    return fig

--- a/pa_core/viz/fan.py
+++ b/pa_core/viz/fan.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_paths: pd.DataFrame | np.ndarray) -> go.Figure:
+    """Return funding fan chart with median and confidence ribbon."""
+    arr = np.asarray(df_paths)
+    median = np.median(arr, axis=0)
+    conf = theme.THRESHOLDS.get("confidence", 0.95)
+    lower = np.percentile(arr, 100 * (1 - conf), axis=0)
+    upper = np.percentile(arr, 100 * conf, axis=0)
+
+    months = np.arange(arr.shape[1])
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(go.Scatter(x=months, y=upper, mode="lines", line=dict(width=0), showlegend=False))
+    fig.add_trace(go.Scatter(x=months, y=lower, mode="lines", fill="tonexty", line=dict(width=0), name=f"{int(conf*100)}% CI"))
+    fig.add_trace(go.Scatter(x=months, y=median, mode="lines", name="Median"))
+    fig.update_layout(xaxis_title="Month", yaxis_title="Return")
+    return fig

--- a/pa_core/viz/path_dist.py
+++ b/pa_core/viz/path_dist.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_paths: pd.DataFrame | np.ndarray) -> go.Figure:
+    """Return histogram of end-point returns."""
+    arr = np.asarray(df_paths)
+    final = arr[:, -1].ravel()
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(go.Histogram(x=final, nbinsx=40, name="Distribution"))
+    fig.update_layout(xaxis_title="Final Return", yaxis_title="Frequency")
+    return fig

--- a/pa_core/viz/risk_return.py
+++ b/pa_core/viz/risk_return.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_summary: pd.DataFrame) -> go.Figure:
+    """Return risk-return scatter plot.
+
+    Parameters
+    ----------
+    df_summary : pandas.DataFrame
+        Must contain AnnReturn, AnnVol, TrackingErr, Agent, ShortfallProb.
+    """
+    df = df_summary.copy()
+    color = []
+    thr = theme.THRESHOLDS
+    for prob in df["ShortfallProb"].fillna(0.0):
+        if prob <= thr.get("shortfall_green", 0.05):
+            color.append("green")
+        elif prob <= thr.get("shortfall_amber", 0.1):
+            color.append("orange")
+        else:
+            color.append("red")
+
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(
+        go.Scatter(
+            x=df["AnnVol"],
+            y=df["AnnReturn"],
+            mode="markers",
+            marker=dict(size=12, color=color),
+            text=df["Agent"],
+            hovertemplate="%{text}<br>Vol=%{x:.2%}<br>Return=%{y:.2%}<extra></extra>",
+        )
+    )
+
+    # sweet-spot rectangle
+    rect = dict(
+        type="rect",
+        xref="x",
+        yref="y",
+        x0=0,
+        x1=thr.get("te_cap", 0.03),
+        y0=thr.get("excess_return_floor", 0.03),
+        y1=thr.get("excess_return_target", 0.05),
+        fillcolor="lightgrey",
+        opacity=0.3,
+        line_width=0,
+    )
+    fig.update_layout(
+        shapes=[rect],
+        xaxis_title="Tracking Error",
+        yaxis_title="Excess Return",
+        template=theme.TEMPLATE,
+    )
+    return fig

--- a/pa_core/viz/sharpe_ladder.py
+++ b/pa_core/viz/sharpe_ladder.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_summary: pd.DataFrame) -> go.Figure:
+    """Return bar chart of Sharpe ratio sorted descending."""
+    df = df_summary.copy()
+    df["Sharpe"] = df["AnnReturn"] / df["AnnVol"].replace(0, pd.NA)
+    df = df.sort_values("Sharpe", ascending=False)
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_bar(x=df["Agent"], y=df["Sharpe"])
+    fig.update_layout(xaxis_title="Agent", yaxis_title="Sharpe Ratio")
+    return fig

--- a/pa_core/viz/theme.py
+++ b/pa_core/viz/theme.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+import plotly.graph_objects as go
+
+# Load thresholds for traffic-light styling
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config_thresholds.yaml"
+if _CONFIG_PATH.exists():
+    with open(_CONFIG_PATH, "r", encoding="utf-8") as fh:
+        THRESHOLDS: dict[str, float] = yaml.safe_load(fh) or {}
+else:
+    THRESHOLDS = {}
+
+# Colour-blind friendly palette
+_COLORWAY = [
+    "#377eb8",  # blue
+    "#ff7f00",  # orange
+    "#4daf4a",  # green
+    "#f781bf",  # pink
+    "#a65628",  # brown
+    "#984ea3",  # purple
+]
+
+TEMPLATE = go.layout.Template(
+    layout=dict(colorway=_COLORWAY, font=dict(family="Roboto"))
+)
+
+# Map agent class -> category name used for consistent colours
+CATEGORY_BY_AGENT = {
+    "InternalPAAgent": "Internal Portable Alpha",
+    "InternalBetaAgent": "Internal Portable Alpha",
+    "ExternalPAAgent": "External Portable Alpha",
+    "ActiveExtensionAgent": "External Portable Alpha",
+    "BaseAgent": "Benchmark / Passive",
+}

--- a/scripts/visualise.py
+++ b/scripts/visualise.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import pandas as pd
+
+from pa_core.viz import risk_return, fan, path_dist, corr_heatmap, sharpe_ladder
+
+
+PLOTS = {
+    "risk_return": risk_return.make,
+    "fan": fan.make,
+    "path_dist": path_dist.make,
+    "corr_heatmap": corr_heatmap.make,
+    "sharpe_ladder": sharpe_ladder.make,
+}
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Visualise simulation outputs")
+    parser.add_argument("--plot", choices=PLOTS.keys(), required=True)
+    parser.add_argument("--xlsx", required=True, help="Outputs.xlsx file")
+    parser.add_argument("--agent", action="append", help="Agent name for paths")
+    parser.add_argument("--png", action="store_true")
+    parser.add_argument("--pdf", action="store_true")
+    parser.add_argument("--pptx", action="store_true")
+    args = parser.parse_args(argv)
+
+    df_summary = pd.read_excel(args.xlsx, sheet_name="Summary")
+    parquet_path = Path(args.xlsx).with_suffix(".parquet")
+    df_paths = pd.read_parquet(parquet_path) if parquet_path.exists() else None
+
+    if args.plot in {"fan", "path_dist"} and df_paths is None:
+        raise FileNotFoundError(parquet_path)
+
+    if args.plot == "corr_heatmap":
+        if df_paths is None:
+            raise FileNotFoundError(parquet_path)
+        paths_map = {"All": df_paths}
+        fig = PLOTS[args.plot](paths_map)
+    elif args.plot in {"fan", "path_dist"}:
+        fig = PLOTS[args.plot](df_paths)
+    else:
+        fig = PLOTS[args.plot](df_summary)
+
+    base = Path("plots")
+    base.mkdir(exist_ok=True)
+    stem = base / args.plot
+    if args.png:
+        fig.write_image(f"{stem}.png")
+    if args.pdf:
+        fig.write_image(f"{stem}.pdf")
+    if args.pptx:
+        from pptx import Presentation
+        img_path = stem.with_suffix(".png")
+        fig.write_image(img_path)
+        pres = Presentation()
+        slide = pres.slides.add_slide(pres.slide_layouts[5])
+        slide.shapes.add_picture(str(img_path), 0, 0)
+        pres.save(f"{stem}.pptx")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,39 @@
+import pandas as pd
+import numpy as np
+import plotly.graph_objects as go
+
+from pa_core.viz import risk_return, fan, path_dist, sharpe_ladder
+
+
+def test_risk_return_make():
+    df = pd.DataFrame({
+        "AnnReturn": [0.05],
+        "AnnVol": [0.02],
+        "TrackingErr": [0.01],
+        "Agent": ["Base"],
+        "ShortfallProb": [0.02],
+    })
+    fig = risk_return.make(df)
+    assert isinstance(fig, go.Figure)
+    fig.to_json()
+
+
+def test_fan_and_dist():
+    arr = np.random.normal(size=(10, 5))
+    fig1 = fan.make(arr)
+    fig2 = path_dist.make(arr)
+    assert isinstance(fig1, go.Figure)
+    assert isinstance(fig2, go.Figure)
+    fig1.to_json()
+    fig2.to_json()
+
+
+def test_sharpe_ladder():
+    df = pd.DataFrame({
+        "AnnReturn": [0.05, 0.03],
+        "AnnVol": [0.02, 0.04],
+        "Agent": ["A", "B"],
+    })
+    fig = sharpe_ladder.make(df)
+    assert isinstance(fig, go.Figure)
+    fig.to_json()


### PR DESCRIPTION
## Summary
- add visualisation and dashboard modules
- provide CLI helper for exporting figures
- expose viz package in the public API
- create thresholds config for charts
- tests for the new plotting utilities

## Testing
- `ruff check pa_core scripts dashboard tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864df7ec8348331b155f95e171a8a78