### PR TITLE
Fix docs after returns sweep bug resolved

### DIFF
--- a/COMPLETE_TUTORIAL_TESTING_SUMMARY.md
+++ b/COMPLETE_TUTORIAL_TESTING_SUMMARY.md
@@ -16,7 +16,7 @@
 - **Status**: ✅ **WORKING** - Core functionality excellent
 - **Enhancement Opportunity**: 🚀 **HIGH** - Ready for 5-part restructure using parameter sweeps
 - **Key Success**: Parameter sweep functionality fully implemented and working
-- **Implementation Ready**: Parts 1-4 immediately, Part 5 after CLI bug fix
+- **Implementation Ready**: All five parts now working, including returns mode
 
 ### **🟡 Tutorial 2: Metrics Interpretation** 
 - **Status**: ⚠️ **WORKING but needs guidance** - Functionality complete, UX gaps
@@ -64,14 +64,14 @@ python -m pa_core.cli --params config/alpha_shares_mode_template.csv --mode alph
 # Volatility stress testing - 13KB Excel output
 python -m pa_core.cli --params config/vol_mult_mode_template.csv --mode vol_mult --index sp500tr_fred_divyield.csv
 
-# Returns sensitivity (has CLI bug but engine works)
+# Returns sensitivity - return assumption sweep
 python -m pa_core.cli --params config/returns_mode_template.csv --mode returns --index sp500tr_fred_divyield.csv
 ```
 
 ### **✅ Implementation Infrastructure:**
 - **pa_core/sweep.py**: 184-line parameter sweep engine (commits 10f750b, 8b4ffe6)
 - **config/*_mode_template.csv**: 4 working CSV templates for each analysis mode
-- **pa_core/cli.py**: --mode parameter integration (3/4 modes working)
+- **pa_core/cli.py**: --mode parameter integration (all 4 modes working)
 - **Excel Export**: Multi-sheet outputs with embedded risk-return charts
 
 ---
@@ -85,7 +85,7 @@ python -m pa_core.cli --params config/returns_mode_template.csv --mode returns -
 2. **Part 2**: Capital Optimization (38KB parameter sweep demonstration)  
 3. **Part 3**: Alpha Efficiency Analysis (183KB multi-scenario analysis)
 4. **Part 4**: Volatility Stress Testing (13KB systematic volatility analysis)
-5. **Part 5**: Return Sensitivity Analysis (after CLI bug fix)
+5. **Part 5**: Return Sensitivity Analysis (returns sweep working)
 
 #### **Tutorial 2 Enhancement** (Multi-Scenario Focus):
 - **Bulk threshold analysis**: Analyze 50-200 scenarios for compliance patterns

--- a/TUTORIAL_1_PARAMETER_SWEEP_RESULTS.md
+++ b/TUTORIAL_1_PARAMETER_SWEEP_RESULTS.md
@@ -64,7 +64,7 @@
 2. **Capital Optimization** (Part 2): Systematic exploration of allocation strategies  
 3. **Alpha Efficiency** (Part 3): Optimization of alpha capture across different share allocations
 4. **Stress Testing** (Part 4): Volatility regime analysis for portfolio resilience
-5. **Returns Analysis** (Part 5): Available once CLI bug is fixed
+5. **Returns Analysis** (Part 5): Works via `--mode returns` using `returns_mode_template.csv`
 
 ### **File Outputs for User Analysis:**
 - `Tutorial1_Basic.xlsx` - Single scenario baseline

--- a/TUTORIAL_2_ISSUES.md
+++ b/TUTORIAL_2_ISSUES.md
@@ -31,7 +31,7 @@
 ### **Parameter Sweep Tests (NEWLY DISCOVERED AS WORKING):**
 - ✅ `--params config/capital_mode_template.csv --mode capital` → Multi-scenario capital allocation sweep
 - ✅ `--params config/alpha_shares_mode_template.csv --mode alpha_shares` → Multi-scenario alpha optimization
-- ⚠️ `--params config/returns_mode_template.csv --mode returns` → CLI bug prevents sweep mode
+- ✅ `--params config/returns_mode_template.csv --mode returns` → Returns sensitivity sweep working
 - 🔄 `--params config/vol_mult_mode_template.csv --mode vol_mult` → Available but not tested
 
 ### **Enhanced Tutorial 2 Capabilities:**
@@ -75,7 +75,7 @@ Volatility stress test     | .csv      | --params + --mode vol_mult | vol_mult_m
 ## 🎯 **NEXT STEPS (UPDATED):**
 1. **Immediate**: Implement enhanced Tutorial 2 with working parameter sweep demonstrations
 2. **Create**: Tutorial examples using capital and alpha_shares modes (confirmed working)
-3. **Fix**: Minor CLI bug for returns mode (should be trivial fix)
+3. **Returns sensitivity**: Demonstrate working returns mode sweeps
 4. **Test**: vol_mult mode to confirm it works like the others
 5. **Document**: Comprehensive file usage guidance with working examples
 

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -38,7 +38,7 @@
 - ✅ **Part 2**: Capital Allocation Optimization - Use `config/capital_mode_template.csv` with `--mode capital` (38KB Excel output, working)
 - ✅ **Part 3**: Alpha Capture Efficiency - Use `config/alpha_shares_mode_template.csv` with `--mode alpha_shares` (183KB Excel, 187 combinations, working)  
 - ✅ **Part 4**: Volatility Stress Testing - Use `config/vol_mult_mode_template.csv` with `--mode vol_mult` (13KB Excel output, working)
-- ⚠️ **Part 5**: Return Sensitivity Analysis - CLI bug prevents returns mode sweep (easy fix: modify `pa_core/cli.py` line ~268)
+ - ✅ **Part 5**: Return Sensitivity Analysis - Use `config/returns_mode_template.csv` with `--mode returns` (bug fixed)
 
 #### 🎓 **Tutorial 2: Advanced Threshold Analysis (MEDIUM PRIORITY)**
 **Current**: Basic metric interpretation  
@@ -147,7 +147,7 @@
 #### 📊 **Implementation Priority Order**
 
 **PHASE 1: Core Tutorial Enhancements**
-1. **HIGH**: Tutorial 1 enhancement (Parts 1-4 ready immediately, Part 5 needs CLI bug fix)
+1. **HIGH**: Tutorial 1 enhancement (all five parts working including returns mode)
 2. **MEDIUM**: Tutorial 2 enhancement using sweep outputs (threshold analysis workflows)
 3. **MEDIUM**: Tutorial 3 enhancement after dependency fixes (multi-scenario dashboard workflows)
 4. **MEDIUM**: Tutorial 4 enhancement using sweep outputs (bulk export and reporting workflows)
@@ -167,7 +167,7 @@
     - **Prerequisites**: All core tutorial enhancements complete, dependency issues resolved
 
 ### 🔧 **Critical Bug Fixes Required**
-- **Returns Mode CLI Bug**: Modify `pa_core/cli.py` line ~268 to include returns mode in sweep logic
+- **Returns Mode CLI Bug**: **Fixed** – returns sweep now works via `--mode returns`
 - **Streamlit Installation**: Add Streamlit to default installation instructions
 - **Chrome/Kaleido Dependencies**: Document static export requirements and provide installation guidance
 
@@ -232,7 +232,7 @@ The following sections have been removed as they contain completed architectural
 - **Tutorial Source**: `docs/UserGuide.md` (tutorials 1-10)
 - **Parameter Templates**: `config/` directory (sweep mode templates)
 - **Test Results**: Tutorial testing documentation files
-- **CLI Interface**: `pa_core/cli.py` (returns mode bug fix needed)
+- **CLI Interface**: `pa_core/cli.py` (returns mode sweep fixed)
 - **Dashboard**: `dashboard/app.py` (Streamlit integration)
 - **Visualization**: `scripts/visualise.py` (bulk export workflows)
 


### PR DESCRIPTION
## Summary
- update tutorial instructions in Agents.md that the returns sweep bug is fixed
- tweak tutorial results documents to remove outdated bug note

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9a5efde083319d877ab8145ea950