### PR TITLE
Add additional viz helpers and tests

### DIFF
--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -19,6 +19,9 @@ from . import scenario_slider
 from . import data_table
 from . import scenario_viewer
 from . import grid_heatmap
+from . import capital_treemap
+from . import corr_network
+from . import beta_heatmap
 from . import panel
 from . import violin
 from . import rolling_corr_heatmap
@@ -52,6 +55,9 @@ __all__ = [
     "data_table",
     "scenario_viewer",
     "grid_heatmap",
+    "capital_treemap",
+    "corr_network",
+    "beta_heatmap",
     "panel",
     "violin",
     "rolling_corr_heatmap",

--- a/pa_core/viz/beta_heatmap.py
+++ b/pa_core/viz/beta_heatmap.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(beta_by_month: pd.DataFrame) -> go.Figure:
+    """Return heatmap of beta exposure over time."""
+    fig = go.Figure(
+        data=go.Heatmap(z=beta_by_month.values, x=beta_by_month.index, y=beta_by_month.columns),
+        layout_template=theme.TEMPLATE,
+    )
+    fig.update_layout(xaxis_title="Month", yaxis_title="Agent")
+    return fig

--- a/pa_core/viz/capital_treemap.py
+++ b/pa_core/viz/capital_treemap.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(capital: dict[str, float], category_map: dict[str, str] | None = None) -> go.Figure:
+    """Return treemap of capital allocation by agent category."""
+    df = pd.DataFrame({"Agent": list(capital.keys()), "Capital": list(capital.values())})
+    if category_map is None:
+        cat = {a: theme.CATEGORY_BY_AGENT.get(a, a) for a in df["Agent"]}
+    else:
+        cat = {a: category_map.get(a, theme.CATEGORY_BY_AGENT.get(a, a)) for a in df["Agent"]}
+    df["Category"] = df["Agent"].map(lambda x: cat.get(x))
+    fig = go.Figure(
+        go.Treemap(labels=df["Agent"], parents=df["Category"], values=df["Capital"]),
+        layout_template=theme.TEMPLATE,
+    )
+    return fig

--- a/pa_core/viz/corr_network.py
+++ b/pa_core/viz/corr_network.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(paths: dict[str, pd.DataFrame | np.ndarray], *, threshold: float = 0.3) -> go.Figure:
+    """Return correlation network diagram."""
+    names = list(paths.keys())
+    series = [np.asarray(v).mean(axis=0) for v in paths.values()]
+    corr = np.corrcoef(series)
+    n = len(names)
+    angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    xs = np.cos(angles)
+    ys = np.sin(angles)
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(go.Scatter(x=xs, y=ys, mode="markers+text", text=names, textposition="bottom center"))
+    for i in range(n):
+        for j in range(i + 1, n):
+            if corr[i, j] >= threshold:
+                fig.add_trace(go.Scatter(x=[xs[i], xs[j]], y=[ys[i], ys[j]], mode="lines", line=dict(width=1), showlegend=False))
+    fig.update_layout(xaxis_visible=False, yaxis_visible=False)
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -32,6 +32,9 @@ from pa_core.viz import (
     breach_calendar,
     moments_panel,
     parallel_coords,
+    capital_treemap,
+    corr_network,
+    beta_heatmap,
 )
 
 
@@ -244,5 +247,21 @@ def test_extra_viz_helpers():
     pc_fig = parallel_coords.make(df[["AnnReturn", "AnnVol", "TrackingErr"]])
     assert isinstance(pc_fig, go.Figure)
     pc_fig.to_json()
+
+
+def test_newly_added_viz_helpers():
+    cap_fig = capital_treemap.make({"A": 100, "B": 200})
+    assert isinstance(cap_fig, go.Figure)
+    cap_fig.to_json()
+
+    arr = np.random.normal(size=(5, 4))
+    net_fig = corr_network.make({"A": arr, "B": arr}, threshold=0.1)
+    assert isinstance(net_fig, go.Figure)
+    net_fig.to_json()
+
+    beta_df = pd.DataFrame({"A": [1, 2], "B": [0.5, 0.6]}, index=[0, 1])
+    beta_fig = beta_heatmap.make(beta_df)
+    assert isinstance(beta_fig, go.Figure)
+    beta_fig.to_json()
 
 


### PR DESCRIPTION
## Summary
- implement capital_treemap, corr_network and beta_heatmap helpers
- expose new helpers via `pa_core.viz.__init__`
- test new helpers

## Testing
- `ruff check pa_core tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867221b8250833187c26d802a6d10f1