### PR TITLE
test: add orchestrator invariants

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import sys
 import types
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -42,3 +43,45 @@ def test_invalid_share_sum() -> None:
                 "risk_metrics": ["ShortfallProb"],
             }
         )
+
+
+def test_te_zero_when_no_alpha() -> None:
+    cfg = load_config(
+        {
+            "N_SIMULATIONS": 5,
+            "N_MONTHS": 12,
+            "w_beta_H": 1.0,
+            "w_alpha_H": 0.0,
+            "external_pa_capital": 0.0,
+            "active_ext_capital": 0.0,
+            "internal_pa_capital": 0.0,
+            "risk_metrics": ["ShortfallProb"],
+        }
+    )
+    idx = pd.Series([0.01, -0.02, 0.015, 0.005] * 3)
+    orch = SimulatorOrchestrator(cfg, idx)
+    returns, summary = orch.run(seed=0)
+    base = returns["Base"]
+    internal_beta = returns["InternalBeta"]
+    np.testing.assert_allclose(base, internal_beta)
+    te_val = summary.loc[summary.Agent == "InternalBeta", "TE"].iloc[0]
+    assert te_val == pytest.approx(0.0, abs=1e-12)
+
+
+def test_orchestrator_reproducible_seed() -> None:
+    cfg = load_config(
+        {
+            "N_SIMULATIONS": 5,
+            "N_MONTHS": 6,
+            "w_beta_H": 0.6,
+            "w_alpha_H": 0.4,
+            "risk_metrics": ["ShortfallProb"],
+        }
+    )
+    idx = pd.Series([0.01, 0.02, 0.015, 0.03, 0.005, 0.025])
+    orch = SimulatorOrchestrator(cfg, idx)
+    ret1, sum1 = orch.run(seed=42)
+    ret2, sum2 = orch.run(seed=42)
+    for key in ret1:
+        np.testing.assert_allclose(ret1[key], ret2[key])
+    pd.testing.assert_frame_equal(sum1, sum2)


### PR DESCRIPTION
## Summary
- test orchestrator TE collapses to zero without alpha
- test orchestrator produces identical results for fixed seeds

## Testing
- `pytest tests/test_orchestrator.py::test_te_zero_when_no_alpha -q`
- `pytest tests/test_orchestrator.py::test_orchestrator_reproducible_seed -q`
- `pytest tests/test_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13dca271c833193f90fa820e2ad1e