### PR TITLE
Define tolerance for nearest PSD test

### DIFF
--- a/tests/test_nearest_psd.py
+++ b/tests/test_nearest_psd.py
@@ -6,13 +6,13 @@ import types
 import sys
 from pathlib import Path
 
-import numpy as np
-
 PKG = types.ModuleType("pa_core")
 PKG.__path__ = [str(Path("pa_core"))]
 sys.modules.setdefault("pa_core", PKG)
 import numpy as np
 from pa_core.sim.covariance import nearest_psd
+
+EIGENVALUE_TOLERANCE = -1e-8
 
 
 def test_nearest_psd_makes_matrix_psd() -> None:


### PR DESCRIPTION
## Summary
- fix nearest_psd test by adding eigenvalue tolerance constant

## Testing
- `ruff check tests/test_nearest_psd.py`
- `pytest tests/test_nearest_psd.py`


------
https://chatgpt.com/codex/tasks/task_e_68a12c29960c833187146867432cec4a