### PR TITLE
Update user guide intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ tests/__pycache__/
 
 *.egg-info/
 
+# Virtual environment
+.venv/
+
 *.xlsx

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,7 +16,9 @@ and active‑extension—and simulates monthly returns for each. Key outputs inc
 annualised return, volatility, Value at Risk, tracking error and the required
 **ShortfallProb** metric. The tutorials below walk through running a simulation,
 interpreting these metrics and visualising them so you can test the model’s main
-ideas in practice.
+ideas in practice. Each tutorial highlights how to implement a run, review the
+headline metrics and visualise the results so you can evaluate risk/return,
+shortfall probability and tracking error in a repeatable workflow.
 
 ## 2. Getting Started
 


### PR DESCRIPTION
## Summary
- ignore `.venv` virtual environment directory
- clarify the user guide introduction to mention evaluating risk/return, shortfall probability and tracking error

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686f1dc66a2c8331b6dd08410764383c