### PR TITLE
Expand visualisation utilities

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,12 +1,14 @@
 import pandas as pd
 import streamlit as st
 from pathlib import Path
+import time
 
 from pa_core.viz import risk_return, fan, path_dist
 
 _DEF_XLSX = "Outputs.xlsx"
 
 
+@st.cache_data(ttl=600)
 def load_data(xlsx: str) -> tuple[pd.DataFrame, pd.DataFrame | None]:
     summary = pd.read_excel(xlsx, sheet_name="Summary")
     p = Path(xlsx).with_suffix(".parquet")
@@ -27,6 +29,8 @@ def main() -> None:
         "Agents", summary["Config"].unique().tolist(), summary["Config"].unique().tolist()
     )
     st.sidebar.number_input("Risk-free rate", value=0.0)
+    auto = st.sidebar.checkbox("Auto-refresh")
+    interval = st.sidebar.number_input("Refresh every (s)", 5, 300, 60)
 
     tab1, tab2, tab3, tab4 = st.tabs(
         ["Headline", "Funding fan", "Path dist", "Diagnostics"]
@@ -46,6 +50,10 @@ def main() -> None:
     st.download_button("Download PNG", png, file_name="risk_return.png", mime="image/png")
     with open(xlsx, "rb") as fh:
         st.download_button("Download XLSX", fh, file_name=Path(xlsx).name)
+
+    if auto:
+        time.sleep(interval)
+        st.experimental_rerun()
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -169,11 +169,11 @@ class RunFlags:
 7  Reporting
 // NEW
 
-Excel – reporting/excel.py now calls viz.risk_return.make() etc. and embeds the PNG exports as worksheet objects (use xlsxwriter.Workbook.insert_image).
+Excel – `reporting/excel.py` now calls `viz.risk_return.make()` and embeds the PNG directly in the ``Summary`` sheet using ``openpyxl``.
 
 Static exports – scripts/visualise.py accepts --png --pdf --pptx; each flag triggers fig.write_image() or python‑pptx helper.
 
-Dashboard – dashboard/app.py launches automatically when --launch_dashboard flag is set or via streamlit run dashboard/app.py.
+Dashboard – `dashboard/app.py` caches loaded data with ``@st.cache_data`` and offers an optional auto‑refresh checkbox. Launch with ``--launch_dashboard`` or run ``streamlit run dashboard/app.py``.
 
 
 8  Testing & CI
@@ -451,8 +451,8 @@ dashboard.
 
 ### 12.15  Caching heavy calculations
 The Streamlit app may reuse the same large path matrices across widgets. Use
-`@st.cache_data` with an explicit TTL to prevent repeated computations while
-keeping memory use in check.
+``@st.cache_data(ttl=600)`` so data refreshes every ten minutes without
+recomputing on each interaction.
 
 ### 12.16  Animation & video export
 For marketing or board presentations, animated graphics can illustrate how risk
@@ -464,9 +464,10 @@ under `plots/`.
 
 ### 12.17  Real-time dashboard refresh
 When simulations run continuously, Streamlit widgets can poll for new output
-files on an interval.  Use `st.experimental_rerun()` inside a timer thread to
-reload figures without manual refresh.  Keep the data layer read-only so users
-cannot accidentally rerun heavy calculations.
+files on an interval.  The dashboard includes an **Auto-refresh** checkbox that
+sleep-waits for the chosen interval then calls ``st.experimental_rerun()``.
+Keep the data layer read-only so users cannot accidentally rerun heavy
+calculations.
 
 ### 12.18  Accessibility considerations
 All charts must remain readable for colour-blind users and screen readers.

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 """Command-line interface for running simulations.
 
 Additional options allow exporting visualisations and launching the
@@ -10,6 +9,7 @@ CLI flags:
     --gif                  Animated export of monthly paths
     --dashboard            Launch Streamlit dashboard after run
 """
+from __future__ import annotations
 
 import argparse
 from typing import Sequence, Optional

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1,4 +1,16 @@
 from __future__ import annotations
+"""Command-line interface for running simulations.
+
+Additional options allow exporting visualisations and launching the
+Streamlit dashboard after a run.
+
+CLI flags:
+    --png / --pdf / --pptx  Static exports (can be combined)
+    --html                 Save interactive HTML
+    --gif                  Animated export of monthly paths
+    --dashboard            Launch Streamlit dashboard after run
+"""
+
 import argparse
 from typing import Sequence, Optional
 import pandas as pd

--- a/pa_core/reporting/excel.py
+++ b/pa_core/reporting/excel.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from typing import cast
+import io
 
 import pandas as pd
 import openpyxl
 from openpyxl.utils import get_column_letter
+from openpyxl.drawing.image import Image as XLImage
+
+from ..viz import risk_return
 
 __all__ = ["export_to_excel"]
 
@@ -77,6 +81,13 @@ def export_to_excel(
                 col_letter = get_column_letter(idx)
                 for cell in ws[col_letter][1:]:
                     cell.number_format = "0.00%"
+
+        try:
+            img_bytes = risk_return.make(summary_df).to_image(format="png")
+            img = XLImage(io.BytesIO(img_bytes))
+            ws.add_image(img, "H2")
+        except Exception:
+            pass
 
     wb.save(filename)
     print(f"Exported results to {filename}")


### PR DESCRIPTION
## Summary
- cache dashboard data and add auto-refresh option
- embed risk-return chart in the Excel report
- document CLI image flags
- clarify visualization sections in Agents.md

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a868e138833193645f3b1794b0dd