### PR TITLE
feat: add risk metrics agent

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -9,6 +9,8 @@ from .agents import (
     ExternalPAAgent,
     InternalBetaAgent,
     InternalPAAgent,
+    RiskMetricsAgent,
+    RiskMetrics,
 )
 from .agents.registry import build_all as build_agents
 from .agents.registry import build_from_config
@@ -80,6 +82,8 @@ __all__ = [
     "ActiveExtensionAgent",
     "InternalBetaAgent",
     "InternalPAAgent",
+    "RiskMetricsAgent",
+    "RiskMetrics",
     "ModelConfig",
     "load_config",
     "ConfigError",

--- a/pa_core/agents/__init__.py
+++ b/pa_core/agents/__init__.py
@@ -3,6 +3,7 @@ from .base import BaseAgent
 from .external_pa import ExternalPAAgent
 from .internal_beta import InternalBetaAgent
 from .internal_pa import InternalPAAgent
+from .risk_metrics import RiskMetrics, RiskMetricsAgent
 from .types import Agent, AgentParams, Array
 
 __all__ = [
@@ -14,4 +15,6 @@ __all__ = [
     "ActiveExtensionAgent",
     "InternalBetaAgent",
     "InternalPAAgent",
+    "RiskMetricsAgent",
+    "RiskMetrics",
 ]

--- a/pa_core/agents/risk_metrics.py
+++ b/pa_core/agents/risk_metrics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..sim.metrics import (
+    breach_count,
+    breach_probability,
+    conditional_value_at_risk,
+    max_drawdown,
+    time_under_water,
+)
+
+
+Array = NDArray[np.float64]
+
+
+@dataclass
+class RiskMetrics:
+    """Container for common risk statistics."""
+
+    cvar: float
+    max_drawdown: float
+    time_under_water: float
+    breach_probability: float
+    breach_count: int
+
+
+class RiskMetricsAgent:
+    """Compute CVaR, drawdown and breach metrics from return paths."""
+
+    def __init__(
+        self, *, var_conf: float = 0.95, breach_threshold: float = -0.02
+    ) -> None:
+        self.var_conf = var_conf
+        self.breach_threshold = breach_threshold
+
+    def run(self, returns: Array) -> RiskMetrics:
+        """Return risk metrics for the given return paths."""
+
+        cvar = conditional_value_at_risk(returns, confidence=self.var_conf)
+        mdd = max_drawdown(returns)
+        tuw = time_under_water(returns)
+        bprob = breach_probability(returns, self.breach_threshold)
+        bcount = breach_count(returns, self.breach_threshold)
+        return RiskMetrics(cvar, mdd, tuw, bprob, bcount)

--- a/tests/test_risk_metrics_agent.py
+++ b/tests/test_risk_metrics_agent.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+# ruff: noqa: E402
+
+from pathlib import Path
+import types
+import sys
+
+import numpy as np
+import pytest
+
+PKG = types.ModuleType("pa_core")
+PKG.__path__ = [str(Path("pa_core"))]
+sys.modules.setdefault("pa_core", PKG)
+
+from pa_core.agents.risk_metrics import RiskMetricsAgent
+from pa_core.sim.metrics import (
+    breach_count,
+    breach_probability,
+    conditional_value_at_risk,
+    max_drawdown,
+    time_under_water,
+)
+
+
+def test_risk_metrics_agent_matches_functions() -> None:
+    rng = np.random.default_rng(0)
+    returns = rng.normal(0.0, 0.1, size=(100, 12))
+    agent = RiskMetricsAgent(var_conf=0.95, breach_threshold=-0.02)
+    metrics = agent.run(returns)
+    assert metrics.cvar == pytest.approx(
+        conditional_value_at_risk(returns, confidence=0.95)
+    )
+    assert metrics.max_drawdown == pytest.approx(max_drawdown(returns))
+    assert metrics.time_under_water == pytest.approx(time_under_water(returns))
+    assert metrics.breach_probability == pytest.approx(
+        breach_probability(returns, -0.02)
+    )
+    assert metrics.breach_count == breach_count(returns, -0.02)
+
+
+def test_risk_metrics_agent_scaling() -> None:
+    rng = np.random.default_rng(1)
+    base = rng.normal(0.0, 0.05, size=(50, 6))
+    scaled = 2 * base
+    agent = RiskMetricsAgent()
+    m1 = agent.run(base)
+    m2 = agent.run(scaled)
+    assert m2.cvar <= m1.cvar
+    assert m2.max_drawdown <= m1.max_drawdown


### PR DESCRIPTION
## Summary
- add `RiskMetricsAgent` to compute CVaR, max drawdown, time under water and breach stats
- export risk metrics utilities through package init
- test risk metrics agent against underlying metric functions

## Testing
- `pytest tests/test_risk_metrics_agent.py`
- `SKIP=pyright pre-commit run --files pa_core/agents/risk_metrics.py pa_core/agents/__init__.py pa_core/__init__.py tests/test_risk_metrics_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_6897afbe0550833188d8ba8dd7a2016d