### PR TITLE
Validate correlation bounds in covariance builder

### DIFF
--- a/pa_core/sim/covariance.py
+++ b/pa_core/sim/covariance.py
@@ -5,6 +5,7 @@ import numpy as npt
 from numpy.typing import NDArray
 
 from ..backend import xp as np
+from ..schema import CORRELATION_LOWER_BOUND, CORRELATION_UPPER_BOUND
 
 __all__ = ["build_cov_matrix", "nearest_psd"]
 
@@ -62,6 +63,19 @@ def build_cov_matrix(
     resulting matrix is symmetrised and, if necessary, projected to the
     nearest positive semidefinite matrix.
     """
+
+    for name, rho in [
+        ("rho_idx_H", rho_idx_H),
+        ("rho_idx_E", rho_idx_E),
+        ("rho_idx_M", rho_idx_M),
+        ("rho_H_E", rho_H_E),
+        ("rho_H_M", rho_H_M),
+        ("rho_E_M", rho_E_M),
+    ]:
+        if not (CORRELATION_LOWER_BOUND <= rho <= CORRELATION_UPPER_BOUND):
+            raise ValueError(
+                f"{name} must be between {CORRELATION_LOWER_BOUND} and {CORRELATION_UPPER_BOUND}"
+            )
 
     sds = np.clip(np.array([idx_sigma, sigma_H, sigma_E, sigma_M]), 0.0, None)
     rho = np.array(

--- a/tests/test_covariance_psd.py
+++ b/tests/test_covariance_psd.py
@@ -46,3 +46,19 @@ def test_build_cov_matrix_psd_projection() -> None:
     assert eigvals.min() >= -1e-8
     max_delta = float(np.max(np.abs(cov - raw_cov)))
     assert max_delta < 0.03
+
+
+def test_build_cov_matrix_invalid_rho() -> None:
+    with pytest.raises(ValueError):
+        build_cov_matrix(
+            rho_idx_H=1.2,
+            rho_idx_E=0.0,
+            rho_idx_M=0.0,
+            rho_H_E=0.0,
+            rho_H_M=0.0,
+            rho_E_M=0.0,
+            idx_sigma=0.2,
+            sigma_H=0.2,
+            sigma_E=0.2,
+            sigma_M=0.2,
+        )


### PR DESCRIPTION
## Summary
- validate correlation inputs in covariance builder against schema bounds
- add test for invalid correlation detection

## Testing
- `SKIP=pyright pre-commit run --files pa_core/sim/covariance.py tests/test_covariance_psd.py`
- `pytest tests/test_covariance_psd.py`
- `pytest` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a13602f87c833191139af98addff74