### PR TITLE
Add CLI export flags

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,3 +37,21 @@ def test_main_with_csv(tmp_path):
     assert out_file.exists()
 
 
+def test_main_with_png(tmp_path, monkeypatch):
+    csv_path = tmp_path / "params.csv"
+    csv_content = "Parameter,Value\nNumber of simulations,2\nNumber of months,1\n"
+    csv_path.write_text(csv_content)
+    idx_csv = Path(__file__).resolve().parents[1] / "sp500tr_fred_divyield.csv"
+    out_file = tmp_path / "out.xlsx"
+    monkeypatch.chdir(tmp_path)
+    main([
+        "--params",
+        str(csv_path),
+        "--index",
+        str(idx_csv),
+        "--output",
+        str(out_file),
+        "--png",
+    ])
+
+


### PR DESCRIPTION
## Summary
- extend the command-line interface with dashboard and file export options
- generate basic visuals and optional exports after simulation
- test CLI `--png` flag

## Testing
- `ruff check pa_core tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869475401b48331807d6a9498542e77