### PR TITLE
feat: add pa-validate console script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,4 +72,5 @@ dependencies = [
 
 [project.scripts]
 pa = "pa_core.pa:main"
+pa-validate = "pa_core.validate:main"
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
     ],
     python_requires=">=3.7",
     entry_points={
-        "console_scripts": ["pa=pa_core.pa:main"],
+        "console_scripts": [
+            "pa=pa_core.pa:main",
+            "pa-validate=pa_core.validate:main",
+        ],
     },
 )

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+
+def test_pa_validate_entrypoint() -> None:
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    scripts = data["project"]["scripts"]
+    assert scripts["pa-validate"] == "pa_core.validate:main"
+


### PR DESCRIPTION
## Summary
- expose `pa-validate` console entry point for validating scenario YAMLs
- test entrypoint wiring

## Testing
- `pytest -q` *(fails: cannot import name 'build_range' from 'pa_core.data')*
- `pytest tests/test_entrypoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d85878a48331b73aca86e95318e5