### PR TITLE
test: verify pa-validate outputs

### DIFF
--- a/tests/test_validate_cli.py
+++ b/tests/test_validate_cli.py
@@ -1,22 +1,21 @@
 from __future__ import annotations
 
-# ruff: noqa: E402
-
+import sys
+import types
 from pathlib import Path
 
 import pytest
 import yaml
-import types
-import sys
 
+# Stub package to avoid importing heavy dependencies in pa_core.__init__
 PKG = types.ModuleType("pa_core")
 PKG.__path__ = [str(Path("pa_core"))]
 sys.modules.setdefault("pa_core", PKG)
 
-from pa_core.validate import main
+from pa_core import validate  # noqa: E402
 
 
-def test_validate_cli(tmp_path: Path) -> None:
+def test_validate_cli_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     data = {
         "index": {"id": "IDX", "mu": 0.1, "sigma": 0.2},
         "assets": [{"id": "A", "mu": 0.05, "sigma": 0.1}],
@@ -25,17 +24,23 @@ def test_validate_cli(tmp_path: Path) -> None:
     }
     path = tmp_path / "scen.yaml"
     path.write_text(yaml.safe_dump(data))
-    main([str(path)])
+    validate.main([str(path)])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "OK"
+    assert captured.err == ""
 
 
-def test_validate_cli_fail(tmp_path: Path) -> None:
+def test_validate_cli_error(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     data = {
         "index": {"id": "IDX", "mu": 0.1, "sigma": 0.2},
-        "assets": [],
+        "assets": [{"id": "A", "mu": 0.05, "sigma": 0.1}],
         "correlations": [],
-        "portfolios": [{"id": "p1", "weights": {"IDX": 0.5}}],
+        "portfolios": [{"id": "p1", "weights": {"A": 1.0}}],
     }
-    path = tmp_path / "bad.yaml"
+    path = tmp_path / "scen.yaml"
     path.write_text(yaml.safe_dump(data))
-    with pytest.raises(SystemExit):
-        main([str(path)])
+    with pytest.raises(SystemExit) as exc:
+        validate.main([str(path)])
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "missing correlations" in captured.out


### PR DESCRIPTION
## Summary
- strengthen pa-validate CLI tests by checking stdout and exit codes for success and failure scenarios

## Testing
- `python -m ruff check tests/test_validate_cli.py`
- `python -m pyright tests/test_validate_cli.py`
- `pytest tests/test_validate_cli.py tests/test_pa_cli_validate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a125b528688331a5c3bf6782460899