### PR TITLE
Add category pie chart visualization

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -513,6 +513,23 @@ with open("ladder.json", "w") as fh:
     fh.write(fig.to_json())
 ```
 
+### 12.24  Capital-allocation donut
+`viz.category_pie.make` summarises the capital invested in each agent
+category as a donut chart. Pass a mapping of agent name to capital and the
+function groups by `viz.theme.CATEGORY_BY_AGENT` to keep colours consistent.
+
+```python
+from pa_core.viz import category_pie
+
+cap = {
+    "BaseAgent": 500,
+    "ExternalPAAgent": 300,
+    "InternalPAAgent": 200,
+}
+fig = category_pie.make(cap)
+fig.show()
+```
+
 
 ### **13  CLI Additions** &nbsp;*(new subsection in cli.py docstring)*
 

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -9,6 +9,7 @@ from . import sharpe_ladder
 from . import rolling_panel
 from . import surface
 from . import pptx_export
+from . import category_pie
 
 __all__ = [
     "theme",
@@ -20,4 +21,5 @@ __all__ = [
     "rolling_panel",
     "surface",
     "pptx_export",
+    "category_pie",
 ]

--- a/pa_core/viz/category_pie.py
+++ b/pa_core/viz/category_pie.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(capital_map: Mapping[str, float]) -> go.Figure:
+    """Return donut chart of capital by agent category."""
+    grouped: dict[str, float] = {}
+    for agent, capital in capital_map.items():
+        cat = theme.CATEGORY_BY_AGENT.get(agent, agent)
+        grouped[cat] = grouped.get(cat, 0.0) + float(capital)
+
+    labels = list(grouped.keys())
+    values = [grouped[c] for c in labels]
+
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_pie(labels=labels, values=values, hole=0.4)
+    fig.update_layout(title="Capital Allocation by Category")
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -10,6 +10,7 @@ from pa_core.viz import (
     rolling_panel,
     surface,
     pptx_export,
+    category_pie,
 )
 
 
@@ -65,3 +66,13 @@ def test_rolling_panel_and_surface_and_pptx(tmp_path):
     out = tmp_path / "out.pptx"
     pptx_export.save([panel_fig, surf_fig], out)
     assert out.exists()
+
+
+def test_category_pie():
+    fig = category_pie.make({
+        "BaseAgent": 500,
+        "ExternalPAAgent": 300,
+        "InternalPAAgent": 200,
+    })
+    assert isinstance(fig, go.Figure)
+    fig.to_json()


### PR DESCRIPTION
## Summary
- extend visualization docs with capital-allocation donut example
- implement `category_pie.make` helper
- expose new helper from `pa_core.viz`
- test the new plot function

## Testing
- `pip install -e .`
- `pip install python-pptx`
- `pip install hypothesis`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686624faca088331a154f49ff3612d81