### PR TITLE
feat: add multipage Streamlit skeleton

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,10 +1,8 @@
-"""Streamlit dashboard entrypoint."""
-
+"""Shared utilities and home page for the Streamlit dashboard."""
 from __future__ import annotations
 
 import importlib
 import importlib.util
-import time
 from pathlib import Path
 from types import ModuleType
 
@@ -56,59 +54,10 @@ def load_data(xlsx: str) -> tuple[pd.DataFrame, pd.DataFrame | None]:
 
 
 def main() -> None:
+    """Render the dashboard home page."""
+
     st.title("Portable Alpha Dashboard")
-    xlsx = st.sidebar.text_input("Results file", _DEF_XLSX)
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
-    apply_theme(theme_path)
-    if not Path(xlsx).exists():
-        st.warning(f"File {xlsx} not found")
-        st.stop()
-    summary, paths = load_data(xlsx)
-
-    months = st.sidebar.slider("Months", 1, summary.shape[0], summary.shape[0])
-
-    # Handle missing Config column gracefully
-    if "Config" in summary.columns:
-        config_options = summary["Config"].unique().tolist()
-        agents = st.sidebar.multiselect("Agents", config_options, config_options)
-    else:
-        # If no Config column, use the index (agent names) instead
-        if summary.index.name:
-            agent_options = summary.index.tolist()
-        else:
-            agent_options = (
-                summary.index.tolist() if len(summary.index) > 0 else ["All"]
-            )
-        agents = st.sidebar.multiselect("Agents", agent_options, agent_options)
-    st.sidebar.number_input("Risk-free rate", value=0.0)
-    auto = st.sidebar.checkbox("Auto-refresh")
-    interval = st.sidebar.number_input("Refresh every (s)", 5, 300, 60)
-
-    tab_names = list(PLOTS) + ["Diagnostics"]
-    tabs = st.tabs(tab_names)
-
-    for name, tab in zip(tab_names[:-1], tabs[:-1]):
-        fn = _get_plot_fn(PLOTS[name])
-        with tab:
-            if name == "Headline":
-                st.plotly_chart(fn(summary), use_container_width=True)
-            elif paths is not None:
-                sub_paths = paths[agents].iloc[:, :months]
-                st.plotly_chart(fn(sub_paths), use_container_width=True)
-
-    with tabs[-1]:
-        st.dataframe(summary)
-
-    png = _get_plot_fn(PLOTS["Headline"])(summary).to_image(format="png")
-    st.download_button(
-        "Download PNG", png, file_name="risk_return.png", mime="image/png"
-    )
-    with open(xlsx, "rb") as fh:
-        st.download_button("Download XLSX", fh, file_name=Path(xlsx).name)
-
-    if auto:
-        time.sleep(interval)
-        st.experimental_rerun()
+    st.write("Select a page from the sidebar to begin.")
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point

