### PR TITLE
Remove verbose export message

### DIFF
--- a/pa_core/reporting/excel.py
+++ b/pa_core/reporting/excel.py
@@ -90,4 +90,3 @@ def export_to_excel(
             pass
 
     wb.save(filename)
-    print(f"Exported results to {filename}")


### PR DESCRIPTION
## Summary
- eliminate `print` from `export_to_excel`
- update requirements and run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df566b234833188911deb46133fc9