### PR TITLE
Add new viz helpers and doc updates

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -682,8 +682,10 @@ fig.show()
 
 ### 12.42  Rolling correlation heatmap
 `viz.rolling_corr_heatmap.make` visualises how correlations evolve over time
-with a sliding window. Pass a `(n_sim, n_months)` DataFrame and set the window
-size in months.
+with a sliding window.  Provide a `(n_sim, n_months)` array of monthly returns
+and choose the window length in months.  The helper computes the correlation
+between each month and its predecessors up to the chosen lag so users can spot
+periods of heightened autocorrelation.
 
 ```python
 from pa_core.viz import rolling_corr_heatmap
@@ -693,7 +695,9 @@ fig.show()
 
 ### 12.43  Exposure timeline
 `viz.exposure_timeline.make` plots each agent's capital allocation as a stacked
-area chart so PMs can verify exposure drift across the horizon.
+area chart so PMs can verify exposure drift across the horizon.  The input is a
+DataFrame indexed by month with one column per agent.  Values should represent
+capital in the sleeve's base currency.
 
 ```python
 from pa_core.viz import exposure_timeline
@@ -703,8 +707,9 @@ fig.show()
 
 ### 12.44  Risk-target gauge
 Display tracking error or CVaR relative to thresholds using
-`viz.gauge.make(df_summary)`. The dial turns amber or red when metrics breach
-limits defined in `config_thresholds.yaml`.
+`viz.gauge.make(df_summary)`.  Pass a summary table with the metric of interest
+(``TrackingErr`` or ``CVaR``).  The dial turns amber or red when the value
+breaches the levels in ``config_thresholds.yaml``.
 
 ```python
 from pa_core.viz import gauge
@@ -714,8 +719,9 @@ fig.show()
 
 ### 12.45  Parameter-sensitivity radar
 Compare multiple scenarios on a single radar chart with
-`viz.radar.make(df_metrics)`. Each axis represents a risk metric and each trace
-is one scenario.
+`viz.radar.make(df_metrics)`.  Provide a DataFrame whose rows are scenarios and
+whose columns are metrics such as TE and ER.  Each trace plots the metrics in a
+closed loop so sensitivities leap out visually.
 
 ```python
 from pa_core.viz import radar

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -21,6 +21,10 @@ from . import scenario_viewer
 from . import grid_heatmap
 from . import panel
 from . import violin
+from . import rolling_corr_heatmap
+from . import exposure_timeline
+from . import gauge
+from . import radar
 
 __all__ = [
     "theme",
@@ -44,4 +48,8 @@ __all__ = [
     "grid_heatmap",
     "panel",
     "violin",
+    "rolling_corr_heatmap",
+    "exposure_timeline",
+    "gauge",
+    "radar",
 ]

--- a/pa_core/viz/exposure_timeline.py
+++ b/pa_core/viz/exposure_timeline.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(capital_by_month: pd.DataFrame) -> go.Figure:
+    """Return stacked area chart of capital allocation over time."""
+    df = capital_by_month.copy()
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    for i, col in enumerate(df.columns):
+        fig.add_trace(
+            go.Scatter(
+                x=df.index,
+                y=df[col],
+                mode="lines",
+                stackgroup="one",
+                name=col,
+            )
+        )
+    fig.update_layout(xaxis_title="Month", yaxis_title="Capital")
+    return fig

--- a/pa_core/viz/gauge.py
+++ b/pa_core/viz/gauge.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_summary: pd.DataFrame, metric: str = "TrackingErr") -> go.Figure:
+    """Return gauge of a risk metric against thresholds."""
+    value = float(df_summary[metric].iloc[0])
+    thr = theme.THRESHOLDS
+    amber = thr.get("sharpe_amber", 0.4)
+    green = thr.get("sharpe_green", 0.5)
+    fig = go.Figure(
+        go.Indicator(
+            mode="gauge+number",
+            value=value,
+            gauge={
+                "axis": {"range": [None, green]},
+                "bar": {"color": "darkblue"},
+                "steps": [
+                    {"range": [0, amber], "color": "red"},
+                    {"range": [amber, green], "color": "orange"},
+                    {"range": [green, green * 1.2], "color": "green"},
+                ],
+            },
+        )
+    )
+    fig.update_layout(template=theme.TEMPLATE)
+    return fig

