### PR TITLE
feat(schema): validate sleeve capital shares

### DIFF
--- a/pa_core/schema.py
+++ b/pa_core/schema.py
@@ -77,6 +77,14 @@ class Scenario(BaseModel):
             raise ValueError(f"missing correlations for pairs: {sorted(missing)}")
         return self
 
+    @model_validator(mode="after")
+    def _check_sleeves(self) -> "Scenario":
+        if self.sleeves:
+            total = sum(s.capital_share for s in self.sleeves.values())
+            if abs(total - 1.0) > WEIGHT_SUM_TOLERANCE:
+                raise ValueError("sleeves capital_share must sum to 1")
+        return self
+
 
 def load_scenario(path: str | Path) -> Scenario:
     data = yaml.safe_load(Path(path).read_text())

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -51,3 +51,18 @@ def test_missing_rho() -> None:
     }
     with pytest.raises(ValueError):
         Scenario.model_validate(data)
+
+
+def test_sleeve_capital_share_sum() -> None:
+    data = {
+        "index": {"id": "IDX", "mu": 0.1, "sigma": 0.2},
+        "assets": [],
+        "correlations": [],
+        "portfolios": [],
+        "sleeves": {
+            "s1": {"alpha_source": "p:1", "capital_share": 0.6},
+            "s2": {"alpha_source": "p:2", "capital_share": 0.5},
+        },
+    }
+    with pytest.raises(ValueError, match="capital_share"):
+        Scenario.model_validate(data)


### PR DESCRIPTION
## Summary
- ensure Scenario sleeves capital_share values sum to 1
- test sleeve capital share validation logic

## Testing
- `pytest tests/test_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_6897b9bab9248331afee6f9d179f2ebc