### PR TITLE
Improve dashboard theme customization

### DIFF
--- a/config_theme.yaml
+++ b/config_theme.yaml
@@ -6,3 +6,5 @@ colorway:
   - "#0092d8"
   - "#c8222f"
 font: "Open Sans"
+paper_bgcolor: "#ffffff"
+plot_bgcolor: "#ffffff"

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -391,6 +391,9 @@ from pa_core.viz import theme
 # Inspect or tweak the palette
 print(theme.TEMPLATE.layout.colorway)
 
+# Background colours are also loaded from ``config_theme.yaml``
+print(theme.TEMPLATE.layout.paper_bgcolor)
+
 # Map new agent classes to existing categories for consistent colours
 theme.CATEGORY_BY_AGENT["OverlayOptionsAgent"] = "External Portable Alpha"
 ```
@@ -405,7 +408,8 @@ theme.reload_theme("my_theme.yaml")
 ```
 
 Editing the YAML file or the mapping dictionary lets Ops adjust visuals without
-changing any plotting code.
+changing any plotting code. ``config_theme.yaml`` now supports ``paper_bgcolor``
+and ``plot_bgcolor`` keys so the GUI background matches corporate colours.
 
 ### 12.12  Annotation & hover tips
 Use Plotly's built‑in helpers to keep charts self‑explanatory:

--- a/pa_core/viz/theme.py
+++ b/pa_core/viz/theme.py
@@ -14,7 +14,7 @@ if _THRESH_PATH.exists():
 else:
     THRESHOLDS = {}
 
-def _load_theme(path: Path) -> tuple[list[str], str]:
+def _load_theme(path: Path) -> tuple[list[str], str, str, str]:
     if path.exists():
         with open(path, "r", encoding="utf-8") as fh:
             cfg = yaml.safe_load(fh) or {}
@@ -27,6 +27,8 @@ def _load_theme(path: Path) -> tuple[list[str], str]:
             "#984ea3",
         ]
         font = cfg.get("font", "Roboto")
+        paper_bg = cfg.get("paper_bgcolor", "#ffffff")
+        plot_bg = cfg.get("plot_bgcolor", "#ffffff")
     else:
         colors = [
             "#377eb8",
@@ -37,12 +39,19 @@ def _load_theme(path: Path) -> tuple[list[str], str]:
             "#984ea3",
         ]
         font = "Roboto"
-    return colors, font
+        paper_bg = "#ffffff"
+        plot_bg = "#ffffff"
+    return colors, font, paper_bg, plot_bg
 
 
-_COLORWAY, _FONT = _load_theme(_THEME_PATH)
+_COLORWAY, _FONT, _PAPER_BG, _PLOT_BG = _load_theme(_THEME_PATH)
 TEMPLATE = go.layout.Template(
-    layout=dict(colorway=_COLORWAY, font=dict(family=_FONT))
+    layout=dict(
+        colorway=_COLORWAY,
+        font=dict(family=_FONT),
+        paper_bgcolor=_PAPER_BG,
+        plot_bgcolor=_PLOT_BG,
+    )
 )
 
 # Map agent class -> category name used for consistent colours
@@ -71,8 +80,13 @@ def reload_thresholds(path: str | Path = _THRESH_PATH) -> None:
 
 def reload_theme(path: str | Path = _THEME_PATH) -> None:
     """Reload colour palette and font from a YAML file."""
-    global _COLORWAY, _FONT, TEMPLATE
-    _COLORWAY, _FONT = _load_theme(Path(path))
+    global _COLORWAY, _FONT, _PAPER_BG, _PLOT_BG, TEMPLATE
+    _COLORWAY, _FONT, _PAPER_BG, _PLOT_BG = _load_theme(Path(path))
     TEMPLATE = go.layout.Template(
-        layout=dict(colorway=_COLORWAY, font=dict(family=_FONT))
+        layout=dict(
+            colorway=_COLORWAY,
+            font=dict(family=_FONT),
+            paper_bgcolor=_PAPER_BG,
+            plot_bgcolor=_PLOT_BG,
+        )
     )

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -462,12 +462,19 @@ def test_additional_visualisations(tmp_path):
 
 def test_theme_reload(tmp_path):
     cfg = tmp_path / "theme.yaml"
-    cfg.write_text("colorway: ['#111111', '#222222']\nfont: DejaVu Sans")
+    cfg.write_text(
+        "colorway: ['#111111', '#222222']\n"
+        "font: DejaVu Sans\n"
+        "paper_bgcolor: '#eeeeee'\n"
+        "plot_bgcolor: '#dddddd'\n"
+    )
     from pa_core.viz import theme
 
     theme.reload_theme(cfg)
     assert theme.TEMPLATE.layout.font.family == "DejaVu Sans"
     assert list(theme.TEMPLATE.layout.colorway)[:2] == ["#111111", "#222222"]
+    assert theme.TEMPLATE.layout.paper_bgcolor == "#eeeeee"
+    assert theme.TEMPLATE.layout.plot_bgcolor == "#dddddd"
 
 
 


### PR DESCRIPTION
## Summary
- allow config_theme to set paper and plot backgrounds
- expose background colors through viz.theme
- document new YAML keys in Agents guide
- test theme reload with background colors

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869853773b88331bbd95fddcf50866e