### PR TITLE
Expose PSD projection utility

### DIFF
--- a/tests/test_nearest_psd.py
+++ b/tests/test_nearest_psd.py
@@ -19,7 +19,7 @@ def test_nearest_psd_makes_matrix_psd() -> None:
     mat = np.array([[1.0, 2.0], [2.0, 1.0]])
     psd = nearest_psd(mat)
     eigvals = np.linalg.eigvalsh(psd)
-    assert eigvals.min() >= -1e-8
+    assert eigvals.min() >= EIGENVALUE_TOLERANCE
     assert np.allclose(psd, psd.T)
 
 

--- a/tests/test_nearest_psd.py
+++ b/tests/test_nearest_psd.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+# ruff: noqa: E402
+
+import types
+import sys
+from pathlib import Path
+
+import numpy as np
+
+PKG = types.ModuleType("pa_core")
+PKG.__path__ = [str(Path("pa_core"))]
+sys.modules.setdefault("pa_core", PKG)
+
+from pa_core.sim.covariance import nearest_psd
+
+
+def test_nearest_psd_makes_matrix_psd() -> None:
+    mat = np.array([[1.0, 2.0], [2.0, 1.0]])
+    psd = nearest_psd(mat)
+    eigvals = np.linalg.eigvalsh(psd)
+    assert eigvals.min() >= -1e-8
+    assert np.allclose(psd, psd.T)
+
+
+def test_nearest_psd_leaves_psd_matrix_unchanged() -> None:
+    mat = np.eye(3)
+    psd = nearest_psd(mat)
+    assert np.allclose(psd, mat)

--- a/tests/test_nearest_psd.py
+++ b/tests/test_nearest_psd.py
@@ -11,7 +11,7 @@ import numpy as np
 PKG = types.ModuleType("pa_core")
 PKG.__path__ = [str(Path("pa_core"))]
 sys.modules.setdefault("pa_core", PKG)
-
+import numpy as np
 from pa_core.sim.covariance import nearest_psd
 
 


### PR DESCRIPTION
## Summary
- expose `nearest_psd` helper using Higham's method
- add unit tests for PSD projection helper

## Testing
- `pre-commit run --files pa_core/sim/covariance.py tests/test_nearest_psd.py` *(fails: pyright Cannot access attribute "to_dict" for class "Mapping[str, float]" etc)*
- `python -m pytest tests/test_nearest_psd.py tests/test_covariance_psd.py`


------
https://chatgpt.com/codex/tasks/task_e_68a10cd507e88331b5c15509ddd2de06