### PR TITLE
feat: extend data import agent for flexible formats

### DIFF
--- a/pa_core/data/importer.py
+++ b/pa_core/data/importer.py
@@ -75,7 +75,8 @@ class DataImportAgent:
             long_df = (
                 long_df.set_index("date")
                 .groupby("id")["return"]
-                .apply(lambda s: (1 + s).resample("M").prod() - 1)
+                .transform(lambda s: (1 + s).resample("M").prod() - 1)
+                .dropna()
                 .reset_index()
             )
 

--- a/pa_core/data/importer.py
+++ b/pa_core/data/importer.py
@@ -1,14 +1,35 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal, Set
+
 import pandas as pd
 
 
 class DataImportAgent:
-    """Load asset time series from CSV or Excel and return long-form returns."""
+    """Load asset time series from CSV or Excel and return long-form returns.
 
-    def __init__(self, *, date_col: str = "Date") -> None:
+    Supports both wide and already-long formats and can transform price
+    series to returns. Optionally aggregates higher frequency returns to
+    monthly via compounding.
+    """
+
+    def __init__(
+        self,
+        *,
+        date_col: str = "Date",
+        id_col: str = "Id",
+        value_col: str = "Return",
+        wide: bool = True,
+        value_type: Literal["returns", "prices"] = "returns",
+        to_monthly: bool = False,
+    ) -> None:
         self.date_col = date_col
+        self.id_col = id_col
+        self.value_col = value_col
+        self.wide = wide
+        self.value_type = value_type
+        self.to_monthly = to_monthly
 
     def load(self, path: str | Path) -> pd.DataFrame:
         p = Path(path)
@@ -18,12 +39,44 @@ class DataImportAgent:
             df = pd.read_excel(p)
         else:
             raise ValueError("unsupported file type")
+
         if self.date_col not in df.columns:
             raise ValueError("date column missing")
         df[self.date_col] = pd.to_datetime(df[self.date_col])
-        long_df = df.melt(id_vars=[self.date_col], var_name="id", value_name="return")
-        long_df = (
-            long_df.dropna().sort_values([self.date_col, "id"]).reset_index(drop=True)
+
+        if self.wide:
+            long_df = df.melt(
+                id_vars=[self.date_col],
+                var_name=self.id_col,
+                value_name=self.value_col,
+            )
+        else:
+            required: Set[str] = {self.id_col, self.value_col}
+            missing = required - set(df.columns)
+            if missing:
+                raise ValueError(f"missing columns: {sorted(missing)}")
+            long_df = df[[self.date_col, self.id_col, self.value_col]].copy()
+
+        long_df.dropna(subset=[self.value_col], inplace=True)
+        long_df.sort_values([self.date_col, self.id_col], inplace=True)
+        long_df.rename(
+            columns={self.date_col: "date", self.id_col: "id", self.value_col: "value"},
+            inplace=True,
         )
-        long_df.rename(columns={self.date_col: "date"}, inplace=True)
-        return long_df
+
+        if self.value_type == "prices":
+            long_df = long_df.sort_values(["id", "date"])
+            long_df["value"] = long_df.groupby("id")["value"].pct_change()
+            long_df.dropna(subset=["value"], inplace=True)
+
+        long_df.rename(columns={"value": "return"}, inplace=True)
+
+        if self.to_monthly:
+            long_df = (
+                long_df.set_index("date")
+                .groupby("id")["return"]
+                .apply(lambda s: (1 + s).resample("M").prod() - 1)
+                .reset_index()
+            )
+
+        return long_df.reset_index(drop=True)

--- a/tests/test_data_calibration.py
+++ b/tests/test_data_calibration.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
+from pandas.testing import assert_frame_equal
 
 import types
 import sys
@@ -40,3 +42,31 @@ def test_calibration_wide_csv() -> None:
         c for c in result.correlations if set(c.pair) == {"FUND_A", "FUND_B"}
     )
     assert pair_ab.rho == pytest.approx(corr_ab)
+
+
+def test_import_long_equals_wide() -> None:
+    wide = Path("templates/asset_timeseries_wide_returns.csv")
+    long = Path("templates/asset_timeseries_long_returns.csv")
+
+    df_wide = DataImportAgent(date_col="Date").load(wide)
+    df_long = DataImportAgent(
+        date_col="Date", id_col="Id", value_col="Return", wide=False
+    ).load(long)
+
+    assert_frame_equal(df_wide, df_long)
+
+
+def test_calibration_to_yaml(tmp_path: Path) -> None:
+    path = Path("templates/asset_timeseries_wide_returns.csv")
+    importer = DataImportAgent(date_col="Date")
+    df = importer.load(path)
+    calib = CalibrationAgent(min_obs=1)
+    result = calib.calibrate(df, index_id="SP500_TR")
+
+    out = tmp_path / "library.yaml"
+    calib.to_yaml(result, out)
+    data = yaml.safe_load(out.read_text())
+
+    assert data["index"]["id"] == "SP500_TR"
+    assert any(a["id"] == "FUND_A" for a in data["assets"])
+    assert any({"SP500_TR", "FUND_B"} == set(c["pair"]) for c in data["correlations"])


### PR DESCRIPTION
## Summary
- support wide/long formats, price-to-return conversion, and monthly aggregation in DataImportAgent
- test long vs wide import parity and YAML asset library export

## Testing
- `pytest tests/test_data_calibration.py -q`
- `ruff check pa_core/data/importer.py tests/test_data_calibration.py`


------
https://chatgpt.com/codex/tasks/task_e_6897b6682abc83318b611800e9d58405