### PR TITLE
feat: add portfolio builder page and packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ This project includes comprehensive VS Code configuration:
 - **Linting**: Automatic ruff linting on save
 - **Extensions**: Recommended extensions will be suggested on first open
 
+### Packaging
+
+Create a portable Windows archive of the project:
+
+```bash
+pa-make-zip --output portable_windows.zip
+```
+
+See `docs/PORTABLE_ZIP_GUIDE.md` for details.
+
 ## Setup
 
 Run the setup script to create a Python virtual environment and install dependencies

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -1,18 +1,71 @@
-"""Placeholder page for portfolio construction."""
+"""Interactive page for building portfolios from an asset library."""
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
 import streamlit as st
+import yaml
 
 from dashboard.app import _DEF_THEME, apply_theme
+from pa_core.schema import Portfolio, load_scenario
+from pa_core.portfolio.aggregator import PortfolioAggregator
 
 
 def main() -> None:
     st.title("Portfolio Builder")
     theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
     apply_theme(theme_path)
-    st.write("Coming soon: interactive portfolio builder.")
+
+    uploaded = st.file_uploader("Upload Asset Library YAML", type=["yaml", "yml"])
+    if uploaded is None:
+        st.info("Upload an asset library YAML to begin.")
+        return
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".yaml") as tmp:
+        tmp.write(uploaded.getvalue())
+        tmp_path = tmp.name
+    try:
+        scenario = load_scenario(tmp_path)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+    if not scenario.assets:
+        st.warning("No assets found in file.")
+        return
+
+    st.subheader("Weights") 
+    weight_inputs: dict[str, float] = {}
+    for asset in scenario.assets:
+        weight_inputs[asset.id] = st.number_input(
+            asset.id, min_value=0.0, max_value=1.0, step=0.01, value=0.0
+        )
+    total = sum(weight_inputs.values())
+    if total == 0:
+        st.warning("Enter weights for at least one asset.")
+        return
+    weights = {k: v / total for k, v in weight_inputs.items() if v > 0}
+    st.write(f"Weights normalised to sum to 1 (total input={total:.2f}).")
+
+    if st.button("Generate Portfolio"):
+        try:
+            scenario.portfolios = [Portfolio(id="portfolio1", weights=weights)]
+            yaml_str = yaml.safe_dump(scenario.model_dump())
+            st.download_button(
+                "Download Portfolio YAML",
+                yaml_str,
+                file_name="portfolio.yaml",
+                mime="application/x-yaml",
+            )
+
+            agg = PortfolioAggregator(scenario.assets, scenario.correlations)
+            mu, sigma = agg.aggregate(weights)
+            st.write(f"Expected return: {mu:.2%}")
+            st.write(f"Expected volatility: {sigma:.2%}")
+        except Exception as exc:  # pragma: no cover - streamlit runtime
+            st.error(str(exc))
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - entry point
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ python_files = ["test_*.py"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["pa_core*", "archive*"]
+include = ["pa_core*", "archive*", "scripts*"]
 
 [build-system]
 requires = ["setuptools>=61"]
@@ -75,3 +75,4 @@ pa = "pa_core.pa:main"
 pa-validate = "pa_core.validate:main"
 pa-convert-params = "pa_core.data.convert:main"
 pa-dashboard = "dashboard.cli:main"
+pa-make-zip = "scripts.make_portable_zip:main"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts packaged with the Portable Alpha project."""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.1.0",
     description="Portable alpha plus active extension model",
     author="Your Name",
-    packages=find_packages(include=["pa_core*", "archive*"]),
+    packages=find_packages(include=["pa_core*", "archive*", "scripts*"]),
     install_requires=[
         "numpy",
         "pandas",
@@ -25,6 +25,7 @@ setup(
             "pa-validate=pa_core.validate:main",
             "pa-convert-params=pa_core.data.convert:main",
             "pa-dashboard=dashboard.cli:main",
+            "pa-make-zip=scripts.make_portable_zip:main",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- add interactive Streamlit portfolio builder with weight inputs and YAML download
- expose portable zip creator via `pa-make-zip` console script
- document packaging command in README

## Testing
- `make lint` *(fails: trailing whitespace, E501, and other existing style issues)*
- `make typecheck` *(fails: missing modules and type errors)*
- `make test` *(fails: missing modules such as plotly)*

------
https://chatgpt.com/codex/tasks/task_e_68a14f70b04c83318855fbf01c46fabb