### PR TITLE
Document and implement overlay colouring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 pa_core/**/__pycache__/
 tests/__pycache__/
 .ipynb_checkpoints/
+
+*.egg-info/

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -592,6 +592,8 @@ fig.show()
 ### 12.30  Multi-agent overlay
 `viz.overlay.make` plots the median cumulative return of several agents on a single chart for quick comparisons.
 Colours follow `viz.theme.CATEGORY_BY_AGENT` so the same agent categories share a consistent hue across all charts.
+The palette is drawn from `viz.theme.TEMPLATE`; if that template lacks a
+`colorway`, Plotly's default colours are used as a fallback.
 
 ```python
 from pa_core.viz import overlay

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -591,6 +591,7 @@ fig.show()
 
 ### 12.30  Multi-agent overlay
 `viz.overlay.make` plots the median cumulative return of several agents on a single chart for quick comparisons.
+Colours follow `viz.theme.CATEGORY_BY_AGENT` so the same agent categories share a consistent hue across all charts.
 
 ```python
 from pa_core.viz import overlay

--- a/pa_core/viz/overlay.py
+++ b/pa_core/viz/overlay.py
@@ -10,13 +10,37 @@ from . import theme
 
 
 def make(paths_map: Mapping[str, pd.DataFrame | np.ndarray]) -> go.Figure:
-    """Return overlay of median cumulative return paths."""
+    """Return overlay of median cumulative return paths.
+
+    Colours are assigned by ``theme.CATEGORY_BY_AGENT`` so that multiple
+    charts share a consistent palette.
+    """
     fig = go.Figure(layout_template=theme.TEMPLATE)
+
+    # Build deterministic colour mapping by category
+    palette = list(theme.TEMPLATE.layout.colorway)
+    cat_to_color: dict[str, str] = {}
+
     for name, data in paths_map.items():
         arr = np.asarray(data)
         cum = np.cumprod(1 + arr, axis=1)
         median = np.median(cum, axis=0)
         months = np.arange(median.size)
-        fig.add_trace(go.Scatter(x=months, y=median, mode="lines", name=name))
+
+        cat = theme.CATEGORY_BY_AGENT.get(name, name)
+        if cat not in cat_to_color:
+            color = palette[len(cat_to_color) % len(palette)]
+            cat_to_color[cat] = color
+
+        fig.add_trace(
+            go.Scatter(
+                x=months,
+                y=median,
+                mode="lines",
+                name=name,
+                line=dict(color=cat_to_color[cat]),
+            )
+        )
+
     fig.update_layout(xaxis_title="Month", yaxis_title="Cumulative Return")
     return fig

--- a/pa_core/viz/overlay.py
+++ b/pa_core/viz/overlay.py
@@ -21,12 +21,11 @@ def make(paths_map: Mapping[str, pd.DataFrame | np.ndarray]) -> go.Figure:
     # Build deterministic colour mapping by category
     tmpl = theme.TEMPLATE
     if isinstance(tmpl, str):
-        tmpl = pio.get_template(tmpl)
-    layout = getattr(tmpl, "layout", {})
-    palette = (
-        list(getattr(layout, "colorway", []) or getattr(layout, "get", lambda _k, _d=None: _d)("colorway", []))
-        or list(pio.templates["plotly"].layout.colorway)
-    )
+        tmpl = pio.templates[tmpl]
+    palette = getattr(tmpl.layout, "colorway", None)
+    if palette is None:
+        palette = pio.templates["plotly"].layout.colorway
+    palette = list(palette)
     cat_to_color: dict[str, str] = {}
 
     for name, data in paths_map.items():

--- a/pa_core/viz/overlay.py
+++ b/pa_core/viz/overlay.py
@@ -22,7 +22,11 @@ def make(paths_map: Mapping[str, pd.DataFrame | np.ndarray]) -> go.Figure:
     tmpl = theme.TEMPLATE
     if isinstance(tmpl, str):
         tmpl = pio.get_template(tmpl)
-    palette = getattr(getattr(tmpl.layout, "colorway", None), "copy", lambda: [])() or pio.templates["plotly"].layout.colorway
+    layout = getattr(tmpl, "layout", {})
+    palette = (
+        list(getattr(layout, "colorway", []) or getattr(layout, "get", lambda _k, _d=None: _d)("colorway", []))
+        or list(pio.templates["plotly"].layout.colorway)
+    )
     cat_to_color: dict[str, str] = {}
 
     for name, data in paths_map.items():

--- a/pa_core/viz/overlay.py
+++ b/pa_core/viz/overlay.py
@@ -5,6 +5,7 @@ from typing import Mapping
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
+import plotly.io as pio
 
 from . import theme
 
@@ -18,7 +19,10 @@ def make(paths_map: Mapping[str, pd.DataFrame | np.ndarray]) -> go.Figure:
     fig = go.Figure(layout_template=theme.TEMPLATE)
 
     # Build deterministic colour mapping by category
-    palette = list(theme.TEMPLATE.layout.colorway)
+    tmpl = theme.TEMPLATE
+    if isinstance(tmpl, str):
+        tmpl = pio.get_template(tmpl)
+    palette = getattr(getattr(tmpl.layout, "colorway", None), "copy", lambda: [])() or pio.templates["plotly"].layout.colorway
     cat_to_color: dict[str, str] = {}
 
     for name, data in paths_map.items():

--- a/pa_core/viz/overlay.py
+++ b/pa_core/viz/overlay.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Any, Mapping, cast
 
 import numpy as np
 import pandas as pd
@@ -22,9 +22,13 @@ def make(paths_map: Mapping[str, pd.DataFrame | np.ndarray]) -> go.Figure:
     tmpl = theme.TEMPLATE
     if isinstance(tmpl, str):
         tmpl = pio.templates[tmpl]
-    palette = getattr(tmpl.layout, "colorway", None)
+
+    palette = None
+    layout = cast(Any, getattr(tmpl, "layout", None))
+    if layout is not None and not isinstance(layout, tuple):
+        palette = getattr(layout, "colorway", None)  # type: ignore[attr-defined]
     if palette is None:
-        palette = pio.templates["plotly"].layout.colorway
+        palette = cast(Any, pio.templates["plotly"].layout).colorway
     palette = list(palette)
     cat_to_color: dict[str, str] = {}
 


### PR DESCRIPTION
## Summary
- explain in docs that overlay chart now uses category colours
- assign colours consistently by category in `viz.overlay.make`

## Testing
- `pytest tests/test_viz.py::test_overlay_and_waterfall_and_bundle -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667e0be7e483319107ec07a9adaa02