### PR TITLE
docs: document scenario validation and add example

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -22,9 +22,15 @@ The introductory tutorials demonstrate how to implement a run, interpret these m
 
 ### Quick start
 
-1. **Implement a scenario** – run the model with a CSV or YAML config.
-2. **Interpret the metrics** – review the summary table and check `ShortfallProb` and `TrackingErr`.
-3. **Visualise the results** – launch the dashboard or use `scripts/visualise.py`.
+1. **Create and validate a scenario** – draft a YAML configuration and verify the schema with `pa validate`. A minimal example is provided in `templates/scenario_example.yaml`:
+
+   ```bash
+   pa validate templates/scenario_example.yaml
+   ```
+
+2. **Run the simulation** – execute the model with a CSV parameter sweep or YAML config.
+3. **Interpret the metrics** – review the summary table and check `ShortfallProb` and `TrackingErr`.
+4. **Visualise the results** – launch the dashboard or use `scripts/visualise.py`.
 
 Example quick run:
 

--- a/templates/scenario_example.yaml
+++ b/templates/scenario_example.yaml
@@ -1,0 +1,21 @@
+index:
+  id: IDX
+  label: Sample Index
+  mu: 0.07
+  sigma: 0.15
+assets:
+  - id: FUND_A
+    label: Fund A
+    mu: 0.08
+    sigma: 0.2
+correlations:
+  - pair: [IDX, FUND_A]
+    rho: 0.3
+portfolios:
+  - id: core
+    weights:
+      FUND_A: 1.0
+sleeves:
+  core:
+    alpha_source: p:core
+    capital_share: 1.0


### PR DESCRIPTION
## Summary
- document `pa validate` workflow in UserGuide and include sample YAML scenario
- add minimal `scenario_example.yaml` to templates for schema validation

## Testing
- `pre-commit run --files docs/UserGuide.md templates/scenario_example.yaml`
- `pytest tests/test_schema.py tests/test_validate_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6897cb5f3a2483319087d268a1a400de