### PR TITLE
Enhance Tutorial 1 setup and export guidance

### DIFF
--- a/tutorials/TUTORIAL_1_ENHANCED_PARAMETER_SWEEPS.md
+++ b/tutorials/TUTORIAL_1_ENHANCED_PARAMETER_SWEEPS.md
@@ -4,7 +4,20 @@
 
 **⏱️ Duration**: 45-60 minutes  
 **📋 Prerequisites**: Basic familiarity with Portable Alpha concepts  
-**🛠️ Tools**: Parameter sweep engine (all 4 modes), Excel output analysis  
+**🛠️ Tools**: Parameter sweep engine (all 4 modes), Excel output analysis
+
+### Setup
+
+Install the package along with Streamlit and Kaleido so the dashboard and static
+exports work:
+
+```bash
+pip install -r requirements.txt
+pip install streamlit kaleido
+```
+
+> **PNG/PDF/PPTX exports require a local Chrome or Chromium installation**.
+> On Debian/Ubuntu run `sudo apt-get install -y chromium-browser`.
 
 ---
 
@@ -49,6 +62,11 @@ python -m pa_core --params config/params_template.yml --output tutorial_1_baseli
 3. How much capital is allocated to external alpha vs internal beta?
 
 **⏱️ Expected Time**: 10 minutes
+
+> **Tip**: Add `--dashboard` to automatically open the Streamlit dashboard
+> after the run. Include `--png`, `--pdf`, `--pptx`, `--html` or `--gif`
+> to export charts during the simulation. Combine these with
+> `--alt-text "Description"` for accessible captions.
 
 ---
 


### PR DESCRIPTION
## Summary
- document Streamlit and Kaleido setup requirements
- add Chrome install note in Tutorial 1
- include dashboard and export flag tips in Part 1

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687c639470a88331b8157cc13ad6656d