### PR TITLE
Add TE vs CVaR scatter and quantile fan

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -863,6 +863,18 @@ agents. The input DataFrame should have factors as the index and agent names as
 columns. Values are visualised using ``go.Heatmap`` with the theme palette so
 risk contributions are easy to compare and export alongside the numeric table.
 
+### 12.61  TE vs. CVaR scatter
+`viz.te_cvar_scatter.make(df_summary)` compares tracking error on the x-axis
+with CVaR on the y-axis. Marker colour follows the shortfall-probability rules
+and size scales with the ``Capital`` column when present. Hover text lists the
+agent name and values so outliers pop out immediately.
+
+### 12.62  Custom quantile fan
+Use `viz.quantile_fan.make(df_paths, quantiles=(0.1, 0.9))` when different
+confidence bounds are required. The helper behaves like `viz.fan.make` but
+lets callers set arbitrary lower and upper quantiles. This is handy for stress
+tests where 80 % or 99 % intervals are desired.
+
 ### **13  CLI Additions** &nbsp;*(new subsection in cli.py docstring)*
 
 // NEW  

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -31,10 +31,12 @@ from . import radar
 from . import scatter_matrix
 from . import risk_return_bubble
 from . import beta_scatter
+from . import te_cvar_scatter
 from . import overlay_weighted
 from . import factor_bar
 from . import factor_matrix
 from . import multi_fan
+from . import quantile_fan
 from . import rolling_var
 from . import breach_calendar
 from . import moments_panel
@@ -73,9 +75,11 @@ __all__ = [
     "scatter_matrix",
     "risk_return_bubble",
     "beta_scatter",
+    "te_cvar_scatter",
     "factor_bar",
     "factor_matrix",
     "multi_fan",
+    "quantile_fan",
     "rolling_var",
     "breach_calendar",
     "moments_panel",

--- a/pa_core/viz/quantile_fan.py
+++ b/pa_core/viz/quantile_fan.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(
+    df_paths: pd.DataFrame | np.ndarray,
+    quantiles: Sequence[float] = (0.05, 0.95),
+) -> go.Figure:
+    """Return fan chart with custom quantile bounds."""
+    arr = np.asarray(df_paths)
+    q_low, q_high = quantiles[0], quantiles[-1]
+    median = np.median(arr, axis=0)
+    lower = np.percentile(arr, 100 * q_low, axis=0)
+    upper = np.percentile(arr, 100 * q_high, axis=0)
+    months = np.arange(arr.shape[1])
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(go.Scatter(x=months, y=upper, mode="lines", line=dict(width=0), showlegend=False))
+    fig.add_trace(
+        go.Scatter(
+            x=months,
+            y=lower,
+            mode="lines",
+            fill="tonexty",
+            line=dict(width=0),
+            name=f"{int(q_low*100)}–{int(q_high*100)}% CI",
+        )
+    )
+    fig.add_trace(go.Scatter(x=months, y=median, mode="lines", name="Median"))
+    fig.update_layout(xaxis_title="Month", yaxis_title="Return")
+    return fig

--- a/pa_core/viz/te_cvar_scatter.py
+++ b/pa_core/viz/te_cvar_scatter.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_summary: pd.DataFrame, *, size_col: str = "Capital") -> go.Figure:
+    """Return scatter of tracking error vs CVaR.
+
+    Parameters
+    ----------
+    df_summary : pandas.DataFrame
+        Must contain TrackingErr, CVaR and Agent columns.
+    size_col : str, default "Capital"
+        Optional column to scale marker size.
+    """
+    df = df_summary.copy()
+    thr = theme.THRESHOLDS
+    probs = df.get("ShortfallProb")
+    probs = probs.fillna(0.0) if probs is not None else pd.Series(0.0, index=df.index)
+    colors = []
+    for p in probs:
+        if p <= thr.get("shortfall_green", 0.05):
+            colors.append("green")
+        elif p <= thr.get("shortfall_amber", 0.10):
+            colors.append("orange")
+        else:
+            colors.append("red")
+    size = df.get(size_col)
+    size = size if size is not None else pd.Series(1.0, index=df.index)
+    max_size = size.max() if size.max() > 0 else 1.0
+    fig = go.Figure(layout_template=theme.TEMPLATE)
+    fig.add_trace(
+        go.Scatter(
+            x=df["TrackingErr"],
+            y=df["CVaR"],
+            mode="markers",
+            marker=dict(size=10 + 20 * size / max_size, color=colors),
+            text=df["Agent"],
+            hovertemplate="%{text}<br>TE=%{x:.2%}<br>CVaR=%{y:.2%}<extra></extra>",
+        )
+    )
+    fig.update_layout(xaxis_title="Tracking Error", yaxis_title="CVaR")
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -36,10 +36,12 @@ from pa_core.viz import (
     corr_network,
     beta_heatmap,
     beta_scatter,
+    te_cvar_scatter,
     overlay_weighted,
     factor_bar,
     factor_matrix,
     multi_fan,
+    quantile_fan,
 )
 
 
@@ -299,5 +301,21 @@ def test_additional_new_viz_helpers():
     mf_fig = multi_fan.make(arr, horizons=[3, 5])
     assert isinstance(mf_fig, go.Figure)
     mf_fig.to_json()
+
+
+def test_te_cvar_scatter_and_quantile_fan():
+    df = pd.DataFrame({
+        "TrackingErr": [0.02, 0.03],
+        "CVaR": [0.05, 0.04],
+        "Agent": ["A", "B"],
+    })
+    fig1 = te_cvar_scatter.make(df)
+    assert isinstance(fig1, go.Figure)
+    fig1.to_json()
+
+    arr = np.random.normal(size=(5, 6))
+    fig2 = quantile_fan.make(arr, quantiles=(0.1, 0.9))
+    assert isinstance(fig2, go.Figure)
+    fig2.to_json()
 
 


### PR DESCRIPTION
## Summary
- document new visualisation helpers in Agents guide
- add `te_cvar_scatter` and `quantile_fan` modules
- expose new helpers via `viz.__init__`
- test the new figures

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673a8799fc833196ae2b028470c476