### PR TITLE
refactor: drop CSV params and add converter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ clean:
 	rm -rf htmlcov/
 
 demo:
-	python -m pa_core.cli --params parameters.csv --index sp500tr_fred_divyield.csv
+ pa-convert-params parameters.csv params.yml
+ python -m pa_core.cli --config params.yml --index sp500tr_fred_divyield.csv
 
 dashboard:
 	python -m streamlit run dashboard/app.py

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ options and an optional dashboard:
 
 ```bash
 # CSV parameters
-python -m pa_core.cli --params parameters.csv --index sp500tr_fred_divyield.csv \
+pa-convert-params parameters.csv params.yml
+python -m pa_core.cli --config params.yml --index sp500tr_fred_divyield.csv \
   --mode returns
 
 # or YAML configuration

--- a/dev.sh
+++ b/dev.sh
@@ -108,7 +108,8 @@ dev_setup() {
 run_demo() {
     print_status "Running demo with sample configuration..."
     if [ -f "parameters.csv" ] && [ -f "sp500tr_fred_divyield.csv" ]; then
-        python -m pa_core.cli --params parameters.csv --index sp500tr_fred_divyield.csv
+        pa-convert-params parameters.csv params.yml
+        python -m pa_core.cli --config params.yml --index sp500tr_fred_divyield.csv
         print_success "Demo completed! Check Outputs.xlsx for results"
     else
         print_warning "Sample data files not found. Please ensure parameters.csv and sp500tr_fred_divyield.csv exist"

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -89,7 +89,7 @@ shortfall probability and tracking error in a repeatable workflow.
 
 1. Run `./setup.sh` once to create a virtual environment and install all dependencies.
 2. The script installs **Streamlit** for the dashboard and **Kaleido** for static exports so no extra packages are required.
-3. Copy `config/parameters_template.csv` or `config/params_template.yml` and edit the values to suit your scenario. Launch the CLI with `--params` or `--config` and supply your index returns via `--index`.
+3. Copy `config/params_template.yml` and edit the values to suit your scenario. Legacy CSV files can be converted with `pa-convert-params`. Launch the CLI with `--config` and supply your index returns via `--index`.
 4. **Review defaults** – core correlations and volatilities are locked in `pa_core/config.py` (e.g. `rho_E_M` defaults to `0.0`). Override them in your parameter file only when testing different assumptions.
 5. Set the **Analysis mode** in your parameter file to `returns`, `capital`, `alpha_shares` or `vol_mult`. The templates default to `returns`.
 6. The index CSV must contain a `Date` column and either `Monthly_TR` or `Return` for monthly total returns.
@@ -115,7 +115,8 @@ shortfall probability and tracking error in a repeatable workflow.
 13. Install Chrome or Chromium if you plan to use `--png`, `--pdf` or `--pptx`; these exports rely on the browser together with the **kaleido** Python package (`pip install kaleido`).
 
 ```bash
