### PR TITLE
Fix User Guide tutorial section

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,8 +1,14 @@
 # Portable Alpha-Extension Model User Guide
 
-This program simulates a portable‑alpha plus active‑extension strategy. Each run distri- **Auto‑refresh** – polls the file every few seconds so the dashboard updates while simulations run.
-
-## 6. Introductory Tutorial 4 – Exporting Chartsital across internal, external portable‑alpha and active‑extension sleeves and draws joint return paths.  The command line prints a summary and writes an Excel workbook with an embedded risk‑return chart along with optional additional figures.  Use ``python -m pa_core.cli`` to access all command‑line features—including dashboard launch and static exports.  The parameter templates in `config/` already include the mandatory `ShortfallProb` risk metric so the CLI will fail fast if you remove it.  All tutorials assume you invoke the program via ``python -m pa_core.cli``.
+This program simulates a portable‑alpha plus active‑extension strategy. Each run
+distributes capital across internal, external portable‑alpha and active‑extension
+sleeves and draws joint return paths. The command line prints a summary and
+writes an Excel workbook with an embedded risk‑return chart along with optional
+additional figures. Use ``python -m pa_core.cli`` to access all command‑line
+features—including dashboard launch and static exports. The parameter templates
+in `config/` already include the mandatory `ShortfallProb` risk metric so the
+CLI will fail fast if you remove it. All tutorials assume you invoke the program
+via ``python -m pa_core.cli``.
 
 The model is designed to help you explore three core ideas:
 
@@ -182,13 +188,9 @@ This tutorial shows how to visualise the metrics produced in Tutorials 1 and 2
 - **Risk‑free rate** – for any excess return calculations.
 - **Auto‑refresh** – polls the file every few seconds so the dashboard updates while simulations run.
 
-<<<<<<< HEAD
 Two download buttons allow you to save the headline PNG chart and the Excel file.
 
-### Tutorial 4 – Export Charts
-=======
-## 6. Introductory Tutorial 4 – Exporting Charts
->>>>>>> origin/codex/update-user-guide-for-consistency-and-tutorials
+### Introductory Tutorial 4 – Exporting Charts
 
 The CLI can create static images or PPTX packs as part of a run. Combine the following flags as needed:
 


### PR DESCRIPTION
## Summary
- fix broken merge lines in `docs/UserGuide.md`
- clarify intro text and tutorial 4 heading

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ef12cc0c8331a5233fcb1f3849c7