### PR TITLE
Add visualization helpers and expand docs

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -823,9 +823,12 @@ fig.show()
 
 ### 12.56  Factor-exposure bar chart
 Display each sleeve's exposure to common factors (e.g. Value, Momentum) with
-`viz.factor_bar.make`.  Pass a DataFrame whose columns are factor names and
-whose rows are agent labels.  Bars are grouped by
-`viz.theme.CATEGORY_BY_AGENT` so colours stay consistent.
+`viz.factor_bar.make`. Pass a DataFrame whose **rows** are agent names and
+**columns** are factor labels. Colours are assigned via
+`viz.theme.CATEGORY_BY_AGENT` so that exposures line up visually with the other
+charts. Set ``barmode="group"`` by default so each factor is easy to compare
+across agents.  The helper returns a standard ``go.Figure`` which callers can
+further customise (e.g. switch to ``stack`` mode) if required.
 
 ```python
 from pa_core.viz import factor_bar
@@ -835,23 +838,30 @@ fig.show()
 
 ### 12.57  Multi-horizon VaR fan
 `viz.multi_fan.make(df_paths, horizons=[12, 24, 36])` overlays several
-confidence ribbons so PMs can compare 1‑, 2‑ and 3‑year shortfall risks in one
-figure.
+confidence ribbons so PMs can compare 1‑, 2‑ and 3‑year shortfall risks in a
+single plot. Each horizon is drawn in a different colour with the median path on
+top of a shaded region representing the configured confidence level. Pass a
+sequence of month counts to ``horizons`` to change which ribbons are included.
 
 ### 12.58  TE vs. Beta scatter
 Visualise the relationship between tracking error and beta exposure using
-`viz.beta_scatter.make(df_summary)`.  Points are coloured by shortfall
-probability and sized by capital to emphasise material sleeves.
+`viz.beta_scatter.make(df_summary)`. Points are coloured by shortfall
+probability (green/amber/red) and sized by the ``Capital`` column so more
+material sleeves stand out. Hover text shows the agent name and numeric values
+for quick inspection.
 
 ### 12.59  Weighted overlay
 `viz.overlay_weighted.make` extends the basic overlay by weighting each path by
-the invested capital.  This highlights which sleeve dominates the cumulative
-return profile.
+the invested capital. Pass a mapping ``{"Agent": (paths, capital)}``. Line width
+scales with capital and a dashed trace shows the capital-weighted median across
+all agents. This highlights which sleeve dominates the cumulative return
+profile.
 
 ### 12.60  Factor-sensitivity matrix
 `viz.factor_matrix.make(df)` plots a heatmap of factor sensitivities across
-agents. Rows represent factors and columns correspond to agent names.  Colours
-follow the `viz.theme` palette so risk contributions are easy to compare.
+agents. The input DataFrame should have factors as the index and agent names as
+columns. Values are visualised using ``go.Heatmap`` with the theme palette so
+risk contributions are easy to compare and export alongside the numeric table.
 
 ### **13  CLI Additions** &nbsp;*(new subsection in cli.py docstring)*
 

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -30,6 +30,11 @@ from . import gauge
 from . import radar
 from . import scatter_matrix
 from . import risk_return_bubble
+from . import beta_scatter
+from . import overlay_weighted
+from . import factor_bar
+from . import factor_matrix
+from . import multi_fan
 from . import rolling_var
 from . import breach_calendar
 from . import moments_panel
@@ -49,6 +54,7 @@ __all__ = [
     "category_pie",
     "animation",
     "overlay",
+    "overlay_weighted",
     "waterfall",
     "export_bundle",
     "scenario_slider",
@@ -66,6 +72,10 @@ __all__ = [
     "radar",
     "scatter_matrix",
     "risk_return_bubble",
+    "beta_scatter",
+    "factor_bar",
+    "factor_matrix",
+    "multi_fan",
     "rolling_var",
     "breach_calendar",
     "moments_panel",

--- a/pa_core/viz/beta_scatter.py
+++ b/pa_core/viz/beta_scatter.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(
+    df_summary: pd.DataFrame,
+    *,
+    te_col: str = "TrackingErr",
+    beta_col: str = "Beta",
+    size_col: str = "Capital",
+) -> go.Figure:
+    """Return scatter of tracking error vs beta exposure."""
+    df = df_summary.copy()
+    thr = theme.THRESHOLDS
+    probs = df.get("ShortfallProb", pd.Series(0.0, index=df.index)).fillna(0.0)
+    colors = []
+    for p in probs:
+        if p <= thr.get("shortfall_green", 0.05):
+            colors.append("green")
+        elif p <= thr.get("shortfall_amber", 0.1):
+            colors.append("orange")
+        else:
+            colors.append("red")
+    size = df.get(size_col, pd.Series(1.0, index=df.index))
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(
+        go.Scatter(
+            x=df[te_col],
+            y=df[beta_col],
+            mode="markers",
+            marker=dict(size=20 * size / float(size.max()), color=colors, sizemode="diameter"),
+            text=df.get("Agent", ""),
+            hovertemplate="%{text}<br>TE=%{x:.2%}<br>Beta=%{y:.2f}<extra></extra>",
+        )
+    )
+    fig.update_layout(xaxis_title="Tracking Error", yaxis_title="Beta Exposure")
+    return fig

--- a/pa_core/viz/beta_scatter.py
+++ b/pa_core/viz/beta_scatter.py
@@ -16,7 +16,8 @@ def make(
     """Return scatter of tracking error vs beta exposure."""
     df = df_summary.copy()
     thr = theme.THRESHOLDS
-    probs = df.get("ShortfallProb", pd.Series(0.0, index=df.index)).fillna(0.0)
+    probs = df.get("ShortfallProb")
+    probs = probs.fillna(0.0) if probs is not None else pd.Series(0.0, index=df.index)
     colors = []
     for p in probs:
         if p <= thr.get("shortfall_green", 0.05):
@@ -25,7 +26,8 @@ def make(
             colors.append("orange")
         else:
             colors.append("red")
-    size = df.get(size_col, pd.Series(1.0, index=df.index))
+    size = df.get(size_col)
+    size = size if size is not None else pd.Series(1.0, index=df.index)
     fig = go.Figure(layout_template=theme.TEMPLATE)
     fig.add_trace(
         go.Scatter(

--- a/pa_core/viz/factor_bar.py
+++ b/pa_core/viz/factor_bar.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df: pd.DataFrame) -> go.Figure:
+    """Return grouped bar chart of factor exposures."""
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    palette = list(getattr(theme.TEMPLATE.layout, "colorway", []))
+    if not palette:
+        palette = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"]
+    cat_colors: dict[str, str] = {}
+    for idx, (agent, row) in enumerate(df.iterrows()):
+        cat = theme.CATEGORY_BY_AGENT.get(agent, agent)
+        if cat not in cat_colors:
+            cat_colors[cat] = palette[len(cat_colors) % len(palette)]
+        fig.add_trace(
+            go.Bar(
+                name=agent,
+                x=list(df.columns),
+                y=row.values,
+                marker_color=cat_colors[cat],
+            )
+        )
+    fig.update_layout(barmode="group", xaxis_title="Factor", yaxis_title="Exposure")
+    return fig

--- a/pa_core/viz/factor_bar.py
+++ b/pa_core/viz/factor_bar.py
@@ -14,6 +14,7 @@ def make(df: pd.DataFrame) -> go.Figure:
         palette = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"]
     cat_colors: dict[str, str] = {}
     for idx, (agent, row) in enumerate(df.iterrows()):
+        agent = str(agent)
         cat = theme.CATEGORY_BY_AGENT.get(agent, agent)
         if cat not in cat_colors:
             cat_colors[cat] = palette[len(cat_colors) % len(palette)]

--- a/pa_core/viz/factor_matrix.py
+++ b/pa_core/viz/factor_matrix.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df: pd.DataFrame) -> go.Figure:
+    """Return heatmap of factor sensitivities."""
+    fig = go.Figure(
+        data=go.Heatmap(z=df.values, x=list(df.columns), y=list(df.index)),
+        layout_template=theme.TEMPLATE,
+    )
+    fig.update_layout(xaxis_title="Agent", yaxis_title="Factor")
+    return fig

--- a/pa_core/viz/multi_fan.py
+++ b/pa_core/viz/multi_fan.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(
+    df_paths: pd.DataFrame | np.ndarray,
+    horizons: Sequence[int] = (12, 24, 36),
+) -> go.Figure:
+    """Return overlay of fan charts for multiple horizons."""
+    arr = np.asarray(df_paths)
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    conf = theme.THRESHOLDS.get("confidence", 0.95)
+    colors = ["blue", "orange", "green", "purple"]
+    for idx, horizon in enumerate(horizons):
+        h = min(int(horizon), arr.shape[1])
+        sub = arr[:, :h]
+        median = np.median(sub, axis=0)
+        lower = np.percentile(sub, 100 * (1 - conf), axis=0)
+        upper = np.percentile(sub, 100 * conf, axis=0)
+        months = np.arange(h)
+        color = colors[idx % len(colors)]
+        fig.add_trace(go.Scatter(x=months, y=upper, mode="lines", line=dict(width=0), showlegend=False))
+        fig.add_trace(
+            go.Scatter(
+                x=months,
+                y=lower,
+                mode="lines",
+                fill="tonexty",
+                line=dict(width=0),
+                fillcolor=f"rgba(0,0,255,{0.2 + 0.1*idx})",
+                name=f"{h}m CI",
+            )
+        )
+        fig.add_trace(go.Scatter(x=months, y=median, mode="lines", name=f"{h}m Median", line=dict(color=color)))
+    fig.update_layout(xaxis_title="Month", yaxis_title="Return")
+    return fig

--- a/pa_core/viz/overlay_weighted.py
+++ b/pa_core/viz/overlay_weighted.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Mapping, Tuple
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(paths_map: Mapping[str, Tuple[pd.DataFrame | np.ndarray, float]]) -> go.Figure:
+    """Return overlay of median cumulative return paths weighted by capital."""
+    first = next(iter(paths_map.values()))[0]
+    months = np.arange(np.asarray(first).shape[1])
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    weights = {name: weight for name, (_, weight) in paths_map.items()}
+    max_w = max(weights.values()) if weights else 1.0
+    # Individual paths with line width based on weight
+    for name, (data, weight) in paths_map.items():
+        arr = np.asarray(data)
+        cum = np.cumprod(1 + arr, axis=1)
+        median = np.median(cum, axis=0)
+        fig.add_trace(
+            go.Scatter(
+                x=months,
+                y=median,
+                mode="lines",
+                name=name,
+                line=dict(width=2 + 4 * weight / max_w),
+            )
+        )
+    # Combined weighted path
+    tot_w = sum(weights.values())
+    if tot_w > 0:
+        composite = np.zeros_like(months, dtype=float)
+        for name, (data, weight) in paths_map.items():
+            arr = np.asarray(data)
+            cum = np.cumprod(1 + arr, axis=1)
+            median = np.median(cum, axis=0)
+            composite += weight * median
+        fig.add_trace(
+            go.Scatter(
+                x=months,
+                y=composite / tot_w,
+                mode="lines",
+                name="Weighted",
+                line=dict(dash="dash"),
+            )
+        )
+    fig.update_layout(xaxis_title="Month", yaxis_title="Cumulative Return")
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -35,6 +35,11 @@ from pa_core.viz import (
     capital_treemap,
     corr_network,
     beta_heatmap,
+    beta_scatter,
+    overlay_weighted,
+    factor_bar,
+    factor_matrix,
+    multi_fan,
 )
 
 
@@ -263,5 +268,36 @@ def test_newly_added_viz_helpers():
     beta_fig = beta_heatmap.make(beta_df)
     assert isinstance(beta_fig, go.Figure)
     beta_fig.to_json()
+
+
+def test_additional_new_viz_helpers():
+    df = pd.DataFrame({
+        "TrackingErr": [0.02, 0.03],
+        "Beta": [1.1, 0.9],
+        "Capital": [100, 200],
+        "ShortfallProb": [0.01, 0.2],
+        "Agent": ["A", "B"],
+    })
+    bs_fig = beta_scatter.make(df)
+    assert isinstance(bs_fig, go.Figure)
+    bs_fig.to_json()
+
+    arr = np.random.normal(size=(4, 6))
+    ow_fig = overlay_weighted.make({"A": (arr, 1.0)})
+    assert isinstance(ow_fig, go.Figure)
+    ow_fig.to_json()
+
+    exp_df = pd.DataFrame({"Val": [0.1, 0.2], "Mom": [0.3, -0.1]}, index=["A", "B"])
+    fb_fig = factor_bar.make(exp_df)
+    assert isinstance(fb_fig, go.Figure)
+    fb_fig.to_json()
+
+    fm_fig = factor_matrix.make(exp_df.T)
+    assert isinstance(fm_fig, go.Figure)
+    fm_fig.to_json()
+
+    mf_fig = multi_fan.make(arr, horizons=[3, 5])
+    assert isinstance(mf_fig, go.Figure)
+    mf_fig.to_json()
 
 


### PR DESCRIPTION
## Summary
- build new viz modules: beta_scatter, overlay_weighted, multi_fan, factor_bar, factor_matrix
- export new helpers from `pa_core.viz`
- extend unit tests to cover new functions
- document the new visualisations in Agents.md

## Testing
- `ruff check pa_core/viz/overlay_weighted.py pa_core/viz/factor_bar.py pa_core/viz/factor_matrix.py pa_core/viz/multi_fan.py pa_core/viz/beta_scatter.py tests/test_viz.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867339336188331bc9971dc1ebeeedd