### PR TITLE
feat: add config validation option

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -1,6 +1,10 @@
 """Core portable alpha utilities."""
 
-from . import viz
+try:  # pragma: no cover - optional dependency
+    from . import viz
+except Exception:  # pragma: no cover - viz may require heavy deps
+    viz = None
+
 from .agents import (
     ActiveExtensionAgent,
     Agent,

--- a/pa_core/validate.py
+++ b/pa_core/validate.py
@@ -5,15 +5,25 @@ import sys
 from pydantic import ValidationError
 
 from .schema import load_scenario
+from .config import load_config
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Validate scenario YAML")
-    parser.add_argument("path", help="Scenario YAML file")
+    parser = argparse.ArgumentParser(description="Validate YAML against a schema")
+    parser.add_argument(
+        "--schema",
+        choices=["scenario", "config"],
+        default="scenario",
+        help="Type of YAML file to validate",
+    )
+    parser.add_argument("path", help="YAML file")
     args = parser.parse_args(argv)
     try:
-        load_scenario(args.path)
-    except ValidationError as exc:  # pragma: no cover - reached in tests via SystemExit
+        if args.schema == "scenario":
+            load_scenario(args.path)
+        else:
+            load_config(args.path)
+    except (ValidationError, ValueError) as exc:  # pragma: no cover - reached via SystemExit
         print(exc)
         sys.exit(1)
     print("OK")

--- a/tests/test_pa_cli_validate.py
+++ b/tests/test_pa_cli_validate.py
@@ -39,3 +39,18 @@ def test_pa_validate_fail(tmp_path: Path) -> None:
     path.write_text(yaml.safe_dump(data))
     with pytest.raises(SystemExit):
         main(["validate", str(path)])
+
+
+def test_pa_validate_config(tmp_path: Path) -> None:
+    data = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "mu_H": 0.04, "sigma_H": 0.01}
+    path = tmp_path / "conf.yml"
+    path.write_text(yaml.safe_dump(data))
+    main(["validate", "--schema", "config", str(path)])
+
+
+def test_pa_validate_config_fail(tmp_path: Path) -> None:
+    data = {"N_SIMULATIONS": 1}
+    path = tmp_path / "conf.yml"
+    path.write_text(yaml.safe_dump(data))
+    with pytest.raises(SystemExit):
+        main(["validate", "--schema", "config", str(path)])


### PR DESCRIPTION
## Summary
- support scenario or config schemas in `pa_core.validate`
- guard optional viz import in package init
- test config validation via CLI and subproc helper

## Testing
- `pytest tests/test_validate_cli.py tests/test_validate_cli_subproc.py tests/test_pa_cli_validate.py -q`
- `pytest -q` *(fails: No module named 'pa_core', No module named 'plotly', No module named 'streamlit', No module named 'pptx', No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68a1388243fc83319a1b2d4e884fe0cc