### PR TITLE
feat: add dashboard home and packaging scripts

### DIFF
--- a/dashboard/cli.py
+++ b/dashboard/cli.py
@@ -1,0 +1,16 @@
+"""Command-line helpers for launching the dashboard."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    """Launch the Streamlit dashboard."""
+    app_path = Path(__file__).with_name("app.py")
+    subprocess.run(["streamlit", "run", str(app_path)], check=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/dashboard/pages/0_Home.py
+++ b/dashboard/pages/0_Home.py
@@ -1,0 +1,19 @@
+"""Home page for the Streamlit dashboard."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from dashboard.app import _DEF_THEME, apply_theme
+
+
+def main() -> None:
+    """Render the landing page and theme selector."""
+    st.title("Portable Alpha Dashboard")
+    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    apply_theme(theme_path)
+    st.write("Use the sidebar to navigate between pages.")
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/dashboard/pages/0_Home.py
+++ b/dashboard/pages/0_Home.py
@@ -10,7 +10,14 @@ from dashboard.app import _DEF_THEME, apply_theme
 def main() -> None:
     """Render the landing page and theme selector."""
     st.title("Portable Alpha Dashboard")
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+from dashboard.app import apply_theme
+
+DEF_THEME = "default_theme.toml"  # TODO: Set to actual default theme value if known
+
+def main() -> None:
+    """Render the landing page and theme selector."""
+    st.title("Portable Alpha Dashboard")
+    theme_path = st.sidebar.text_input("Theme file", DEF_THEME)
     apply_theme(theme_path)
     st.write("Use the sidebar to navigate between pages.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,4 @@ dependencies = [
 pa = "pa_core.pa:main"
 pa-validate = "pa_core.validate:main"
 pa-convert-params = "pa_core.data.convert:main"
-
+pa-dashboard = "dashboard.cli:main"

--- a/scripts/launch_dashboard.bat
+++ b/scripts/launch_dashboard.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Launch the Streamlit dashboard.
+pa-dashboard %*

--- a/scripts/launch_dashboard.sh
+++ b/scripts/launch_dashboard.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Launch the Streamlit dashboard.
+pa-dashboard "$@"

--- a/scripts/make_portable_zip.py
+++ b/scripts/make_portable_zip.py
@@ -1,0 +1,26 @@
+"""Create a portable Windows zip archive of the project.
+
+This utility is a starting point for generating a self-contained zip
+that can be distributed on Windows systems without an installer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create portable zip archive")
+    parser.add_argument(
+        "--output", default="portable_windows.zip", help="Output zip file name"
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    shutil.make_archive(str(Path(args.output).with_suffix("")), "zip", root)
+
+
+if __name__ == "__main__":  # pragma: no cover - utility script
+    main()

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             "pa=pa_core.pa:main",
             "pa-validate=pa_core.validate:main",
             "pa-convert-params=pa_core.data.convert:main",
+            "pa-dashboard=dashboard.cli:main",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- add Streamlit Home page with theme selector
- introduce pa-dashboard console script and OS launchers
- include utility to build portable Windows zip

## Testing
- `pre-commit run --files dashboard/pages/0_Home.py dashboard/cli.py setup.py pyproject.toml scripts/launch_dashboard.sh scripts/launch_dashboard.bat scripts/make_portable_zip.py` (fails: pyright errors)
- `pytest` (fails: missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68a14052d5b8833188e64b6f8e0e4849