### PR TITLE
Implement Streamlit scenario wizard and packaging helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,14 @@ dashboard:
 
 # Documentation
 docs:
-	sphinx-build -b html docs/ docs/_build/html
+        sphinx-build -b html docs/ docs/_build/html
+
+# Packaging
+launchers:
+	pa-create-launchers pa pa-dashboard
+
+portable-zip:
+	pa-make-zip --output portable_windows.zip
 
 # Security check
 security:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Create a portable Windows archive of the project:
 
 ```bash
 pa-make-zip --output portable_windows.zip
+# or using Make
+make portable-zip
 ```
 
 See `docs/PORTABLE_ZIP_GUIDE.md` for details.
@@ -84,6 +86,8 @@ Generate Windows `.bat` and macOS `.command` launchers for the console scripts:
 
 ```bash
 python scripts/create_launchers.py pa-dashboard pa
+# or using Make
+make launchers
 ```
 
 ## Setup

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -1,18 +1,51 @@
-"""Placeholder page for guided scenario setup."""
+"""Guided interface for running a full simulation."""
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
 import streamlit as st
 
-from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.app import _DEF_THEME, _DEF_XLSX, apply_theme
+from pa_core import cli as pa_cli
+
+
+def _write_temp(uploaded: st.runtime.uploaded_file_manager.UploadedFile, suffix: str) -> str:
+    """Write *uploaded* content to a temporary file with *suffix* and return path."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(uploaded.getvalue())
+        return tmp.name
 
 
 def main() -> None:
     st.title("Scenario Wizard")
     theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
     apply_theme(theme_path)
-    st.write("Coming soon: guided scenario configuration.")
+
+    st.write("Upload a scenario configuration and index returns to run a simulation.")
+    cfg = st.file_uploader("Scenario YAML", type=["yaml", "yml"])
+    idx = st.file_uploader("Index CSV", type=["csv"])
+    output = st.text_input("Output workbook", _DEF_XLSX)
+
+    if st.button("Run"):
+        if cfg is None or idx is None:
+            st.warning("Please upload both files before running.")
+            return
+
+        cfg_path = _write_temp(cfg, ".yaml")
+        idx_path = _write_temp(idx, ".csv")
+        try:
+            pa_cli.main(["--config", cfg_path, "--index", idx_path, "--output", output])
+        except Exception as exc:  # pragma: no cover - runtime feedback
+            st.error(str(exc))
+        else:
+            st.success(f"Run complete. Results written to {output}.")
+            st.page_link("pages/4_Results.py", label="View results")
+        finally:
+            Path(cfg_path).unlink(missing_ok=True)
+            Path(idx_path).unlink(missing_ok=True)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - entry point
     main()


### PR DESCRIPTION
## Summary
- Add working Scenario Wizard page that runs simulations from uploaded YAML and CSV inputs
- Expose packaging helpers via Makefile targets for launcher generation and portable zip creation
- Document packaging Make targets in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest tests/test_create_launchers.py::test_make_windows_launcher -q` *(fails: cannot import name 'make_mac_launcher')*


------
https://chatgpt.com/codex/tasks/task_e_68a15b94d56c833191298849b1f12164