### PR TITLE
Add sunburst visualization

### DIFF
--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -37,6 +37,7 @@ from . import factor_bar
 from . import factor_matrix
 from . import multi_fan
 from . import quantile_fan
+from . import sunburst
 from . import rolling_var
 from . import breach_calendar
 from . import moments_panel
@@ -87,6 +88,7 @@ __all__ = [
     "factor_matrix",
     "multi_fan",
     "quantile_fan",
+    "sunburst",
     "rolling_var",
     "breach_calendar",
     "moments_panel",

--- a/pa_core/viz/sunburst.py
+++ b/pa_core/viz/sunburst.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from . import theme
+
+
+def make(df_returns: pd.DataFrame) -> go.Figure:
+    """Return sunburst chart of return attribution by sleeve."""
+    df = df_returns.copy()
+    if {"Agent", "Sub", "Return"} <= set(df.columns):
+        df["Category"] = df["Agent"].map(lambda a: theme.CATEGORY_BY_AGENT.get(a, a))
+        rows: list[tuple[str, str, float]] = []
+        for cat, cat_df in df.groupby("Category"):
+            cat_ret = float(cat_df["Return"].sum())
+            rows.append((str(cat), "", cat_ret))
+            for agent, ag_df in cat_df.groupby("Agent"):
+                ag_ret = float(ag_df["Return"].sum())
+                rows.append((str(agent), str(cat), ag_ret))
+                for _, row in ag_df.iterrows():
+                    rows.append((str(row["Sub"]), str(agent), float(row["Return"])) )
+    else:
+        raise ValueError("DataFrame must contain Agent, Sub and Return columns")
+
+    labels = [r[0] for r in rows]
+    parents = [r[1] for r in rows]
+    values = [r[2] for r in rows]
+
+    fig = go.Figure(
+        go.Sunburst(labels=labels, parents=parents, values=values),
+        layout_template=theme.TEMPLATE,
+    )
+    return fig

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -42,6 +42,7 @@ from pa_core.viz import (
     factor_matrix,
     multi_fan,
     quantile_fan,
+    sunburst,
     horizon_slicer,
     inset,
     data_quality,
@@ -346,5 +347,16 @@ def test_horizon_inset_and_quality(tmp_path):
     out = tmp_path / "out.pdf"
     pdf_export.save(fig2, out)
     assert out.exists()
+
+
+def test_sunburst_make():
+    df = pd.DataFrame({
+        "Agent": ["A", "A", "B"],
+        "Sub": ["S1", "S2", "S1"],
+        "Return": [0.05, 0.02, -0.01],
+    })
+    fig = sunburst.make(df)
+    assert isinstance(fig, go.Figure)
+    fig.to_json()
 
 


### PR DESCRIPTION
## Summary
- implement `viz.sunburst` helper
- expose the helper in `viz.__init__`
- add tests for the sunburst chart

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675cf5b9c08331a84e918bf2446e71