### PR TITLE
docs: fix dashboard flag in UserGuide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -23,7 +23,7 @@ After producing an output file you can start an interactive dashboard to visuali
 
 ### Option 1 – from the CLI
 
-Add `--launch_dashboard` to the `pa_core` command. Once the simulation finishes, Streamlit opens in your browser.
+Add `--dashboard` to the `pa_core` command. Once the simulation finishes, Streamlit opens in your browser.
 
 ### Option 2 – manual launch
 


### PR DESCRIPTION
## Summary
- update CLI instructions to use `--dashboard`
- replace old `--launch_dashboard` references

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dee37767c8331a238e1222bfc5462