### PR TITLE
Add panel visualization helper

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -286,6 +286,7 @@ class MyNewAgent(BaseAgent):
 | `grid_heatmap.make` | same parameter grid                           | `go.Figure` | 2‑D heatmap of the sweep |
 | `category_pie.make` | agent → capital mapping                       | `go.Figure` | Donut by category |
 | `animation.make`    | `df_paths`                                    | `go.Figure` | Animated cumulative return |
+| `panel.make`        | `df_summary`                                  | `go.Figure` | Risk‑return & Sharpe ladder panel |
 
 *All functions must be **pure** (no I/O) and honour the colour‑blind‑safe palette defined in `viz.theme.TEMPLATE`.*
 
@@ -445,6 +446,8 @@ def make_panel(df_summary, df_paths):
     fig.update_layout(template=theme.TEMPLATE)
     return fig
 ```
+The library exposes this helper as `viz.panel.make` for reuse in the CLI and
+dashboard.
 
 ### 12.15  Caching heavy calculations
 The Streamlit app may reuse the same large path matrices across widgets. Use

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -19,6 +19,7 @@ from . import scenario_slider
 from . import data_table
 from . import scenario_viewer
 from . import grid_heatmap
+from . import panel
 
 __all__ = [
     "theme",
@@ -40,4 +41,5 @@ __all__ = [
     "data_table",
     "scenario_viewer",
     "grid_heatmap",
+    "panel",
 ]

--- a/pa_core/viz/panel.py
+++ b/pa_core/viz/panel.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from . import theme, risk_return, sharpe_ladder
+
+
+def make(df_summary: pd.DataFrame, df_paths: pd.DataFrame | None = None) -> go.Figure:
+    """Return composite panel with risk-return and Sharpe ladder charts."""
+    fig = make_subplots(rows=1, cols=2)
+    risk_fig = risk_return.make(df_summary)
+    ladder_fig = sharpe_ladder.make(df_summary)
+    for trace in risk_fig.data:
+        fig.add_trace(trace, row=1, col=1)
+    for trace in ladder_fig.data:
+        fig.add_trace(trace, row=1, col=2)
+    fig.update_layout(template=theme.TEMPLATE)
+    return fig
+

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -20,6 +20,7 @@ from pa_core.viz import (
     data_table,
     scenario_viewer,
     grid_heatmap,
+    panel,
 )
 
 
@@ -145,5 +146,18 @@ def test_data_table_and_scenario_viewer_and_heatmap():
     heatmap_fig = grid_heatmap.make(grid)
     assert isinstance(heatmap_fig, go.Figure)
     heatmap_fig.to_json()
+
+
+def test_panel_make():
+    df = pd.DataFrame({
+        "AnnReturn": [0.05, 0.04],
+        "AnnVol": [0.02, 0.03],
+        "TrackingErr": [0.01, 0.015],
+        "Agent": ["A", "B"],
+        "ShortfallProb": [0.02, 0.03],
+    })
+    fig = panel.make(df)
+    assert isinstance(fig, go.Figure)
+    fig.to_json()
 
 


### PR DESCRIPTION
## Summary
- add new `panel.make` function for composite layouts
- export `panel` in `pa_core.viz`
- document helper in Agents guide
- test new helper

## Testing
- `ruff check pa_core tests scripts dashboard`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866776f26b48331b1c85d15e3f09b89