### PR TITLE
Extend visualization docs and helpers

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -764,6 +764,28 @@ compatible with the Streamlit dashboard.
 `viz.export_bundle.save` produces an HTML bundle containing the figures and the
 table so PMs can explore results offline.
 
+### 12.51  Rolling-moments panel
+`viz.moments_panel.make` charts rolling skewness and kurtosis so heavy tails are
+easy to spot. Pass the same `df_paths` matrix used by other helpers and adjust
+the `window` argument to change the lookback period.
+
+```python
+from pa_core.viz import moments_panel
+fig = moments_panel.make(df_paths, window=12)
+fig.show()
+```
+
+### 12.52  Parallel-coordinates view
+Compare multiple metrics simultaneously with `viz.parallel_coords.make(df)`. The
+input DataFrame's columns become the parallel axes, allowing quick detection of
+outliers across dimensions.
+
+```python
+from pa_core.viz import parallel_coords
+fig = parallel_coords.make(df_summary[["AnnReturn", "AnnVol", "TrackingErr"]])
+fig.show()
+```
+
 ### **13  CLI Additions** &nbsp;*(new subsection in cli.py docstring)*
 
 // NEW  

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -29,6 +29,8 @@ from . import scatter_matrix
 from . import risk_return_bubble
 from . import rolling_var
 from . import breach_calendar
+from . import moments_panel
+from . import parallel_coords
 
 __all__ = [
     "theme",
@@ -60,4 +62,6 @@ __all__ = [
     "risk_return_bubble",
     "rolling_var",
     "breach_calendar",
+    "moments_panel",
+    "parallel_coords",
 ]

--- a/pa_core/viz/moments_panel.py
+++ b/pa_core/viz/moments_panel.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from . import theme
+
+
+def make(df_paths: pd.DataFrame | np.ndarray, *, window: int = 12) -> go.Figure:
+    """Return rolling skewness and kurtosis panel."""
+    arr = np.asarray(df_paths)
+    df = pd.DataFrame(arr)
+    roll_skew = df.rolling(window, axis=1, min_periods=1).skew().mean(axis=0)
+    roll_kurt = df.rolling(window, axis=1, min_periods=1).kurt().mean(axis=0)
+    months = np.arange(arr.shape[1])
+    fig = make_subplots(rows=2, cols=1, shared_xaxes=True,
+                        subplot_titles=("Skewness", "Kurtosis"))
+    fig.add_trace(go.Scatter(x=months, y=roll_skew, name="Skew"), row=1, col=1)
+    fig.add_trace(go.Scatter(x=months, y=roll_kurt, name="Kurtosis"), row=2, col=1)
+    fig.update_layout(template=theme.TEMPLATE, xaxis_title="Month", height=500)
+    return fig

--- a/pa_core/viz/parallel_coords.py
+++ b/pa_core/viz/parallel_coords.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df: pd.DataFrame) -> go.Figure:
+    """Return parallel coordinates plot for multi-metric comparison."""
+    dimensions = [dict(label=col, values=df[col]) for col in df.columns]
+    fig = go.Figure(data=go.Parcoords(dimensions=dimensions), layout_template=theme.TEMPLATE)
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -30,6 +30,8 @@ from pa_core.viz import (
     risk_return_bubble,
     rolling_var,
     breach_calendar,
+    moments_panel,
+    parallel_coords,
 )
 
 
@@ -234,5 +236,13 @@ def test_extra_viz_helpers():
     sm_fig = scatter_matrix.make(df[["AnnReturn", "AnnVol", "TrackingErr"]])
     assert isinstance(sm_fig, go.Figure)
     sm_fig.to_json()
+
+    moments_fig = moments_panel.make(arr)
+    assert isinstance(moments_fig, go.Figure)
+    moments_fig.to_json()
+
+    pc_fig = parallel_coords.make(df[["AnnReturn", "AnnVol", "TrackingErr"]])
+    assert isinstance(pc_fig, go.Figure)
+    pc_fig.to_json()
 
 


### PR DESCRIPTION
## Summary
- expand Agents.md with rolling-moments and parallel-coordinates docs
- add new viz helpers: `moments_panel` and `parallel_coords`
- expose the helpers via `viz.__init__`
- test the new helpers

## Testing
- `pip install -e .`
- `pip install python-pptx`
- `pip install hypothesis`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d573ba3c8331bd1c40133fc23030