### PR TITLE
Add advanced visualization functions

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -287,6 +287,10 @@ class MyNewAgent(BaseAgent):
 | `category_pie.make` | agent → capital mapping                       | `go.Figure` | Donut by category |
 | `animation.make`    | `df_paths`                                    | `go.Figure` | Animated cumulative return |
 | `panel.make`        | `df_summary`                                  | `go.Figure` | Risk‑return & Sharpe ladder panel |
+| `scatter_matrix.make` | any DataFrame                                | `go.Figure` | Pairwise scatter plot matrix |
+| `risk_return_bubble.make` | `df_summary` with `Capital`               | `go.Figure` | Bubble-scaled risk‑return |
+| `rolling_var.make`  | `df_paths`                                    | `go.Figure` | Rolling VaR line |
+| `breach_calendar.make` | summary by month                           | `go.Figure` | Heatmap of TE & shortfall breaches |
 
 *All functions must be **pure** (no I/O) and honour the colour‑blind‑safe palette defined in `viz.theme.TEMPLATE`.*
 

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -25,6 +25,10 @@ from . import rolling_corr_heatmap
 from . import exposure_timeline
 from . import gauge
 from . import radar
+from . import scatter_matrix
+from . import risk_return_bubble
+from . import rolling_var
+from . import breach_calendar
 
 __all__ = [
     "theme",
@@ -52,4 +56,8 @@ __all__ = [
     "exposure_timeline",
     "gauge",
     "radar",
+    "scatter_matrix",
+    "risk_return_bubble",
+    "rolling_var",
+    "breach_calendar",
 ]

--- a/pa_core/viz/breach_calendar.py
+++ b/pa_core/viz/breach_calendar.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_summary: pd.DataFrame) -> go.Figure:
+    """Return heatmap of threshold breaches by month."""
+    df = df_summary.copy()
+    month_series = df.get("Month")
+    months = month_series if month_series is not None else df.index
+    te_cap = theme.THRESHOLDS.get("te_cap", 0.03)
+    short_cap = theme.THRESHOLDS.get("shortfall_amber", 0.1)
+    te_vals = df["TrackingErr"] if "TrackingErr" in df else pd.Series(0.0, index=df.index)
+    short_vals = df["ShortfallProb"] if "ShortfallProb" in df else pd.Series(0.0, index=df.index)
+    te_breach = (te_vals > te_cap).astype(float)
+    short_breach = (short_vals > short_cap).astype(float)
+    z = np.vstack([te_breach.to_numpy(), short_breach.to_numpy()])
+    fig = go.Figure(
+        data=go.Heatmap(z=z, x=list(months), y=["TE", "Shortfall"]),
+        layout_template=theme.TEMPLATE,
+    )
+    fig.update_layout(xaxis_title="Month", yaxis_title="Metric")
+    return fig

--- a/pa_core/viz/risk_return_bubble.py
+++ b/pa_core/viz/risk_return_bubble.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_summary: pd.DataFrame, *, size_col: str = "Capital") -> go.Figure:
+    """Return risk-return scatter with bubble sizing."""
+    df = df_summary.copy()
+    color = []
+    thr = theme.THRESHOLDS
+    probs = df["ShortfallProb"] if "ShortfallProb" in df else pd.Series(0.0, index=df.index)
+    for prob in probs.fillna(0.0):
+        if prob <= thr.get("shortfall_green", 0.05):
+            color.append("green")
+        elif prob <= thr.get("shortfall_amber", 0.1):
+            color.append("orange")
+        else:
+            color.append("red")
+    size = df[size_col] if size_col in df else pd.Series(1.0, index=df.index)
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(
+        go.Scatter(
+            x=df["AnnVol"],
+            y=df["AnnReturn"],
+            mode="markers",
+            marker=dict(size=20 * size / float(size.max()), color=color, sizemode="diameter"),
+            text=df.get("Agent", ""),
+            hovertemplate="%{text}<br>Vol=%{x:.2%}<br>Return=%{y:.2%}<extra></extra>",
+        )
+    )
+    fig.update_layout(xaxis_title="Tracking Error", yaxis_title="Excess Return")
+    return fig

--- a/pa_core/viz/rolling_var.py
+++ b/pa_core/viz/rolling_var.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_paths: pd.DataFrame | np.ndarray, *, window: int = 12, alpha: float = 0.95) -> go.Figure:
+    """Return rolling VaR line chart over the horizon."""
+    arr = np.asarray(df_paths)
+    n_months = arr.shape[1]
+    var = np.full(n_months, np.nan)
+    for t in range(window - 1, n_months):
+        sub = arr[:, t - window + 1 : t + 1]
+        cum = np.cumprod(1 + sub, axis=1)[:, -1] - 1
+        var[t] = np.quantile(cum, 1 - alpha)
+    months = np.arange(n_months)
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(go.Scatter(x=months, y=var, mode="lines", name="VaR"))
+    fig.update_layout(xaxis_title="Month", yaxis_title="VaR")
+    return fig

--- a/pa_core/viz/scatter_matrix.py
+++ b/pa_core/viz/scatter_matrix.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df: pd.DataFrame) -> go.Figure:
+    """Return scatter-matrix plot coloured by agent category."""
+    fig = px.scatter_matrix(df, color_discrete_sequence=theme.TEMPLATE.layout.colorway)  # type: ignore[attr-defined]
+    fig.update_layout(template=theme.TEMPLATE)
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -26,6 +26,10 @@ from pa_core.viz import (
     exposure_timeline,
     gauge,
     radar,
+    scatter_matrix,
+    risk_return_bubble,
+    rolling_var,
+    breach_calendar,
 )
 
 
@@ -199,5 +203,36 @@ def test_new_viz_helpers():
     radar_fig = radar.make(metrics)
     assert isinstance(radar_fig, go.Figure)
     radar_fig.to_json()
+
+
+def test_extra_viz_helpers():
+    df = pd.DataFrame({
+        "AnnReturn": [0.05, 0.04],
+        "AnnVol": [0.02, 0.03],
+        "TrackingErr": [0.01, 0.015],
+        "Capital": [100, 200],
+        "ShortfallProb": [0.02, 0.03],
+    })
+    bubble_fig = risk_return_bubble.make(df)
+    assert isinstance(bubble_fig, go.Figure)
+    bubble_fig.to_json()
+
+    arr = np.random.normal(size=(10, 12))
+    var_fig = rolling_var.make(arr, window=3)
+    assert isinstance(var_fig, go.Figure)
+    var_fig.to_json()
+
+    summary = pd.DataFrame({
+        "Month": [0, 1, 2],
+        "TrackingErr": [0.02, 0.04, 0.01],
+        "ShortfallProb": [0.01, 0.15, 0.02],
+    })
+    breach_fig = breach_calendar.make(summary)
+    assert isinstance(breach_fig, go.Figure)
+    breach_fig.to_json()
+
+    sm_fig = scatter_matrix.make(df[["AnnReturn", "AnnVol", "TrackingErr"]])
+    assert isinstance(sm_fig, go.Figure)
+    sm_fig.to_json()
 
 


### PR DESCRIPTION
## Summary
- expand visualisation table in Agents.md
- implement `scatter_matrix`, `risk_return_bubble`, `rolling_var`, and `breach_calendar`
- export new modules via `viz.__init__`
- extend test coverage for new visualisations

## Testing
- `ruff check pa_core`
- `pyright`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cc0323348331afc8067fa68e0cd0