### PR TITLE
Add subprocess tests for YAML validation CLI

### DIFF
--- a/tests/test_validate_cli.py
+++ b/tests/test_validate_cli.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
-import sys
-import types
 from pathlib import Path
 
 import pytest
 import yaml
 
-# Stub package to avoid importing heavy dependencies in pa_core.__init__
-PKG = types.ModuleType("pa_core")
-PKG.__path__ = [str(Path("pa_core"))]
-sys.modules.setdefault("pa_core", PKG)
-
-from pa_core import validate  # noqa: E402
+from pa_core import validate
 
 
 def test_validate_cli_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_validate_cli_subproc.py
+++ b/tests/test_validate_cli_subproc.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.write_text(content)
+
+
+def test_validate_cli_ok(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "scen.yaml"
+    _write_yaml(
+        yaml_path,
+        """
+index:
+  id: IDX
+  mu: 0.1
+  sigma: 0.2
+assets:
+  - id: A
+    mu: 0.05
+    sigma: 0.1
+correlations:
+  - pair: [IDX, A]
+    rho: 0.1
+portfolios:
+  - id: p1
+    weights: {A: 1.0}
+""",
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "pa_core.validate", str(yaml_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "OK"
+
+
+def test_validate_cli_failure(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "bad.yaml"
+    _write_yaml(
+        yaml_path,
+        """
+index:
+  id: IDX
+  mu: 0.1
+  sigma: 0.2
+assets: []
+correlations: []
+portfolios:
+  - id: p1
+    weights: {A: 1.0}
+""",
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "pa_core.validate", str(yaml_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "unknown assets" in result.stdout


### PR DESCRIPTION
## Summary
- expand schema validation coverage with subprocess tests for `pa_core.validate`
- drop test stub module to avoid masking full `pa_core` package

## Testing
- `pytest` *(fails: golden tutorial assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68a12e9328e88331959ecf180f54de8a