### PR TITLE
Add default breach and shortfall probability thresholds

### DIFF
--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -32,7 +32,6 @@ from . import (
 )
 from .agents.registry import build_from_config
 from .backend import set_backend
-from .config import ModelConfig
 from .random import spawn_agent_rngs, spawn_rngs
 from .reporting.console import print_summary
 from .reporting.sweep_excel import export_sweep_results
@@ -83,29 +82,15 @@ LABEL_MAP = {
 
 def create_enhanced_summary(
     returns_map: dict[str, np.ndarray],
-    config: ModelConfig,
     *,
     benchmark: str | None = None,
 ) -> pd.DataFrame:
-    """Create enhanced summary table with ShortfallProb and better defaults."""
+    """Create summary table with standard breach and shortfall defaults."""
 
-    # Start with summary including breach and shortfall probabilities
-    summary = summary_table(
-        returns_map,
-        benchmark=benchmark,
-        breach_threshold=-0.02,  # Default 2% monthly loss threshold
-        shortfall_threshold=(
-            -0.05
-            if hasattr(config, "risk_metrics")
-            and "ShortfallProb" in config.risk_metrics
-            else None
-        ),
-    )
-
-    return summary
+    return summary_table(returns_map, benchmark=benchmark)
 
 
-def print_enhanced_summary(summary: pd.DataFrame, config: ModelConfig) -> None:
+def print_enhanced_summary(summary: pd.DataFrame) -> None:
     """Print enhanced summary with explanations."""
     from rich.console import Console
     from rich.panel import Panel
@@ -313,10 +298,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     returns = simulate_agents(agents, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act)
 
     # Enhanced summary with better defaults and ShortfallProb
-    summary = create_enhanced_summary(returns, cfg, benchmark="Base")
+    summary = create_enhanced_summary(returns, benchmark="Base")
     inputs_dict = {k: raw_params.get(k, "") for k in raw_params}
     raw_returns_dict = {k: pd.DataFrame(v) for k, v in returns.items()}
-    print_enhanced_summary(summary, cfg)
+    print_enhanced_summary(summary)
     export_to_excel(
         inputs_dict,
         summary,

--- a/pa_core/sim/metrics.py
+++ b/pa_core/sim/metrics.py
@@ -99,11 +99,21 @@ def summary_table(
     *,
     periods_per_year: int = 12,
     var_conf: float = 0.95,
-    breach_threshold: float | None = None,
-    shortfall_threshold: float | None = None,
+    breach_threshold: float = -0.02,
+    shortfall_threshold: float = -0.05,
     benchmark: str | None = None,
 ) -> pd.DataFrame:
-    """Return a summary DataFrame of key metrics for each agent."""
+    """Return a summary DataFrame of key metrics for each agent.
+
+    Parameters
+    ----------
+    breach_threshold:
+        Monthly return threshold for :func:`breach_probability`.  Defaults to
+        ``-0.02`` (a 2% loss).
+    shortfall_threshold:
+        Threshold for :func:`shortfall_probability`.  Defaults to ``-0.05``
+        (a 5% annual loss).
+    """
 
     rows = []
     bench_arr = returns_map.get(benchmark) if benchmark else None
@@ -111,16 +121,8 @@ def summary_table(
         ann_ret = annualised_return(arr, periods_per_year)
         ann_vol = annualised_vol(arr, periods_per_year)
         var = value_at_risk(arr, confidence=var_conf)
-        breach = (
-            breach_probability(arr, breach_threshold)
-            if breach_threshold is not None
-            else None
-        )
-        shortfall = (
-            shortfall_probability(arr, shortfall_threshold)
-            if shortfall_threshold is not None
-            else None
-        )
+        breach = breach_probability(arr, breach_threshold)
+        shortfall = shortfall_probability(arr, shortfall_threshold)
         te = (
             tracking_error(arr, bench_arr)
             if bench_arr is not None and name != benchmark

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -70,9 +70,16 @@ def test_breach_probability_path():
 
 
 def test_summary_table_breach():
+    arr = np.array([[0.0, -0.03, 0.03]])
+    stats = summary_table({"Base": arr})
+    assert "BreachProb" in stats.columns
+    assert stats["BreachProb"].iloc[0] == 1 / 3
+
+
+def test_summary_table_breach_custom():
     arr = np.array([[0.0, -0.02, 0.03]])
     stats = summary_table({"Base": arr}, breach_threshold=-0.01)
-    assert "BreachProb" in stats.columns
+    assert stats["BreachProb"].iloc[0] == 1 / 3
 
 
 def test_shortfall_probability_basic():
@@ -83,6 +90,6 @@ def test_shortfall_probability_basic():
 
 def test_summary_table_shortfall():
     arr = np.array([[0.1, -0.2], [0.05, 0.02]])
-    stats = summary_table({"A": arr}, shortfall_threshold=-0.05)
+    stats = summary_table({"A": arr})
     assert "ShortfallProb" in stats.columns
     assert stats["ShortfallProb"].iloc[0] == 0.5


### PR DESCRIPTION
## Summary
- compute breach and shortfall probabilities by default in `summary_table`
- simplify CLI helper to use new defaults and always print metric guidance
- adjust metric tests for new defaults and add coverage for custom threshold override

## Testing
- `./dev.sh lint`
- `./dev.sh typecheck` *(fails: "build_range" unknown import symbol, etc.)*
- `./dev.sh test` *(fails: ImportError: cannot import name 'build_range')*

------
https://chatgpt.com/codex/tasks/task_e_689774111bd483319029f82383d4bd46