### PR TITLE
Update tutorial to clarify analysis mode

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -136,18 +136,19 @@ Introductory Tutorials 1‑3 cover the main workflow of implementing a scenario,
 
 This tutorial walks through producing a set of results that you can later analyse for risk/return, shortfall probability and tracking error.
 
-1. **Prepare a configuration** – copy one of the templates in `config/` and edit the values for your scenario.
-2. **Run the CLI** – invoke `python -m pa_core.cli` with `--config` (or `--params`) and `--index` to supply index returns. Add `--output` to set the Excel name and `--pivot` if you want raw return paths saved.
+1. **Prepare a configuration** – copy one of the templates in `config/` and edit the values for your scenario. **Set `analysis_mode` to `returns`, `capital`, `alpha_shares` or `vol_mult` before running.**
+2. **Run the CLI** – invoke `python -m pa_core.cli` with `--config` (or `--params`) and `--index` to supply index returns. Add `--mode` if not specified in the file, `--output` to set the Excel name and `--pivot` if you want raw return paths saved.
 3. **Check the console** – after the run finishes, a table lists `AnnReturn`, `AnnVol`, `VaR`, `BreachProb` and `TE` for each sleeve.
 4. **Review the workbook** – open the generated `Outputs.xlsx` to confirm the summary table. A **ShortfallProb** column is always added so you can compare funding‑shortfall risk, and the `Summary` sheet contains an embedded risk‑return chart showing how each sleeve stacks up at a glance.
 
 
 ```bash
-python -m pa_core.cli \
-  --config my_params.yml \
-  --index sp500tr_fred_divyield.csv \
-  --output Results.xlsx \
-  --pivot
+  python -m pa_core.cli \
+    --config my_params.yml \
+    --index sp500tr_fred_divyield.csv \
+    --mode returns \
+    --output Results.xlsx \
+    --pivot
 ```
 
 Set `--seed` for reproducible draws or `--backend cupy` if a GPU is available. This first run verifies that the program is installed correctly and prints a console table of `AnnReturn`, `AnnVol`, `VaR`, `BreachProb` and `TE` for each sleeve while writing the same data to `Outputs.xlsx`.


### PR DESCRIPTION
## Summary
- clarify the mandatory `analysis_mode` parameter in Tutorial 1
- show `--mode returns` in the CLI example

## Testing
- `python -m pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6875f6d66ad8833193b05df6323400ac