### PR TITLE
Ensure decimal active share

### DIFF
--- a/pa_core/agents/active_ext.py
+++ b/pa_core/agents/active_ext.py
@@ -8,9 +8,9 @@ class ActiveExtensionAgent(Agent):
         self, r_beta: Array, alpha_stream: Array, financing: Array
     ) -> Array:
         self._validate_inputs(r_beta, alpha_stream, financing)
-        active_share = (
-            float(self.extra.get("active_share", 50.0)) / 100.0
-        )  # Convert percentage to decimal
+        active_share = float(self.extra.get("active_share", 0.5))
+        if active_share > 1:
+            active_share /= 100.0
         return (
             self.p.beta_share * (r_beta - financing)
             + (self.p.beta_share * active_share) * alpha_stream


### PR DESCRIPTION
## Summary
- allow decimal or percentage inputs for active share
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d00bd2c08331ac3f036110b4fe02