### PR TITLE
Expand visualization docs and helpers

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -276,9 +276,9 @@ class MyNewAgent(BaseAgent):
 
 | Function            | Input (pandas)                                | Output | Notes |
 |---------------------|-----------------------------------------------|--------|-------|
-| `risk_return.make`  | `df_summary` columns = AnnReturn, AnnVol, TrackingErr, Agent, CVaR, MaxDD, ShortfallProb | `go.Figure` | Adds grey “sweet‑spot” rectangle & traffic‑light colours |
-| `fan.make`          | `df_paths` shape = (n_sim, n_months)          | `go.Figure` | Plots median + 95 % ribbon vs. liability glide‑path |
-| `path_dist.make`    | same `df_paths`                               | `go.Figure` | Histogram and CDF slider |
+| `risk_return.make`  | `df_summary` columns = AnnReturn, AnnVol, TrackingErr, Agent, CVaR, MaxDD, ShortfallProb | `go.Figure` | Adds grey “sweet‑spot”, TE/ER lines & traffic‑light colours |
+| `fan.make`          | `df_paths` shape = (n_sim, n_months)          | `go.Figure` | Median + confidence ribbon, optional liability overlay |
+| `path_dist.make`    | same `df_paths`                               | `go.Figure` | Histogram with toggleable CDF view |
 | `corr_heatmap.make` | dict of agent → df_paths                      | `go.Figure` | Monthly return ρ |
 | `sharpe_ladder.make`| `df_summary`                                  | `go.Figure` | Sorted bar; hover shows ExcessReturn |
 
@@ -486,6 +486,31 @@ hassle.
 ```python
 figs = [risk_return.make(df_summary), fan.make(df_paths)]
 pptx_export.save(figs, "board_pack.pptx")
+```
+
+### 12.22  Category-based colouring
+`viz.theme.CATEGORY_BY_AGENT` maps each agent class to a descriptive
+category.  The chart helpers use this mapping so that colours remain
+consistent across plots.  Update the dictionary before plotting to apply a
+bespoke palette or to register new agents.
+
+```python
+from pa_core.viz import theme, risk_return
+
+theme.CATEGORY_BY_AGENT["OverlayOptionsAgent"] = "External Portable Alpha"
+fig = risk_return.make(df_summary)
+fig.show()
+```
+
+### 12.23  Archiving figures
+Every visualisation returns a `go.Figure`.  Use Plotly's built‑in serializers
+to save static SVG or the full JSON specification alongside model outputs.
+
+```python
+fig = sharpe_ladder.make(df_summary)
+fig.write_image("ladder.svg")
+with open("ladder.json", "w") as fh:
+    fh.write(fig.to_json())
 ```
 
 

--- a/pa_core/viz/fan.py
+++ b/pa_core/viz/fan.py
@@ -7,8 +7,8 @@ import plotly.graph_objects as go
 from . import theme
 
 
-def make(df_paths: pd.DataFrame | np.ndarray) -> go.Figure:
-    """Return funding fan chart with median and confidence ribbon."""
+def make(df_paths: pd.DataFrame | np.ndarray, liability: pd.Series | np.ndarray | None = None) -> go.Figure:
+    """Return funding fan chart with median, confidence ribbon and optional liability path."""
     arr = np.asarray(df_paths)
     median = np.median(arr, axis=0)
     conf = theme.THRESHOLDS.get("confidence", 0.95)
@@ -20,5 +20,16 @@ def make(df_paths: pd.DataFrame | np.ndarray) -> go.Figure:
     fig.add_trace(go.Scatter(x=months, y=upper, mode="lines", line=dict(width=0), showlegend=False))
     fig.add_trace(go.Scatter(x=months, y=lower, mode="lines", fill="tonexty", line=dict(width=0), name=f"{int(conf*100)}% CI"))
     fig.add_trace(go.Scatter(x=months, y=median, mode="lines", name="Median"))
+    if liability is not None:
+        liab = np.asarray(liability).ravel()
+        fig.add_trace(
+            go.Scatter(
+                x=months[: len(liab)],
+                y=liab,
+                mode="lines",
+                line=dict(dash="dot"),
+                name="Liability",
+            )
+        )
     fig.update_layout(xaxis_title="Month", yaxis_title="Return")
     return fig

--- a/pa_core/viz/path_dist.py
+++ b/pa_core/viz/path_dist.py
@@ -8,10 +8,44 @@ from . import theme
 
 
 def make(df_paths: pd.DataFrame | np.ndarray) -> go.Figure:
-    """Return histogram of end-point returns."""
+    """Return histogram of end-point returns with optional CDF view."""
     arr = np.asarray(df_paths)
     final = arr[:, -1].ravel()
-    fig = go.Figure(layout_template=theme.TEMPLATE)
-    fig.add_trace(go.Histogram(x=final, nbinsx=40, name="Distribution"))
-    fig.update_layout(xaxis_title="Final Return", yaxis_title="Frequency")
+
+    hist = go.Histogram(x=final, nbinsx=40, name="Histogram")
+    cdf = go.Scatter(
+        x=np.sort(final),
+        y=np.linspace(0, 1, final.size),
+        mode="lines",
+        name="CDF",
+    )
+
+    fig = go.Figure(data=[hist, cdf], layout_template=theme.TEMPLATE)
+    fig.data[1].visible = False
+    fig.update_layout(
+        xaxis_title="Final Return",
+        yaxis_title="Frequency",
+        updatemenus=[
+            dict(
+                buttons=[
+                    dict(
+                        label="Histogram",
+                        method="update",
+                        args=[{"visible": [True, False]}, {"yaxis": {"title": "Frequency"}}],
+                    ),
+                    dict(
+                        label="CDF",
+                        method="update",
+                        args=[{"visible": [False, True]}, {"yaxis": {"title": "Cumulative Probability"}}],
+                    ),
+                ],
+                direction="left",
+                showactive=True,
+                x=0.5,
+                y=1.1,
+                xanchor="center",
+                yanchor="top",
+            )
+        ],
+    )
     return fig

--- a/pa_core/viz/risk_return.py
+++ b/pa_core/viz/risk_return.py
@@ -50,6 +50,8 @@ def make(df_summary: pd.DataFrame) -> go.Figure:
         opacity=0.3,
         line_width=0,
     )
+    fig.add_vline(x=thr.get("te_cap", 0.03), line_dash="dash")
+    fig.add_hline(y=thr.get("excess_return_target", 0.05), line_dash="dash")
     fig.update_layout(
         shapes=[rect],
         xaxis_title="Tracking Error",


### PR DESCRIPTION
## Summary
- expand the visualization section of `Agents.md`
- add CDF toggle to `path_dist.make`
- support liability overlay in `fan.make`
- add TE/ER threshold lines in `risk_return.make`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686620fdb5908331ab8cc5c318bc5894