### PR TITLE
Add animated viz helper and enhance docs

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,18 +1,16 @@
-from __future__ import annotations
-
 import pandas as pd
 import streamlit as st
 from pathlib import Path
 
 from pa_core.viz import risk_return, fan, path_dist
 
-
 _DEF_XLSX = "Outputs.xlsx"
 
 
-def load_data(xlsx: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+def load_data(xlsx: str) -> tuple[pd.DataFrame, pd.DataFrame | None]:
     summary = pd.read_excel(xlsx, sheet_name="Summary")
-    paths = pd.read_parquet(Path(xlsx).with_suffix(".parquet"))
+    p = Path(xlsx).with_suffix(".parquet")
+    paths = pd.read_parquet(p) if p.exists() else None
     return summary, paths
 
 
@@ -24,28 +22,30 @@ def main() -> None:
         st.stop()
     summary, paths = load_data(xlsx)
 
-    tab1, tab2, tab3, tab4 = st.tabs([
-        "Headline",
-        "Funding fan",
-        "Path dist",
-        "Diagnostics",
-    ])
+    months = st.sidebar.slider("Months", 1, summary.shape[0], summary.shape[0])
+    agents = st.sidebar.multiselect(
+        "Agents", summary["Config"].unique().tolist(), summary["Config"].unique().tolist()
+    )
+    st.sidebar.number_input("Risk-free rate", value=0.0)
+
+    tab1, tab2, tab3, tab4 = st.tabs(
+        ["Headline", "Funding fan", "Path dist", "Diagnostics"]
+    )
     with tab1:
         st.plotly_chart(risk_return.make(summary), use_container_width=True)
-    with tab2:
-        st.plotly_chart(fan.make(paths), use_container_width=True)
-    with tab3:
-        st.plotly_chart(path_dist.make(paths), use_container_width=True)
+    if paths is not None:
+        paths = paths[agents].iloc[:, :months]
+        with tab2:
+            st.plotly_chart(fan.make(paths), use_container_width=True)
+        with tab3:
+            st.plotly_chart(path_dist.make(paths), use_container_width=True)
     with tab4:
         st.dataframe(summary)
 
     png = risk_return.make(summary).to_image(format="png")
-    st.download_button(
-        label="Download PNG",
-        data=png,
-        file_name="risk_return.png",
-        mime="image/png",
-    )
+    st.download_button("Download PNG", png, file_name="risk_return.png", mime="image/png")
+    with open(xlsx, "rb") as fh:
+        st.download_button("Download XLSX", fh, file_name=Path(xlsx).name)
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -281,6 +281,10 @@ class MyNewAgent(BaseAgent):
 | `path_dist.make`    | same `df_paths`                               | `go.Figure` | Histogram with toggleable CDF view |
 | `corr_heatmap.make` | dict of agent → df_paths                      | `go.Figure` | Monthly return ρ |
 | `sharpe_ladder.make`| `df_summary`                                  | `go.Figure` | Sorted bar; hover shows ExcessReturn |
+| `rolling_panel.make`| `df_paths`                                    | `go.Figure` | 3× rolling drawdown, TE and Sharpe |
+| `surface.make`      | parameter grid                                | `go.Figure` | 3‑D risk/return surface |
+| `category_pie.make` | agent → capital mapping                       | `go.Figure` | Donut by category |
+| `animation.make`    | `df_paths`                                    | `go.Figure` | Animated cumulative return |
 
 *All functions must be **pure** (no I/O) and honour the colour‑blind‑safe palette defined in `viz.theme.TEMPLATE`.*
 
@@ -449,9 +453,10 @@ keeping memory use in check.
 ### 12.16  Animation & video export
 For marketing or board presentations, animated graphics can illustrate how risk
 metrics evolve over time. Plotly supports `plotly.io.write_image` with a GIF or
-MP4 writer installed (e.g. `kaleido`).  The CLI wrapper exposes an `--gif`
-flag that iterates over months and saves the resulting animation under
-`plots/`.
+MP4 writer installed (e.g. `kaleido`).  Call `viz.animation.make(df_paths)` to
+build an animated figure of the median cumulative return. The CLI wrapper
+exposes an `--gif` flag that uses this helper and saves the resulting file
+under `plots/`.
 
 ### 12.17  Real-time dashboard refresh
 When simulations run continuously, Streamlit widgets can poll for new output
@@ -532,6 +537,16 @@ cap = {
 fig = category_pie.make(cap)
 fig.show()
 ```
+
+### 12.25  Animated funding path
+`viz.animation.make` builds a Plotly figure with frames showing how the median
+cumulative return evolves month by month. Use the CLI flag `--gif` to export the
+animation:
+
+```bash
+python scripts/visualise.py --plot fan --xlsx Outputs.xlsx --gif
+```
+The resulting GIF in `plots/` can be embedded in presentations or emails.
 
 
 ### **13  CLI Additions** &nbsp;*(new subsection in cli.py docstring)*

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -11,6 +11,7 @@ from . import surface
 from . import pptx_export
 from . import html_export
 from . import category_pie
+from . import animation
 
 __all__ = [
     "theme",
@@ -24,4 +25,5 @@ __all__ = [
     "pptx_export",
     "html_export",
     "category_pie",
+    "animation",
 ]

--- a/pa_core/viz/animation.py
+++ b/pa_core/viz/animation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_paths: pd.DataFrame | np.ndarray, *, interval: int = 300) -> go.Figure:
+    """Return animation of the median cumulative return path."""
+    arr = np.asarray(df_paths)
+    cum = np.cumprod(1 + arr, axis=1)
+    median = np.median(cum, axis=0)
+    months = np.arange(cum.shape[1])
+
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(go.Scatter(x=[0], y=[median[0]], mode="lines"))
+
+    frames = [
+        go.Frame(data=[go.Scatter(x=months[: i + 1], y=median[: i + 1])])
+        for i in range(len(months))
+    ]
+    fig.frames = frames
+
+    fig.update_layout(
+        xaxis_title="Month",
+        yaxis_title="Cumulative Return",
+        updatemenus=[
+            dict(
+                type="buttons",
+                showactive=False,
+                buttons=[
+                    dict(
+                        label="Play",
+                        method="animate",
+                        args=[None, {"frame": {"duration": interval, "redraw": False}}],
+                    )
+                ],
+            )
+        ],
+    )
+    return fig

--- a/scripts/visualise.py
+++ b/scripts/visualise.py
@@ -14,6 +14,7 @@ from pa_core.viz import (
     surface,
     pptx_export,
     html_export,
+    animation,
 )
 
 
@@ -67,7 +68,10 @@ def main(argv: list[str] | None = None) -> None:
     if args.pptx:
         pptx_export.save([fig], f"{stem}.pptx")
     if args.gif:
-        fig.write_image(f"{stem}.gif")
+        if df_paths is None:
+            raise FileNotFoundError(parquet_path)
+        anim = animation.make(df_paths)
+        anim.write_image(f"{stem}.gif")
     if args.html:
         html_export.save(fig, f"{stem}.html")
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -13,6 +13,7 @@ from pa_core.viz import (
     html_export,
     corr_heatmap,
     category_pie,
+    animation,
 )
 
 
@@ -98,3 +99,10 @@ def test_html_and_corr(tmp_path):
     fig2 = corr_heatmap.make({"A": arr, "B": arr})
     assert isinstance(fig2, go.Figure)
     fig2.to_json()
+
+
+def test_animation():
+    arr = np.random.normal(size=(10, 6))
+    fig = animation.make(arr)
+    assert isinstance(fig, go.Figure)
+    fig.to_json()


### PR DESCRIPTION
## Summary
- document visualization helpers in Agents guide
- add animation.make helper for GIF exports
- update Streamlit dashboard with sidebar controls
- enable GIF export in CLI using animation helper
- test animated figure generation

## Testing
- `pip install -e .`
- `pip install python-pptx hypothesis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662be7f4c8833190447bdd304e9def