### PR TITLE
feat: project covariance to psd

### DIFF
--- a/pa_core/sim/covariance.py
+++ b/pa_core/sim/covariance.py
@@ -1,11 +1,41 @@
 from __future__ import annotations
 
+import warnings
 import numpy as npt
 from numpy.typing import NDArray
 
 from ..backend import xp as np
 
 __all__ = ["build_cov_matrix"]
+
+
+def _is_psd(mat: NDArray[npt.float64], tol: float = 0.0) -> bool:
+    """Return True if matrix is positive semidefinite within tolerance."""
+
+    eigvals = np.linalg.eigvalsh(mat)
+    return float(eigvals.min()) >= -tol
+
+
+def _nearest_psd(mat: NDArray[npt.float64]) -> NDArray[npt.float64]:
+    """Project ``mat`` to the nearest PSD matrix using Higham's method."""
+
+    # Symmetrise input
+    sym_mat = 0.5 * (mat + mat.T)
+    u, s, vt = np.linalg.svd(sym_mat)
+    h = vt.T @ np.diag(s) @ vt
+    a2 = 0.5 * (sym_mat + h)
+    a3 = 0.5 * (a2 + a2.T)
+    if _is_psd(a3):
+        return a3
+    # Add jitter until PSD
+    spacing = np.spacing(np.linalg.norm(mat))
+    eye = np.eye(mat.shape[0])
+    k = 1
+    while not _is_psd(a3):
+        mineig = float(np.min(np.linalg.eigvalsh(a3)))
+        a3 += eye * (-mineig * k**2 + spacing)
+        k += 1
+    return a3
 
 
 def build_cov_matrix(
@@ -20,11 +50,13 @@ def build_cov_matrix(
     sigma_E: float,
     sigma_M: float,
 ) -> NDArray[npt.float64]:
-    """Return 4×4 covariance matrix for (Index, H, E, M).
+    """Return PSD 4×4 covariance matrix for (Index, H, E, M).
 
-    Volatilities are clipped at zero to avoid negative variances and the
-    resulting matrix is symmetrised to guard against numerical drift.
+    Volatilities are clipped at zero to avoid negative variances. The
+    resulting matrix is symmetrised and, if necessary, projected to the
+    nearest positive semidefinite matrix.
     """
+
     sds = np.clip(np.array([idx_sigma, sigma_H, sigma_E, sigma_M]), 0.0, None)
     rho = np.array(
         [
@@ -35,4 +67,13 @@ def build_cov_matrix(
         ]
     )
     cov = np.outer(sds, sds) * rho
-    return 0.5 * (cov + cov.T)  # type: ignore[no-any-return]
+    cov = 0.5 * (cov + cov.T)
+    if _is_psd(cov):
+        return cov
+    adjusted = _nearest_psd(cov)
+    max_delta = float(np.max(np.abs(adjusted - cov)))
+    warnings.warn(
+        f"Covariance matrix was not PSD; projected with max|Δ|={max_delta:.2e}",
+        RuntimeWarning,
+    )
+    return adjusted

--- a/tests/test_covariance_psd.py
+++ b/tests/test_covariance_psd.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+# ruff: noqa: E402
+
+import types
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PKG = types.ModuleType("pa_core")
+PKG.__path__ = [str(Path("pa_core"))]
+sys.modules.setdefault("pa_core", PKG)
+
+from pa_core.sim.covariance import build_cov_matrix
+
+
+def test_build_cov_matrix_psd_projection() -> None:
+    params = dict(
+        rho_idx_H=0.5,
+        rho_idx_E=0.5,
+        rho_idx_M=0.5,
+        rho_H_E=0.5,
+        rho_H_M=-0.5,
+        rho_E_M=-0.5,
+        idx_sigma=0.2,
+        sigma_H=0.2,
+        sigma_E=0.2,
+        sigma_M=0.2,
+    )
+    sds = np.array([0.2, 0.2, 0.2, 0.2])
+    rho = np.array(
+        [
+            [1.0, 0.5, 0.5, 0.5],
+            [0.5, 1.0, 0.5, -0.5],
+            [0.5, 0.5, 1.0, -0.5],
+            [0.5, -0.5, -0.5, 1.0],
+        ]
+    )
+    raw_cov = np.outer(sds, sds) * rho
+    raw_cov = 0.5 * (raw_cov + raw_cov.T)
+    with pytest.warns(RuntimeWarning):
+        cov = build_cov_matrix(**params)
+    eigvals = np.linalg.eigvalsh(cov)
+    assert float(eigvals.min()) >= -1e-8
+    max_delta = float(np.max(np.abs(cov - raw_cov)))
+    assert max_delta < 0.03


### PR DESCRIPTION
## Summary
- ensure covariance matrices are positive semidefinite using Higham projection
- warn when projection occurs and report maximum adjustment
- test PSD projection behaviour

## Testing
- `pytest tests/test_covariance_psd.py`
- `pytest tests/test_simulations.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68979ca8b98c83318dd911af76177c96