### PR TITLE
Improve tutorial setup instructions

### DIFF
--- a/tutorials/TUTORIAL_10_INTERACTIVE_GALLERY.md
+++ b/tutorials/TUTORIAL_10_INTERACTIVE_GALLERY.md
@@ -6,6 +6,15 @@
 **📋 Prerequisites**: Completion of Tutorial 9
 **🛠️ Tools**: `viz_gallery.ipynb`, `export_bundle.save`, `scripts/visualise.py`
 
+### Setup
+
+Install Streamlit and Kaleido plus a local Chrome or Chromium browser so the dashboard and static exports work:
+
+```bash
+pip install streamlit kaleido
+sudo apt-get install -y chromium-browser
+```
+
 ### Step 1 – Launch the notebook
 
 ```bash

--- a/tutorials/TUTORIAL_4_PROFESSIONAL_BULK_EXPORT_WORKFLOWS.md
+++ b/tutorials/TUTORIAL_4_PROFESSIONAL_BULK_EXPORT_WORKFLOWS.md
@@ -8,10 +8,10 @@
 
 ### Setup
 
-Ensure Kaleido and a local Chrome or Chromium browser are installed so static exports work:
+Ensure Streamlit, Kaleido and a local Chrome or Chromium browser are installed so static exports work:
 
 ```bash
-pip install kaleido
+pip install streamlit kaleido
 sudo apt-get install -y chromium-browser
 ```
 If these dependencies are missing the CLI logs a warning and no image is

--- a/tutorials/TUTORIAL_5_AUTOMATED_BULK_VISUALIZATION.md
+++ b/tutorials/TUTORIAL_5_AUTOMATED_BULK_VISUALIZATION.md
@@ -21,10 +21,10 @@ Sweeps typically contain **50–200 scenarios**, so these scripts are designed t
 loop over large summary tables automatically. Each scenario can generate one or
 more figures without manual intervention.
 
-Install **Kaleido** and a local Chrome or Chromium browser so PNG, PDF and PPTX exports work:
+Install **Streamlit**, **Kaleido** and a local Chrome or Chromium browser so PNG, PDF and PPTX exports work:
 
 ```bash
-pip install kaleido
+pip install streamlit kaleido
 sudo apt-get install -y chromium-browser
 ```
 ### Available Plot Types

--- a/tutorials/TUTORIAL_6_DYNAMIC_AGENT_CONFIGURATION.md
+++ b/tutorials/TUTORIAL_6_DYNAMIC_AGENT_CONFIGURATION.md
@@ -6,6 +6,15 @@
 **📋 Prerequisites**: Completion of Tutorial 5
 **🛠️ Tools**: `pa_core.agents`, `pa_core.config`, parameter sweep engine
 
+### Setup
+
+Install Streamlit and Kaleido plus a local Chrome or Chromium browser so the dashboard and static exports work:
+
+```bash
+pip install streamlit kaleido
+sudo apt-get install -y chromium-browser
+```
+
 ### Step 1 – Create a new agent
 
 ```python

--- a/tutorials/TUTORIAL_7_ADVANCED_THEME_INTEGRATION.md
+++ b/tutorials/TUTORIAL_7_ADVANCED_THEME_INTEGRATION.md
@@ -6,6 +6,15 @@
 **📋 Prerequisites**: Completion of Tutorial 6
 **🛠️ Tools**: `config_theme.yaml`, `config_thresholds.yaml`, `pa_core.viz.theme`
 
+### Setup
+
+Install Streamlit and Kaleido plus a local Chrome or Chromium browser so the dashboard and static exports work:
+
+```bash
+pip install streamlit kaleido
+sudo apt-get install -y chromium-browser
+```
+
 ### Step 1 – Edit the theme files
 
 Adjust colours and fonts in `config_theme.yaml` and set threshold levels in `config_thresholds.yaml`:

--- a/tutorials/TUTORIAL_8_AUTOMATED_STRESS_TESTING.md
+++ b/tutorials/TUTORIAL_8_AUTOMATED_STRESS_TESTING.md
@@ -6,6 +6,15 @@
 **📋 Prerequisites**: Completion of Tutorial 7
 **🛠️ Tools**: Parameter sweep engine, dashboard, `viz.delta_heatmap`
 
+### Setup
+
+Install Streamlit and Kaleido plus a local Chrome or Chromium browser so the dashboard and static exports work:
+
+```bash
+pip install streamlit kaleido
+sudo apt-get install -y chromium-browser
+```
+
 ### Step 1 – Run a stress‑test sweep
 
 Choose a sweep template such as `returns_mode_template.csv` and always pass `--output` so previous results are preserved:

--- a/tutorials/TUTORIAL_9_ENHANCED_EXPORT_BUNDLE.md
+++ b/tutorials/TUTORIAL_9_ENHANCED_EXPORT_BUNDLE.md
@@ -6,6 +6,15 @@
 **📋 Prerequisites**: Completion of Tutorial 8
 **🛠️ Tools**: `viz.export_bundle`, CLI export flags
 
+### Setup
+
+Install Streamlit and Kaleido plus a local Chrome or Chromium browser so the dashboard and static exports work:
+
+```bash
+pip install streamlit kaleido
+sudo apt-get install -y chromium-browser
+```
+
 ### Step 1 – Save multiple figures at once
 
 ```python


### PR DESCRIPTION
## Summary
- unify dependency setup across tutorials
- mention Streamlit, Kaleido and Chromium for static exports

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687eeecb74b08331963897abe90a2ffe