### PR TITLE
Implement remaining viz helpers

### DIFF
--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -16,6 +16,8 @@ from . import overlay
 from . import waterfall
 from . import export_bundle
 from . import scenario_slider
+from . import data_table
+from . import scenario_viewer
 
 __all__ = [
     "theme",
@@ -34,4 +36,6 @@ __all__ = [
     "waterfall",
     "export_bundle",
     "scenario_slider",
+    "data_table",
+    "scenario_viewer",
 ]

--- a/pa_core/viz/data_table.py
+++ b/pa_core/viz/data_table.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df: pd.DataFrame):
+    """Return table visualisation.
+
+    If Dash is available, return a ``dash_table.DataTable`` with CSV export.
+    Otherwise fall back to a ``plotly.graph_objects.Figure`` table.
+    """
+    try:
+        from dash import dash_table  # type: ignore
+    except Exception:
+        fig = go.Figure(
+            data=[
+                go.Table(
+                    header=dict(values=list(df.columns)),
+                    cells=dict(values=[df[c] for c in df.columns]),
+                )
+            ],
+            layout_template=theme.TEMPLATE,
+        )
+        return fig
+
+    return dash_table.DataTable(
+        data=df.to_dict("records"),
+        columns=[{"name": c, "id": c} for c in df.columns],
+        export_format="csv",
+        style_table={"overflowX": "auto"},
+    )

--- a/pa_core/viz/scenario_viewer.py
+++ b/pa_core/viz/scenario_viewer.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from . import theme, overlay, scenario_slider
+
+
+def make(paths_map: Mapping[str, pd.DataFrame | np.ndarray]) -> go.Figure:
+    """Return figure combining overlay and scenario slider."""
+    # Overlay traces
+    over_fig = overlay.make(paths_map)
+
+    # Build frames from first agent's paths
+    first_data = next(iter(paths_map.values()))
+    arr = np.asarray(first_data)
+    months = np.arange(arr.shape[1])
+    frames = [
+        go.Frame(
+            data=[go.Scatter(x=months, y=np.cumprod(1 + arr[i], axis=0))],
+            name=str(i),
+        )
+        for i in range(min(len(arr), 10))
+    ]
+    slider_fig = scenario_slider.make(frames)
+
+    fig = make_subplots(rows=1, cols=2, subplot_titles=("Overlay", "Scenarios"))
+    for tr in over_fig.data:
+        fig.add_trace(tr, row=1, col=1)
+    if slider_fig.data:
+        for tr in slider_fig.data:
+            fig.add_trace(tr, row=1, col=2)
+    fig.frames = slider_fig.frames
+    fig.update_layout(
+        template=theme.TEMPLATE,
+        updatemenus=slider_fig.layout.updatemenus,
+        sliders=slider_fig.layout.sliders,
+        xaxis_title="Month",
+        xaxis2_title="Month",
+    )
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -17,6 +17,8 @@ from pa_core.viz import (
     overlay,
     waterfall,
     export_bundle,
+    data_table,
+    scenario_viewer,
 )
 
 
@@ -123,3 +125,13 @@ def test_overlay_and_waterfall_and_bundle(tmp_path):
 
     export_bundle.save([over_fig, wf_fig], tmp_path / "bundle")
     assert (tmp_path / "bundle_1.html").exists()
+
+
+def test_data_table_and_scenario_viewer():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    table_obj = data_table.make(df)
+    assert table_obj is not None
+    arr = np.random.normal(size=(3, 6))
+    fig = scenario_viewer.make({"A": arr})
+    assert isinstance(fig, go.Figure)
+    fig.to_json()


### PR DESCRIPTION
## Summary
- add `data_table` and `scenario_viewer` helpers to `pa_core.viz`
- expose new helpers via `viz.__init__`
- test new helpers

## Testing
- `ruff check pa_core tests`
- `pyright`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663ddbe510833181fb826752c50518