### PR TITLE
Update cross references in tutorials

### DIFF
--- a/tutorials/TUTORIAL_2_ADVANCED_THRESHOLD_ANALYSIS.md
+++ b/tutorials/TUTORIAL_2_ADVANCED_THRESHOLD_ANALYSIS.md
@@ -6,6 +6,12 @@
 **📋 Prerequisites**: Completion of Tutorial 1
 **🛠️ Tools**: Parameter sweep engine, `config_thresholds.yaml`, Excel filters
 
+Whether you worked through just Part&nbsp;1 of Tutorial&nbsp;1 or
+ran the full five‑part parameter sweep series, the
+metrics discussed here apply to all those results.  The
+threshold concepts remain the same regardless of which
+analysis mode produced your Excel file.
+
 ### Setup
 
 Ensure all dependencies are installed so the CLI and dashboard work:

--- a/tutorials/TUTORIAL_3_MULTI_SCENARIO_DASHBOARD.md
+++ b/tutorials/TUTORIAL_3_MULTI_SCENARIO_DASHBOARD.md
@@ -6,6 +6,10 @@
 **📋 Prerequisites**: Completion of Tutorial 2, working parameter sweep outputs
 **🛠️ Tools**: Streamlit dashboard, parameter sweep engine, Chrome/Kaleido for exports
 
+You can load results from any part of Tutorial&nbsp;1.
+Single scenarios and all sweep modes produce workbooks that
+the dashboard reads in the same way.
+
 ### Setup
 
 Install the extra packages if they are not already available:


### PR DESCRIPTION
## Summary
- refer to results from all five parts of Tutorial 1 in Tutorial 2
- note that Tutorial 3 dashboard accepts outputs from any Tutorial 1 mode

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_687d7f01465083318ae785faf788b49c