### PR TITLE
Define volatility annualization factor in calibration agent

### DIFF
--- a/pa_core/data/calibration.py
+++ b/pa_core/data/calibration.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
-import numpy as np
 import pandas as pd
 import yaml
 
@@ -12,6 +11,7 @@ from ..schema import Asset, Correlation, Index
 
 
 MONTHS_PER_YEAR = 12
+VOLATILITY_ANNUALIZATION_FACTOR = MONTHS_PER_YEAR**0.5
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add explicit volatility annualization factor constant in CalibrationAgent
- use the constant when computing annualized sigma

## Testing
- `pytest tests/test_data_calibration.py tests/test_portfolio_aggregator.py tests/test_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68976c7c6e788331b3460ecb709c96d6