### PR TITLE
Add violin plot visualisation

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -670,6 +670,16 @@ fig = grid_heatmap.make(grid)
 fig.show()
 ```
 
+### 12.41  Violin distribution of returns
+`viz.violin.make` plots the distribution of monthly returns either aggregated
+across all months or one violin per month when `by_month=True`.
+
+```python
+from pa_core.viz import violin
+fig = violin.make(df_paths, by_month=True)
+fig.show()
+```
+
 ### **13  CLI Additions** &nbsp;*(new subsection in cli.py docstring)*
 
 // NEW  

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -20,6 +20,7 @@ from . import data_table
 from . import scenario_viewer
 from . import grid_heatmap
 from . import panel
+from . import violin
 
 __all__ = [
     "theme",
@@ -42,4 +43,5 @@ __all__ = [
     "scenario_viewer",
     "grid_heatmap",
     "panel",
+    "violin",
 ]

--- a/pa_core/viz/violin.py
+++ b/pa_core/viz/violin.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_paths: pd.DataFrame | np.ndarray, *, by_month: bool = False) -> go.Figure:
+    """Return violin plot of monthly returns.
+
+    Parameters
+    ----------
+    df_paths : pandas.DataFrame or numpy.ndarray
+        Simulation paths with shape (n_sim, n_months).
+    by_month : bool, optional
+        If True, draw a violin per month; otherwise aggregate all months.
+    """
+    arr = np.asarray(df_paths)
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+
+    if by_month:
+        for i in range(arr.shape[1]):
+            fig.add_trace(
+                go.Violin(
+                    y=arr[:, i],
+                    name=f"Month {i + 1}",
+                    box_visible=True,
+                    meanline_visible=True,
+                )
+            )
+    else:
+        fig.add_trace(
+            go.Violin(
+                y=arr.ravel(),
+                box_visible=True,
+                meanline_visible=True,
+                name="Returns",
+            )
+        )
+
+    fig.update_layout(yaxis_title="Monthly Return")
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -21,6 +21,7 @@ from pa_core.viz import (
     scenario_viewer,
     grid_heatmap,
     panel,
+    violin,
 )
 
 
@@ -157,6 +158,13 @@ def test_panel_make():
         "ShortfallProb": [0.02, 0.03],
     })
     fig = panel.make(df)
+    assert isinstance(fig, go.Figure)
+    fig.to_json()
+
+
+def test_violin_make():
+    arr = np.random.normal(size=(10, 5))
+    fig = violin.make(arr, by_month=True)
     assert isinstance(fig, go.Figure)
     fig.to_json()
 


### PR DESCRIPTION
## Summary
- implement `viz.violin.make` for violin plots
- expose new helper in viz package
- document violin chart in Agents.md
- test violin plot

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b2f2ba348331b2fcc4db7619c2b0