### PR TITLE
Add missing test for pa console script entry point

### DIFF
--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -18,3 +18,10 @@ def test_pa_convert_entrypoint() -> None:
     scripts = data["project"]["scripts"]
     assert scripts["pa-convert-params"] == "pa_core.data.convert:main"
 
+
+def test_pa_entrypoint() -> None:
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text())
+    scripts = data["project"]["scripts"]
+    assert scripts["pa"] == "pa_core.pa:main"
+


### PR DESCRIPTION
## Summary
- test that `pa` console script is wired to `pa_core.pa:main`

## Testing
- `pytest tests/test_entrypoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f63b5cf4833190eb28416fd04171