### PR TITLE
Add alt-text option to visualise script

### DIFF
--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -311,7 +311,7 @@ class MyNewAgent(BaseAgent):
 python scripts/visualise.py \
   --plot risk_return --xlsx Outputs.xlsx \
   --agent InternalPAAgent \
-  --png --pdf
+  --png --pdf --alt-text "Risk-return chart"
 Behaviour: loads Excel once → routes to viz.* → saves images under plots/.
 
 Add if __name__ == "__main__": guard so Codex can insert into package.
@@ -489,7 +489,8 @@ calculations.
 All charts must remain readable for colour-blind users and screen readers.
 Provide descriptive titles (`fig.update_layout(title_text="..."`) and add
 alt-text for exported images.  The ``viz.html_export.save`` and
-``viz.pptx_export.save`` helpers accept an ``alt_text`` argument so
+``viz.pptx_export.save`` helpers accept an ``alt_text`` argument, and the
+CLI wrapper exposes ``--alt-text`` for convenience so
 screen readers can describe the figures. Stick to the WCAG contrast ratios
 defined in ``viz.theme`` and avoid relying solely on hue to convey meaning.
 
@@ -1067,6 +1068,7 @@ and factor columns. Use this to check style drift over the simulation horizon.
 --png / --pdf / --pptx     Static exports (can be combined)
 --html                    Save interactive HTML
 --gif                     Animated export of monthly paths
+--alt-text TEXT           Alt text for HTML/PPTX exports
 --dashboard                Launch Streamlit dashboard after run
 
 ```

--- a/scripts/visualise.py
+++ b/scripts/visualise.py
@@ -39,6 +39,11 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--pptx", action="store_true")
     parser.add_argument("--gif", action="store_true")
     parser.add_argument("--html", action="store_true")
+    parser.add_argument(
+        "--alt-text",
+        dest="alt_text",
+        help="Alt text for HTML/PPTX exports",
+    )
     args = parser.parse_args(argv)
 
     df_summary = pd.read_excel(args.xlsx, sheet_name="Summary")
@@ -66,14 +71,14 @@ def main(argv: list[str] | None = None) -> None:
     if args.pdf:
         fig.write_image(f"{stem}.pdf")
     if args.pptx:
-        pptx_export.save([fig], f"{stem}.pptx")
+        pptx_export.save([fig], f"{stem}.pptx", alt_texts=[args.alt_text] if args.alt_text else None)
     if args.gif:
         if df_paths is None:
             raise FileNotFoundError(parquet_path)
         anim = animation.make(df_paths)
         anim.write_image(f"{stem}.gif")
     if args.html:
-        html_export.save(fig, f"{stem}.html")
+        html_export.save(fig, f"{stem}.html", alt_text=args.alt_text)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/tests/test_visualise.py
+++ b/tests/test_visualise.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from pathlib import Path
+from pptx import Presentation
+
+from scripts.visualise import main
+
+
+def test_visualise_alt_text(tmp_path, monkeypatch):
+    summary = pd.DataFrame({
+        "AnnReturn": [0.05],
+        "AnnVol": [0.02],
+        "TrackingErr": [0.01],
+        "Agent": ["Base"],
+        "ShortfallProb": [0.02],
+    })
+    xlsx = tmp_path / "out.xlsx"
+    summary.to_excel(xlsx, sheet_name="Summary", index=False)
+    paths = pd.DataFrame({"Base": [0.01, 0.02]})
+    paths.to_parquet(xlsx.with_suffix(".parquet"))
+    monkeypatch.chdir(tmp_path)
+    main([
+        "--plot",
+        "risk_return",
+        "--xlsx",
+        str(xlsx),
+        "--html",
+        "--pptx",
+        "--alt-text",
+        "Test chart",
+    ])
+    html = Path("plots/risk_return.html").read_text()
+    assert "aria-label=\"Test chart\"" in html
+    pres = Presentation("plots/risk_return.pptx")
+    shapes = pres.slides[0].shapes
+    elements = shapes[0]._element.xpath('./p:nvPicPr/p:cNvPr')
+    if elements:
+        assert elements[0].get("descr") == "Test chart"


### PR DESCRIPTION
## Summary
- support `--alt-text` in `scripts/visualise.py`
- document the new flag in Agents.md
- ensure accessibility docs mention the flag
- test `visualise.py` alt-text handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ca9784208331951c0df69ce8563a