### PR TITLE
Fix quick start example

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -35,7 +35,7 @@ pip install streamlit>=1.35  # required for the dashboard
 
 # Run a quick single-scenario simulation (returns mode by default)
 python -m pa_core.cli \
-  --params config/params_template.yml \
+  --config config/params_template.yml \
   --index sp500tr_fred_divyield.csv \
   --output QuickStart.xlsx
 ```


### PR DESCRIPTION
## Summary
- fix YAML example in quick start to use `--config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfb76f4388331a8e5ff933a9883d6