### PR TITLE
refactor: load theme lazily for dashboard

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4,12 +4,11 @@ from pathlib import Path
 root = Path(__file__).resolve().parents[1]
 sys.path.append(str(root))
 from dashboard.app import apply_theme  # noqa: E402
-from pa_core.viz import theme  # noqa: E402
 
 
 def test_apply_theme(tmp_path):
     cfg = tmp_path / "t.yaml"
     cfg.write_text("colorway: ['#123456']\nfont: Foo\n")
-    apply_theme(cfg)
+    theme = apply_theme(cfg)
     assert theme.TEMPLATE.layout.font.family == "Foo"
     assert list(theme.TEMPLATE.layout.colorway)[0] == "#123456"


### PR DESCRIPTION
## Summary
- load `pa_core.viz.theme` directly from file to avoid heavy package imports
- return theme module from `apply_theme` and adjust unit test

## Testing
- `python -m pytest tests/test_dashboard.py::test_apply_theme -q`
- `python -m pytest -q` *(fails: ImportError cannot import name 'build_range' from 'pa_core.data'; ModuleNotFoundError: No module named 'openpyxl'; ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6897c3c24f2c8331bd67f204531a6413