### PR TITLE
Add RunFlags dataclass for CLI export options

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -29,6 +29,7 @@ from .sim.metrics import (
     summary_table,
 )
 from .config import ModelConfig, load_config
+from .run_flags import RunFlags
 from .agents import (
     Agent,
     AgentParams,
@@ -74,6 +75,7 @@ __all__ = [
     "InternalPAAgent",
     "ModelConfig",
     "load_config",
+    "RunFlags",
     "build_agents",
     "build_from_config",
     "viz",

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -212,7 +212,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         inputs_dict,
         summary,
         raw_returns_dict,
-        filename=flags.save_xlsx,
+        filename=flags.save_xlsx or "Outputs.xlsx",
         pivot=args.pivot,
     )
 

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -129,7 +129,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     else:
         raw_params = load_parameters(args.params, LABEL_MAP)
         cfg = load_config(raw_params)
-    raw_params = cfg.dict()
+    raw_params = cfg.model_dump()
     idx_series = load_index_returns(args.index)
     mu_idx = float(idx_series.mean())
     idx_sigma = float(idx_series.std(ddof=1))

--- a/pa_core/run_flags.py
+++ b/pa_core/run_flags.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class RunFlags:
+    """Flags controlling report export and dashboard launch."""
+
+    save_xlsx: str | None = "Outputs.xlsx"
+    png: bool = False
+    pdf: bool = False
+    pptx: bool = False
+    html: bool = False
+    gif: bool = False
+    dashboard: bool = False
+    alt_text: str | None = None


### PR DESCRIPTION
## Summary
- implement `RunFlags` dataclass and expose it from the package
- parse command-line options into `RunFlags` in `pa_core.cli`

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c83f2e8c0833187b421865a62d7e2