### PR TITLE
Improve dashboard extensibility

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,11 +1,22 @@
+import importlib
 import pandas as pd
 import streamlit as st
 from pathlib import Path
 import time
 
-from pa_core.viz import risk_return, fan, path_dist
+PLOTS: dict[str, str] = {
+    "Headline": "pa_core.viz.risk_return.make",
+    "Funding fan": "pa_core.viz.fan.make",
+    "Path dist": "pa_core.viz.path_dist.make",
+}
 
 _DEF_XLSX = "Outputs.xlsx"
+
+
+def _get_plot_fn(path: str):
+    module, func = path.rsplit(".", 1)
+    mod = importlib.import_module(module)
+    return getattr(mod, func)
 
 
 @st.cache_data(ttl=600)
@@ -32,21 +43,22 @@ def main() -> None:
     auto = st.sidebar.checkbox("Auto-refresh")
     interval = st.sidebar.number_input("Refresh every (s)", 5, 300, 60)
 
-    tab1, tab2, tab3, tab4 = st.tabs(
-        ["Headline", "Funding fan", "Path dist", "Diagnostics"]
-    )
-    with tab1:
-        st.plotly_chart(risk_return.make(summary), use_container_width=True)
-    if paths is not None:
-        paths = paths[agents].iloc[:, :months]
-        with tab2:
-            st.plotly_chart(fan.make(paths), use_container_width=True)
-        with tab3:
-            st.plotly_chart(path_dist.make(paths), use_container_width=True)
-    with tab4:
+    tab_names = list(PLOTS) + ["Diagnostics"]
+    tabs = st.tabs(tab_names)
+
+    for name, tab in zip(tab_names[:-1], tabs[:-1]):
+        fn = _get_plot_fn(PLOTS[name])
+        with tab:
+            if name == "Headline":
+                st.plotly_chart(fn(summary), use_container_width=True)
+            elif paths is not None:
+                sub_paths = paths[agents].iloc[:, :months]
+                st.plotly_chart(fn(sub_paths), use_container_width=True)
+
+    with tabs[-1]:
         st.dataframe(summary)
 
-    png = risk_return.make(summary).to_image(format="png")
+    png = _get_plot_fn(PLOTS["Headline"])(summary).to_image(format="png")
     st.download_button("Download PNG", png, file_name="risk_return.png", mime="image/png")
     with open(xlsx, "rb") as fh:
         st.download_button("Download XLSX", fh, file_name=Path(xlsx).name)


### PR DESCRIPTION
## Summary
- implement lazy loading for dashboard plots
- drop direct plot imports for easier extension

## Testing
- `ruff check pa_core tests scripts dashboard`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694a864efc8331aca32460e1a69dec