-python -m pa_core.cli --params parameters.csv --index sp500tr_fred_divyield.csv
+pa-convert-params parameters.csv params.yml
+python -m pa_core.cli --config params.yml --index sp500tr_fred_divyield.csv
 ```
 The run prints a console summary and writes an Excel workbook (`Outputs.xlsx` by default). If you include the `--pivot` flag the raw return paths are also saved in an
 `AllReturns` sheet. The existing sheet order is retained for compatibility. Convert the extra sheet to an `Outputs.parquet` file and keep it alongside the Excel workbook whenever you want the dashboard to display path‑based charts.
@@ -129,11 +130,11 @@ parameter sweep. Replace the index file with your own returns series and set
 | Scenario type               | Template file                          | Example command |
 |-----------------------------|---------------------------------------|-----------------|
 | Single scenario (YAML)      | `config/params_template.yml`           | `python -m pa_core.cli --config params_template.yml --index sp500tr_fred_divyield.csv --output MyRun.xlsx` |
-| Single scenario (CSV)       | `config/parameters_template.csv`       | `python -m pa_core.cli --params parameters_template.csv --index sp500tr_fred_divyield.csv --output MyRun.xlsx` |
-| Capital allocation sweep    | `config/capital_mode_template.csv`     | `python -m pa_core.cli --params config/capital_mode_template.csv --mode capital --index sp500tr_fred_divyield.csv --output CapitalSweep.xlsx` |
-| Returns sensitivity sweep   | `config/returns_mode_template.csv`     | `python -m pa_core.cli --params config/returns_mode_template.csv --mode returns --index sp500tr_fred_divyield.csv --output ReturnsSweep.xlsx` |
-| Alpha shares optimisation   | `config/alpha_shares_mode_template.csv`| `python -m pa_core.cli --params config/alpha_shares_mode_template.csv --mode alpha_shares --index sp500tr_fred_divyield.csv --output AlphaSweep.xlsx` |
-| Volatility stress test      | `config/vol_mult_mode_template.csv`    | `python -m pa_core.cli --params config/vol_mult_mode_template.csv --mode vol_mult --index sp500tr_fred_divyield.csv --output VolStressTest.xlsx` |
+| Single scenario (CSV)       | `config/parameters_template.csv`       | `pa-convert-params config/parameters_template.csv params.yml && python -m pa_core.cli --config params.yml --index sp500tr_fred_divyield.csv --output MyRun.xlsx` |
+| Capital allocation sweep    | `config/capital_mode_template.csv`     | `pa-convert-params config/capital_mode_template.csv capital_mode.yml && python -m pa_core.cli --config capital_mode.yml --mode capital --index sp500tr_fred_divyield.csv --output CapitalSweep.xlsx` |
+| Returns sensitivity sweep   | `config/returns_mode_template.csv`     | `pa-convert-params config/returns_mode_template.csv returns_mode.yml && python -m pa_core.cli --config returns_mode.yml --mode returns --index sp500tr_fred_divyield.csv --output ReturnsSweep.xlsx` |
+| Alpha shares optimisation   | `config/alpha_shares_mode_template.csv`| `pa-convert-params config/alpha_shares_mode_template.csv alpha_mode.yml && python -m pa_core.cli --config alpha_mode.yml --mode alpha_shares --index sp500tr_fred_divyield.csv --output AlphaSweep.xlsx` |
+| Volatility stress test      | `config/vol_mult_mode_template.csv`    | `pa-convert-params config/vol_mult_mode_template.csv vol_mult_mode.yml && python -m pa_core.cli --config vol_mult_mode.yml --mode vol_mult --index sp500tr_fred_divyield.csv --output VolStressTest.xlsx` |
 
 All four sweep modes now run correctly when the appropriate template and `--mode`
 are supplied.

--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -16,7 +16,7 @@ from .agents.registry import build_all as build_agents
 from .agents.registry import build_from_config
 from .backend import get_backend, set_backend
 from .config import ConfigError, ModelConfig, load_config
-from .data import load_index_returns, load_parameters
+from .data import load_index_returns
 from .random import spawn_agent_rngs, spawn_rngs
 from .reporting import export_to_excel, print_summary
 from .reporting.sweep_excel import export_sweep_results
@@ -42,7 +42,6 @@ from .sim.metrics import (
 from .sweep import run_parameter_sweep
 
 __all__ = [
-    "load_parameters",
     "load_index_returns",
     "simulate_financing",
     "prepare_mc_universe",

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -11,7 +11,6 @@ from . import (
     export_to_excel,
     load_config,
     load_index_returns,
-    load_parameters,
 )
 from .agents.registry import build_from_config
 from .backend import set_backend
@@ -22,50 +21,11 @@ from .sim.metrics import (
 )
 from .simulations import simulate_agents
 
-LABEL_MAP = {
-    "Analysis mode": "analysis_mode",
-    "Number of simulations": "N_SIMULATIONS",
-    "Number of months": "N_MONTHS",
-    "External PA capital (mm)": "external_pa_capital",
-    "Active Extension capital (mm)": "active_ext_capital",
-    "Internal PA capital (mm)": "internal_pa_capital",
-    "In-House beta share": "w_beta_H",
-    "In-House alpha share": "w_alpha_H",
-    "External PA alpha fraction": "theta_extpa",
-    "Active share (%)": "active_share",
-    "In-House annual return (%)": "mu_H",
-    "In-House annual vol (%)": "sigma_H",
-    "Alpha-Extension annual return (%)": "mu_E",
-    "Alpha-Extension annual vol (%)": "sigma_E",
-    "External annual return (%)": "mu_M",
-    "External annual vol (%)": "sigma_M",
-    "Corr index–In-House": "rho_idx_H",
-    "Corr index–Alpha-Extension": "rho_idx_E",
-    "Corr index–External": "rho_idx_M",
-    "Corr In-House–Alpha-Extension": "rho_H_E",
-    "Corr In-House–External": "rho_H_M",
-    "Corr Alpha-Extension–External": "rho_E_M",
-    "Internal financing mean (monthly %)": "internal_financing_mean_month",
-    "Internal financing vol (monthly %)": "internal_financing_sigma_month",
-    "Internal monthly spike prob": "internal_spike_prob",
-    "Internal spike multiplier": "internal_spike_factor",
-    "External PA financing mean (monthly %)": "ext_pa_financing_mean_month",
-    "External PA financing vol (monthly %)": "ext_pa_financing_sigma_month",
-    "External PA monthly spike prob": "ext_pa_spike_prob",
-    "External PA spike multiplier": "ext_pa_spike_factor",
-    "Active Ext financing mean (monthly %)": "act_ext_financing_mean_month",
-    "Active Ext financing vol (monthly %)": "act_ext_financing_sigma_month",
-    "Active Ext monthly spike prob": "act_ext_spike_prob",
-    "Active Ext spike multiplier": "act_ext_spike_factor",
-    "Total fund capital (mm)": "total_fund_capital",
-}
 
 
 def main(argv: Optional[Sequence[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Portable Alpha simulation")
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--params", help="Parameters CSV")
-    group.add_argument("--config", help="YAML config file")
+    parser.add_argument("--config", required=True, help="YAML config file")
     parser.add_argument("--index", required=True, help="Index returns CSV")
     parser.add_argument("--output", default="Outputs.xlsx", help="Output workbook")
     parser.add_argument(
@@ -90,12 +50,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ["internal", "external_pa", "active_ext"],
     )
 
-    if args.config:
-        cfg = load_config(args.config)
-    else:
-        raw_params = load_parameters(args.params, LABEL_MAP)
-        cfg = load_config(raw_params)
-    raw_params = cfg.dict()
+    cfg = load_config(args.config)
+    raw_params = cfg.model_dump()
     idx_series = load_index_returns(args.index)
     mu_idx = float(idx_series.mean())
     idx_sigma = float(idx_series.std(ddof=1))

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -28,7 +28,6 @@ from . import (
     export_to_excel,
     load_config,
     load_index_returns,
-    load_parameters,
 )
 from .agents.registry import build_from_config
 from .backend import set_backend
@@ -40,44 +39,6 @@ from .sim.metrics import summary_table
 from .simulations import simulate_agents
 from .sweep import run_parameter_sweep
 
-LABEL_MAP = {
-    "Analysis mode": "analysis_mode",
-    "Number of simulations": "N_SIMULATIONS",
-    "Number of months": "N_MONTHS",
-    "External PA capital (mm)": "external_pa_capital",
-    "Active Extension capital (mm)": "active_ext_capital",
-    "Internal PA capital (mm)": "internal_pa_capital",
-    "In-House beta share": "w_beta_H",
-    "In-House alpha share": "w_alpha_H",
-    "External PA alpha fraction": "theta_extpa",
-    "Active share (%)": "active_share",
-    "In-House annual return (%)": "mu_H",
-    "In-House annual vol (%)": "sigma_H",
-    "Alpha-Extension annual return (%)": "mu_E",
-    "Alpha-Extension annual vol (%)": "sigma_E",
-    "External annual return (%)": "mu_M",
-    "External annual vol (%)": "sigma_M",
-    "Corr index–In-House": "rho_idx_H",
-    "Corr index–Alpha-Extension": "rho_idx_E",
-    "Corr index–External": "rho_idx_M",
-    "Corr In-House–Alpha-Extension": "rho_H_E",
-    "Corr In-House–External": "rho_H_M",
-    "Corr Alpha-Extension–External": "rho_E_M",
-    "Internal financing mean (monthly %)": "internal_financing_mean_month",
-    "Internal financing vol (monthly %)": "internal_financing_sigma_month",
-    "Internal monthly spike prob": "internal_spike_prob",
-    "Internal spike multiplier": "internal_spike_factor",
-    "External PA financing mean (monthly %)": "ext_pa_financing_mean_month",
-    "External PA financing vol (monthly %)": "ext_pa_financing_sigma_month",
-    "External PA monthly spike prob": "ext_pa_spike_prob",
-    "External PA spike multiplier": "ext_pa_spike_factor",
-    "Active Ext financing mean (monthly %)": "act_ext_financing_mean_month",
-    "Active Ext financing vol (monthly %)": "act_ext_financing_sigma_month",
-    "Active Ext monthly spike prob": "act_ext_spike_prob",
-    "Active Ext spike multiplier": "act_ext_spike_factor",
-    "Total fund capital (mm)": "total_fund_capital",
-    "risk_metrics": "risk_metrics",
-}
 
 
 def create_enhanced_summary(
@@ -129,9 +90,7 @@ def print_enhanced_summary(summary: pd.DataFrame) -> None:
 
 def main(argv: Optional[Sequence[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Portable Alpha simulation")
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--params", help="Parameters CSV")
-    group.add_argument("--config", help="YAML config file")
+    parser.add_argument("--config", required=True, help="YAML config file")
     parser.add_argument("--index", required=True, help="Index returns CSV")
     parser.add_argument("--output", default="Outputs.xlsx", help="Output workbook")
     parser.add_argument(
@@ -201,12 +160,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ["internal", "external_pa", "active_ext"],
     )
 
-    if args.config:
-        cfg = load_config(args.config)
-    else:
-        raw_params = load_parameters(args.params, LABEL_MAP)
-        cfg = load_config(raw_params)
-
+    cfg = load_config(args.config)
     cfg = cfg.model_copy(update={"analysis_mode": args.mode})
     raw_params = cfg.model_dump()
     idx_series = load_index_returns(args.index)

--- a/pa_core/data/__init__.py
+++ b/pa_core/data/__init__.py
@@ -1,11 +1,10 @@
 from .importer import DataImportAgent
 from .calibration import CalibrationAgent, CalibrationResult
-from .loaders import load_index_returns, load_parameters
+from .loaders import load_index_returns
 
 __all__ = [
     "DataImportAgent",
     "CalibrationAgent",
     "CalibrationResult",
-    "load_parameters",
     "load_index_returns",
 ]

--- a/pa_core/data/convert.py
+++ b/pa_core/data/convert.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+
+from .loaders import load_parameters
+from ..config import load_config
+
+LABEL_MAP = {
+    "Analysis mode": "analysis_mode",
+    "Number of simulations": "N_SIMULATIONS",
+    "Number of months": "N_MONTHS",
+    "External PA capital (mm)": "external_pa_capital",
+    "Active Extension capital (mm)": "active_ext_capital",
+    "Internal PA capital (mm)": "internal_pa_capital",
+    "In-House beta share": "w_beta_H",
+    "In-House alpha share": "w_alpha_H",
+    "External PA alpha fraction": "theta_extpa",
+    "Active share (%)": "active_share",
+    "In-House annual return (%)": "mu_H",
+    "In-House annual vol (%)": "sigma_H",
+    "Alpha-Extension annual return (%)": "mu_E",
+    "Alpha-Extension annual vol (%)": "sigma_E",
+    "External annual return (%)": "mu_M",
+    "External annual vol (%)": "sigma_M",
+    "Corr index–In-House": "rho_idx_H",
+    "Corr index–Alpha-Extension": "rho_idx_E",
+    "Corr index–External": "rho_idx_M",
+    "Corr In-House–Alpha-Extension": "rho_H_E",
+    "Corr In-House–External": "rho_H_M",
+    "Corr Alpha-Extension–External": "rho_E_M",
+    "Internal financing mean (monthly %)": "internal_financing_mean_month",
+    "Internal financing vol (monthly %)": "internal_financing_sigma_month",
+    "Internal monthly spike prob": "internal_spike_prob",
+    "Internal spike multiplier": "internal_spike_factor",
+    "External PA financing mean (monthly %)": "ext_pa_financing_mean_month",
+    "External PA financing vol (monthly %)": "ext_pa_financing_sigma_month",
+    "External PA monthly spike prob": "ext_pa_spike_prob",
+    "External PA spike multiplier": "ext_pa_spike_factor",
+    "Active Ext financing mean (monthly %)": "act_ext_financing_mean_month",
+    "Active Ext financing vol (monthly %)": "act_ext_financing_sigma_month",
+    "Active Ext monthly spike prob": "act_ext_spike_prob",
+    "Active Ext spike multiplier": "act_ext_spike_factor",
+    "Total fund capital (mm)": "total_fund_capital",
+    "risk_metrics": "risk_metrics",
+}
+
+
+def convert(csv_path: str | Path, yaml_path: str | Path) -> None:
+    """Convert legacy parameters CSV to YAML configuration."""
+
+    raw = load_parameters(csv_path, LABEL_MAP)
+    cfg = load_config(raw)
+    Path(yaml_path).write_text(yaml.safe_dump(cfg.model_dump()))
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Convert parameters CSV to YAML")
+    parser.add_argument("csv", help="Input parameters CSV file")
+    parser.add_argument(
+        "yaml", nargs="?", help="Output YAML file (default: params.yml)"
+    )
+    args = parser.parse_args(argv)
+    out = args.yaml or Path(args.csv).with_suffix(".yml")
+    convert(args.csv, out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,5 @@ dependencies = [
 [project.scripts]
 pa = "pa_core.pa:main"
 pa-validate = "pa_core.validate:main"
+pa-convert-params = "pa_core.data.convert:main"
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "console_scripts": [
             "pa=pa_core.pa:main",
             "pa-validate=pa_core.validate:main",
+            "pa-convert-params=pa_core.data.convert:main",
         ],
     },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,36 +24,17 @@ def test_main_with_yaml(tmp_path):
     assert out_file.exists()
 
 
-def test_main_with_csv(tmp_path):
-    csv_path = tmp_path / "params.csv"
-    csv_content = "Parameter,Value\nNumber of simulations,2\nNumber of months,1\n"
-    csv_path.write_text(csv_content)
-    idx_csv = Path(__file__).resolve().parents[1] / "sp500tr_fred_divyield.csv"
-    out_file = tmp_path / "out.xlsx"
-    main(
-        [
-            "--params",
-            str(csv_path),
-            "--index",
-            str(idx_csv),
-            "--output",
-            str(out_file),
-        ]
-    )
-    assert out_file.exists()
-
-
 def test_main_with_png(tmp_path, monkeypatch):
-    csv_path = tmp_path / "params.csv"
-    csv_content = "Parameter,Value\nNumber of simulations,2\nNumber of months,1\n"
-    csv_path.write_text(csv_content)
+    cfg = {"N_SIMULATIONS": 2, "N_MONTHS": 1}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
     idx_csv = Path(__file__).resolve().parents[1] / "sp500tr_fred_divyield.csv"
     out_file = tmp_path / "out.xlsx"
     monkeypatch.chdir(tmp_path)
     main(
         [
-            "--params",
-            str(csv_path),
+            "--config",
+            str(cfg_path),
             "--index",
             str(idx_csv),
             "--output",
@@ -61,3 +42,4 @@ def test_main_with_png(tmp_path, monkeypatch):
             "--png",
         ]
     )
+    assert out_file.exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,8 @@ from pathlib import Path
 
 import yaml
 
-from pa_core import load_parameters
-from pa_core.cli import LABEL_MAP
 from pa_core.config import ModelConfig, load_config
+from pa_core.data.convert import convert
 
 
 def test_load_yaml(tmp_path):
@@ -64,9 +63,10 @@ def test_template_yaml_loads():
     assert isinstance(cfg, ModelConfig)
 
 
-def test_template_csv_loads(tmp_path):
+def test_csv_to_yaml_conversion(tmp_path):
     root = Path(__file__).resolve().parents[1]
     csv_path = root / "config" / "parameters_template.csv"
-    raw = load_parameters(csv_path, LABEL_MAP)
-    cfg = load_config(raw)
+    out_yaml = tmp_path / "out.yml"
+    convert(csv_path, out_yaml)
+    cfg = load_config(out_yaml)
     assert isinstance(cfg, ModelConfig)

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -11,3 +11,10 @@ def test_pa_validate_entrypoint() -> None:
     scripts = data["project"]["scripts"]
     assert scripts["pa-validate"] == "pa_core.validate:main"
 
+
+def test_pa_convert_entrypoint() -> None:
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text())
+    scripts = data["project"]["scripts"]
+    assert scripts["pa-convert-params"] == "pa_core.data.convert:main"
+


### PR DESCRIPTION
## Summary
- drop legacy `--params` CSV input from CLI
- add `pa-convert-params` utility to convert CSV configs to YAML
- update docs and tests for YAML-only workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897efa1f6fc8331836e621d0e9066b8