### PR TITLE
Add index pattern for golden scenario test

### DIFF
--- a/tests/golden/test_scenario_smoke.py
+++ b/tests/golden/test_scenario_smoke.py
@@ -2,22 +2,20 @@ from __future__ import annotations
 
 # ruff: noqa: E402
 
-import types
-import sys
 from pathlib import Path
+import sys
 
 import pandas as pd
 import pytest
 
-# Prevent importing full pa_core package with heavy deps
-PKG = types.ModuleType("pa_core")
-PKG.__path__ = [str(Path("pa_core"))]
-sys.modules.setdefault("pa_core", PKG)
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
 
 from pa_core.config import load_config
 from pa_core.orchestrator import SimulatorOrchestrator
 
 
+INDEX_SERIES_PATTERN = [0.01, 0.02, 0.015, 0.03, 0.005, 0.025]
 EXPECTED = {
     "AnnReturn": 0.026798836068948395,
     "AnnVol": 0.0066524784538782465,


### PR DESCRIPTION
## Summary
- define monthly index return pattern used by golden scenario test
- ensure golden scenario test imports project modules correctly

## Testing
- `ruff check tests/golden/test_scenario_smoke.py`
- `pytest` *(fails: ImportError: No module named 'ipywidgets')*
- `pytest tests/golden/test_scenario_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1290734f48331864f5ecc4abbb1b7