### PR TITLE
Improve tutorial docs per Agents plan

### DIFF
--- a/tutorials/TUTORIAL_10_INTERACTIVE_GALLERY.md
+++ b/tutorials/TUTORIAL_10_INTERACTIVE_GALLERY.md
@@ -35,7 +35,21 @@ Load `GalleryDemo.xlsx` (and `GalleryDemo.parquet` if available) and run the cel
 
 ### Step 3 – Save a gallery
 
-Use `export_bundle.save` or `scripts/visualise.py` to batch export charts for each scenario.
+Use `export_bundle.save` or `scripts/visualise.py` to batch export charts for
+each scenario. Example loop inside the notebook:
+
+```python
+import pandas as pd
+from pa_core.viz import risk_return, export_bundle
+
+df = pd.read_excel("GalleryDemo.xlsx", sheet_name="Summary")
+fig = risk_return.make(df)
+export_bundle.save([fig], "plots/gallery_demo", alt_texts=["Risk-return chart"])
+```
+
+Add a markdown cell describing the scenario and chart before each code block so
+the notebook doubles as documentation. `export_bundle.save` writes PNG, HTML and
+JSON files by default and logs a warning if Chrome or Kaleido are missing.
 
 ---
 

--- a/tutorials/TUTORIAL_6_DYNAMIC_AGENT_CONFIGURATION.md
+++ b/tutorials/TUTORIAL_6_DYNAMIC_AGENT_CONFIGURATION.md
@@ -30,15 +30,31 @@ Register the class in `pa_core/agents/registry.py` by adding it to `_AGENT_MAP`.
 
 ### Step 2 – Extend the configuration
 
-Add a capital field to `ModelConfig` and handle it in `build_from_config`:
+Add a capital field to `ModelConfig` and modify `build_from_config` so the agent is created automatically:
 
 ```python
 class ModelConfig(BaseModel):
     my_agent_capital: float = 0.0
+
+def build_from_config(cfg: ModelConfig) -> list[Agent]:
+    params = [
+        AgentParams("Base", cfg.total_fund_capital, cfg.w_beta_H, cfg.w_alpha_H, {})
+    ]
+    if cfg.my_agent_capital > 0:
+        params.append(
+            AgentParams(
+                "MyAgent",
+                cfg.my_agent_capital,
+                cfg.my_agent_capital / cfg.total_fund_capital,
+                0.0,
+                {},
+            )
+        )
+    # existing sleeves here ...
+    return build_all(params)
 ```
 
-When `my_agent_capital` is positive, create an `AgentParams` entry for `MyAgent`.
-Include the new field in your YAML or CSV template so the CLI knows how much to allocate.
+Include `my_agent_capital` in your YAML or CSV template so the CLI knows how much to allocate. When the value is positive the new agent automatically appears in the outputs.
 
 ### Step 3 – Run a parameter sweep
 

--- a/tutorials/TUTORIAL_9_ENHANCED_EXPORT_BUNDLE.md
+++ b/tutorials/TUTORIAL_9_ENHANCED_EXPORT_BUNDLE.md
@@ -24,6 +24,12 @@ export_bundle.save(figs, "plots/summary")
 ```
 
 The helper writes PNG, HTML and JSON files by default. Use `--alt-text` with the CLI for accessible captions.
+If Chrome or Kaleido are missing the PNG step logs a warning and only the HTML
+and JSON files appear. Check the console output if an image is missing.
+
+For additional formats call the matching helpers or enable the CLI flags:
+`--pdf`, `--pptx` and `--gif` generate extra files for each figure when
+supported.
 
 ### Step 2 – Loop over scenarios
 
@@ -34,6 +40,7 @@ for label, df in sweep_dfs.items():
     figs = [risk_return.make(df), fan.make(paths[label])]
     export_bundle.save(figs, f"plots/{label}")
 ```
+Pass `alt_texts` to label each image and adjust the prefix to control file naming. Each call writes `prefix_1.png`, `prefix_1.html` and so on.
 
 Combine this approach with the CLI export flags to archive an entire run automatically.
 


### PR DESCRIPTION
## Summary
- expand Tutorial 6 with `build_from_config` example for custom agents
- clarify export bundle usage and dependency warnings in Tutorial 9
- show gallery export loop in Tutorial 10 notebook instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef9208b348331aa371df51514991f