### PR TITLE
Add pa command with validate subcommand

### DIFF
--- a/pa_core/pa.py
+++ b/pa_core/pa.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+def main(argv: Sequence[str] | None = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    parser = argparse.ArgumentParser(prog="pa")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("run", help="Run simulation")
+    sub.add_parser("validate", help="Validate scenario YAML")
+    args, remaining = parser.parse_known_args(argv)
+    if args.command == "run":
+        from .cli import main as run_main
+
+        run_main(list(remaining))
+    else:
+        from .validate import main as validate_main
+
+        validate_main(list(remaining))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pa_core/sim/covariance.py
+++ b/pa_core/sim/covariance.py
@@ -21,10 +21,6 @@ def _nearest_psd(mat: NDArray[npt.float64]) -> NDArray[npt.float64]:
 
     # Symmetrise input
     sym_mat = 0.5 * (mat + mat.T)
-    u, s, vt = np.linalg.svd(sym_mat)
-    h = vt.T @ np.diag(s) @ vt
-
-    a2 = 0.5 * (sym_mat + vt.T @ np.diag(s) @ vt)
     eigvals, eigvecs = np.linalg.eigh(sym_mat)
     eigvals_clipped = np.clip(eigvals, 0, None)
     psd_mat = eigvecs @ np.diag(eigvals_clipped) @ eigvecs.T
@@ -36,11 +32,8 @@ def _nearest_psd(mat: NDArray[npt.float64]) -> NDArray[npt.float64]:
     eye = np.eye(mat.shape[0])
     k = 1
     while not _is_psd(a3):
-    while True:
         eigvals = np.linalg.eigvalsh(a3)
         mineig = float(eigvals.min())
-        if mineig >= 0.0:
-            break
         a3 += eye * (-mineig * k**2 + spacing)
         k += 1
     return a3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,6 @@ dependencies = [
     "xlsxwriter",
 ]
 
+[project.scripts]
+pa = "pa_core.pa:main"
+

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,7 @@ setup(
         "xlsxwriter",
     ],
     python_requires=">=3.7",
+    entry_points={
+        "console_scripts": ["pa=pa_core.pa:main"],
+    },
 )


### PR DESCRIPTION
## Summary
- add top-level `pa` command with `run` and `validate` subcommands
- expose `pa` in packaging metadata
- fix PSD projection loop in covariance helper
- test CLI `pa validate`

## Testing
- `./dev.sh ci` *(fails: `load_index_returns` unknown import symbol, and more)*
- `.venv/bin/python -m pytest tests/test_pa_cli_validate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a2ca73708331966e78fcd29f6707