### PR TITLE
Update visualization docs with heatmap helper

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -283,6 +283,7 @@ class MyNewAgent(BaseAgent):
 | `sharpe_ladder.make`| `df_summary`                                  | `go.Figure` | Sorted bar; hover shows ExcessReturn |
 | `rolling_panel.make`| `df_paths`                                    | `go.Figure` | 3× rolling drawdown, TE and Sharpe |
 | `surface.make`      | parameter grid                                | `go.Figure` | 3‑D risk/return surface |
+| `grid_heatmap.make` | same parameter grid                           | `go.Figure` | 2‑D heatmap of the sweep |
 | `category_pie.make` | agent → capital mapping                       | `go.Figure` | Donut by category |
 | `animation.make`    | `df_paths`                                    | `go.Figure` | Animated cumulative return |
 
@@ -606,6 +607,14 @@ fig.show()
 
 ### 12.32  Scenario slider animation
 `viz.scenario_slider.make` builds a figure with a slider to step through precomputed Plotly frames. Combine with `viz.animation.make` to present stress tests interactively.
+```python
+frames = [
+    go.Frame(data=[go.Scatter(y=arr[i].cumsum())], name=str(i))
+    for i in range(5)
+]
+fig = scenario_slider.make(frames)
+fig.show()
+```
 
 ### 12.33  Export bundle helper
 
@@ -643,6 +652,16 @@ run timestamp to aid traceability.
 Potential extensions include violin plots of monthly returns, live WebSocket
 hooks for streaming results, and integration with Bokeh for alternate themes.
 Feel free to propose additional visualisations as needs evolve.
+
+### 12.40  Parameter-grid heatmap
+`viz.grid_heatmap.make` complements the 3‑D surface with a top-down view of the
+same data. This is useful when the sweep only spans a handful of values.
+
+```python
+grid = pd.read_csv("sweep.csv")
+fig = grid_heatmap.make(grid)
+fig.show()
+```
 
 ### **13  CLI Additions** &nbsp;*(new subsection in cli.py docstring)*
 

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -18,6 +18,7 @@ from . import export_bundle
 from . import scenario_slider
 from . import data_table
 from . import scenario_viewer
+from . import grid_heatmap
 
 __all__ = [
     "theme",
@@ -38,4 +39,5 @@ __all__ = [
     "scenario_slider",
     "data_table",
     "scenario_viewer",
+    "grid_heatmap",
 ]

--- a/pa_core/viz/grid_heatmap.py
+++ b/pa_core/viz/grid_heatmap.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(
+    df_grid: pd.DataFrame,
+    *,
+    x: str = "AE_leverage",
+    y: str = "ExtPA_frac",
+    z: str = "Sharpe",
+) -> go.Figure:
+    """Return 2-D heatmap from a parameter grid."""
+    table = (
+        df_grid.pivot(index=y, columns=x, values=z)
+        .sort_index()
+        .sort_index(axis=1)
+    )
+    fig = go.Figure(
+        data=go.Heatmap(z=table.values, x=table.columns, y=table.index),
+        layout_template=theme.TEMPLATE,
+    )
+    fig.update_layout(xaxis_title=x, yaxis_title=y)
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -19,6 +19,7 @@ from pa_core.viz import (
     export_bundle,
     data_table,
     scenario_viewer,
+    grid_heatmap,
 )
 
 
@@ -127,7 +128,7 @@ def test_overlay_and_waterfall_and_bundle(tmp_path):
     assert (tmp_path / "bundle_1.html").exists()
 
 
-def test_data_table_and_scenario_viewer():
+def test_data_table_and_scenario_viewer_and_heatmap():
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     table_obj = data_table.make(df)
     assert table_obj is not None
@@ -135,3 +136,14 @@ def test_data_table_and_scenario_viewer():
     fig = scenario_viewer.make({"A": arr})
     assert isinstance(fig, go.Figure)
     fig.to_json()
+
+    grid = pd.DataFrame({
+        "AE_leverage": [1, 2],
+        "ExtPA_frac": [0.2, 0.4],
+        "Sharpe": [0.5, 0.6],
+    })
+    heatmap_fig = grid_heatmap.make(grid)
+    assert isinstance(heatmap_fig, go.Figure)
+    heatmap_fig.to_json()
+
+


### PR DESCRIPTION
## Summary
- document scenario slider and new grid heatmap
- add `grid_heatmap.make` implementation and expose in viz package
- extend viz tests

## Testing
- `ruff check pa_core`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68663fe77fa88331addd089565f9475a