--- a/dashboard/pages/1_Asset_Library.py
+++ b/dashboard/pages/1_Asset_Library.py
@@ -1,0 +1,32 @@
+"""Asset Library page for uploading and calibrating asset data."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import streamlit as st
+
+from pa_core.data import DataImportAgent
+from dashboard.app import _DEF_THEME, apply_theme
+
+
+def main() -> None:
+    st.title("Asset Library")
+    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    apply_theme(theme_path)
+    uploaded = st.file_uploader("Upload CSV or Excel", type=["csv", "xlsx", "xls"])
+    if uploaded is None:
+        return
+    suffix = Path(uploaded.name).suffix
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(uploaded.getvalue())
+        tmp_path = tmp.name
+    importer = DataImportAgent()
+    df = importer.load(tmp_path)
+    st.dataframe(df)
+    st.json(importer.metadata)
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -1,0 +1,18 @@
+"""Placeholder page for portfolio construction."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from dashboard.app import _DEF_THEME, apply_theme
+
+
+def main() -> None:
+    st.title("Portfolio Builder")
+    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    apply_theme(theme_path)
+    st.write("Coming soon: interactive portfolio builder.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -1,0 +1,18 @@
+"""Placeholder page for guided scenario setup."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from dashboard.app import _DEF_THEME, apply_theme
+
+
+def main() -> None:
+    st.title("Scenario Wizard")
+    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    apply_theme(theme_path)
+    st.write("Coming soon: guided scenario configuration.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -1,0 +1,75 @@
+"""Results page showing simulation outputs and plots."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import streamlit as st
+
+from dashboard.app import (
+    PLOTS,
+    _DEF_THEME,
+    _DEF_XLSX,
+    _get_plot_fn,
+    apply_theme,
+    load_data,
+)
+
+
+def main() -> None:
+    st.title("Results")
+    xlsx = st.sidebar.text_input("Results file", _DEF_XLSX)
+    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    apply_theme(theme_path)
+    if not Path(xlsx).exists():
+        st.warning(f"File {xlsx} not found")
+        st.stop()
+    summary, paths = load_data(xlsx)
+
+    months = st.sidebar.slider("Months", 1, summary.shape[0], summary.shape[0])
+
+    if "Config" in summary.columns:
+        config_options = summary["Config"].unique().tolist()
+        agents = st.sidebar.multiselect("Agents", config_options, config_options)
+    else:
+        if summary.index.name:
+            agent_options = summary.index.tolist()
+        else:
+            agent_options = (
+                summary.index.tolist() if len(summary.index) > 0 else ["All"]
+            )
+        agents = st.sidebar.multiselect("Agents", agent_options, agent_options)
+    st.sidebar.number_input("Risk-free rate", value=0.0)
+    auto = st.sidebar.checkbox("Auto-refresh")
+    interval = st.sidebar.number_input("Refresh every (s)", 5, 300, 60)
+
+    tab_names = list(PLOTS) + ["Diagnostics"]
+    tabs = st.tabs(tab_names)
+
+    for name, tab in zip(tab_names[:-1], tabs[:-1]):
+        fn = _get_plot_fn(PLOTS[name])
+        with tab:
+            if name == "Headline":
+                st.plotly_chart(fn(summary), use_container_width=True)
+            elif paths is not None:
+                sub_paths = paths[agents].iloc[:, :months]
+                st.plotly_chart(fn(sub_paths), use_container_width=True)
+
+    with tabs[-1]:
+        st.dataframe(summary)
+
+    png = _get_plot_fn(PLOTS["Headline"])(summary).to_image(format="png")
+    st.download_button(
+        "Download PNG", png, file_name="risk_return.png", mime="image/png"
+    )
+    with open(xlsx, "rb") as fh:
+        st.download_button("Download XLSX", fh, file_name=Path(xlsx).name)
+
+    if auto:
+        time.sleep(interval)
+        st.experimental_rerun()
+
+
+if __name__ == "__main__":
+    main()

--- a/pa_core/data/loaders.py
+++ b/pa_core/data/loaders.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import pandas as pd
 
@@ -18,13 +18,11 @@ def load_parameters(path: str | Path, label_map: Dict[str, str]) -> Dict[str, An
                 if key == "risk_metrics" and isinstance(val, str):
                     data[key] = [v for v in val.split(";") if v]
                     continue
-                try:
-                    num = pd.to_numeric(val)
-                num = pd.to_numeric(val, errors='coerce')
+                num = cast(Any, pd.to_numeric(val, errors="coerce"))
                 if pd.isna(num):
                     num = val
                 if hasattr(num, "__float__") and "(%)" in friendly:
-                    num = float(num) / 100.0
+                    num = float(cast(float, num)) / 100.0
                 data[key] = num
     elif not df.empty:
         row = df.iloc[0].to_dict()
@@ -34,13 +32,11 @@ def load_parameters(path: str | Path, label_map: Dict[str, str]) -> Dict[str, An
                 if key == "risk_metrics" and isinstance(val, str):
                     data[key] = [v for v in val.split(";") if v]
                     continue
-                try:
-                    num = pd.to_numeric(val)
-                num = pd.to_numeric(val, errors='coerce')
+                num = cast(Any, pd.to_numeric(val, errors="coerce"))
                 if pd.isna(num):
                     num = val
                 if hasattr(num, "__float__") and "(%)" in col:
-                    num = float(num) / 100.0
+                    num = float(cast(float, num)) / 100.0
                 data[key] = num
     return data
 

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -1,0 +1,14 @@
+import runpy
+from pathlib import Path
+
+PAGES = [
+    Path("dashboard/pages/1_Asset_Library.py"),
+    Path("dashboard/pages/2_Portfolio_Builder.py"),
+    Path("dashboard/pages/3_Scenario_Wizard.py"),
+    Path("dashboard/pages/4_Results.py"),
+]
+
+
+def test_pages_import() -> None:
+    for page in PAGES:
+        runpy.run_path(page)


### PR DESCRIPTION
## Summary
- refactor dashboard entry point into a simple home page with shared helpers
- add placeholder Streamlit pages for Asset Library, Portfolio Builder, Scenario Wizard and Results
- harden CSV parameter loader and add smoke test for page modules

## Testing
- `pre-commit run --files dashboard/app.py dashboard/pages/1_Asset_Library.py dashboard/pages/2_Portfolio_Builder.py dashboard/pages/3_Scenario_Wizard.py dashboard/pages/4_Results.py pa_core/data/loaders.py pa_core/data/importer.py tests/test_dashboard_pages.py` *(pyright skipped)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897e75264b88331977c99664eafdbdd