--- a/pa_core/viz/radar.py
+++ b/pa_core/viz/radar.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_metrics: pd.DataFrame) -> go.Figure:
+    """Return radar chart comparing scenarios across metrics."""
+    categories = list(df_metrics.columns)
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    for idx, row in df_metrics.iterrows():
+        values = row.tolist()
+        values += values[:1]
+        fig.add_trace(
+            go.Scatterpolar(r=values, theta=categories + [categories[0]], fill="toself", name=str(idx))
+        )
+    fig.update_layout(polar=dict(radialaxis=dict(visible=True)))
+    return fig

--- a/pa_core/viz/rolling_corr_heatmap.py
+++ b/pa_core/viz/rolling_corr_heatmap.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_paths: pd.DataFrame | np.ndarray, window: int = 12) -> go.Figure:
+    """Return heatmap of month-on-month correlations with a rolling window.
+
+    Parameters
+    ----------
+    df_paths:
+        Array-like of shape ``(n_sim, n_months)``.
+    window:
+        Number of months over which to compute correlations.
+    """
+    arr = np.asarray(df_paths)
+    n_months = arr.shape[1]
+    max_lag = min(window, n_months - 1)
+    z = np.full((max_lag, n_months), np.nan)
+
+    for lag in range(1, max_lag + 1):
+        for t in range(lag, n_months):
+            x = arr[:, t]
+            y = arr[:, t - lag]
+            if x.size and y.size:
+                corr = np.corrcoef(x, y)[0, 1]
+            else:
+                corr = np.nan
+            z[lag - 1, t] = corr
+
+    y_labels: Sequence[str] = [f"lag {lag}" for lag in range(1, max_lag + 1)]
+    fig = go.Figure(
+        data=go.Heatmap(z=z, x=list(range(n_months)), y=y_labels),
+        layout_template=theme.TEMPLATE,
+    )
+    fig.update_layout(xaxis_title="Month", yaxis_title="Lag")
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -22,6 +22,10 @@ from pa_core.viz import (
     grid_heatmap,
     panel,
     violin,
+    rolling_corr_heatmap,
+    exposure_timeline,
+    gauge,
+    radar,
 )
 
 
@@ -167,5 +171,33 @@ def test_violin_make():
     fig = violin.make(arr, by_month=True)
     assert isinstance(fig, go.Figure)
     fig.to_json()
+
+
+def test_new_viz_helpers():
+    arr = np.random.normal(size=(10, 12))
+    heat_fig = rolling_corr_heatmap.make(arr, window=3)
+    assert isinstance(heat_fig, go.Figure)
+    heat_fig.to_json()
+
+    df_cap = pd.DataFrame({
+        "A": [100, 120, 110],
+        "B": [50, 60, 55],
+    }, index=[0, 1, 2])
+    exp_fig = exposure_timeline.make(df_cap)
+    assert isinstance(exp_fig, go.Figure)
+    exp_fig.to_json()
+
+    summary = pd.DataFrame({"TrackingErr": [0.02]})
+    gauge_fig = gauge.make(summary)
+    assert isinstance(gauge_fig, go.Figure)
+    gauge_fig.to_json()
+
+    metrics = pd.DataFrame({
+        "TE": [0.02, 0.03],
+        "ER": [0.05, 0.06],
+    }, index=["Scenario1", "Scenario2"])
+    radar_fig = radar.make(metrics)
+    assert isinstance(radar_fig, go.Figure)
+    radar_fig.to_json()
 
 


### PR DESCRIPTION
## Summary
- flesh out the visual-analytics documentation
- implement new visualization helpers: rolling correlation heatmap, exposure timeline, gauge and radar
- expose new helpers in the package
- extend visualization tests

## Testing
- `ruff check pa_core`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c522a9d083318a07aa1df669ecaf