### PR TITLE
Improve tutorials per Agents guide

### DIFF
--- a/tutorials/TUTORIAL_4_PROFESSIONAL_BULK_EXPORT_WORKFLOWS.md
+++ b/tutorials/TUTORIAL_4_PROFESSIONAL_BULK_EXPORT_WORKFLOWS.md
@@ -22,6 +22,16 @@ Parameter sweeps often generate **50–200 scenarios** depending on the template
 The export flags handle these automatically, creating one image or slide per
 scenario so large batches require no extra scripting.
 
+### Export flag quick reference
+
+| Flag | Output format | Best for |
+|------|---------------|----------|
+| `--png` | Static images | quick documentation or emails |
+| `--pdf` | PDF pages | immutable compliance reports |
+| `--pptx` | PowerPoint deck | board presentations |
+| `--html` | Interactive page | exploring results offline |
+| `--gif` | Animated path | dynamic slides or demos |
+
 ### 1. Export During a Simulation
 
 Pass one or more export flags when running the CLI. The example below generates a PPTX deck for every scenario in a capital sweep:

--- a/tutorials/TUTORIAL_5_AUTOMATED_BULK_VISUALIZATION.md
+++ b/tutorials/TUTORIAL_5_AUTOMATED_BULK_VISUALIZATION.md
@@ -8,12 +8,22 @@
 
 ### Setup
 
-Ensure `Outputs.xlsx` and the matching `Outputs.parquet` are in the same folder. Convert the `AllReturns` sheet after running the CLI if needed:
+Start by running your parameter sweep **with the `--pivot` flag** so an `AllReturns` sheet is written. This sheet contains the full path data required for advanced plots.
+
+```bash
+python -m pa_core.cli \
+  --params config/capital_mode_template.csv \
+  --mode capital \
+  --output Sweep.xlsx \
+  --pivot
+```
+
+After the run, convert the sheet to Parquet:
 
 ```python
 import pandas as pd
-df = pd.read_excel("Outputs.xlsx", sheet_name="AllReturns")
-df.to_parquet("Outputs.parquet")
+df = pd.read_excel("Sweep.xlsx", sheet_name="AllReturns")
+df.to_parquet("Sweep.parquet")
 ```
 This Parquet file unlocks path-based plots such as `fan` and `path_dist`.
 


### PR DESCRIPTION
## Summary
- show explicit `--pivot` workflow in automated visualization tutorial
- list export flag options in bulk export tutorial

## Testing
- `pre-commit run --files tutorials/TUTORIAL_4_PROFESSIONAL_BULK_EXPORT_WORKFLOWS.md tutorials/TUTORIAL_5_AUTOMATED_BULK_VISUALIZATION.md`

------
https://chatgpt.com/codex/tasks/task_e_687fd714a91c8331806f7c60afa9addd