### PR TITLE
Update user guide for config checks

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,6 +15,8 @@ interactive formats.
 
 1. Run `./setup.sh` once to create a virtual environment and install all dependencies.
 2. Copy `config/parameters_template.csv` or `config/params_template.yml` and edit the values to suit your scenario. Launch the CLI with `--params` or `--config` and supply your index returns via `--index`.
+3. The index CSV must contain a `Date` column and either `Monthly_TR` or `Return` for monthly total returns.
+4. Make sure your parameter file includes `ShortfallProb` under `risk_metrics`; removing it triggers a validation error.
 
 ```bash
 python -m pa_core.cli --params parameters.csv --index sp500tr_fred_divyield.csv


### PR DESCRIPTION
## Summary
- clarify that index CSV requires Date and Monthly_TR or Return
- note that ShortfallProb must stay in risk_metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ea84dcff08331ac521c2279eb1e5e