### PR TITLE
feat: expand dashboard coverage and launcher utilities

### DIFF
--- a/scripts/create_launchers.py
+++ b/scripts/create_launchers.py
@@ -13,26 +13,35 @@ import stat
 from pathlib import Path
 
 
-def _make_windows_launcher(name: str, target: Path) -> None:
-    """Create a ``.bat`` launcher calling *name* in *target* directory."""
+def make_windows_launcher(name: str, target: Path) -> Path:
+    """Create a ``.bat`` launcher calling *name* in *target* directory.
+
+    Returns the path to the created launcher file.
+    """
+    path = target / f"{name}.bat"
     content = f'@echo off\n"{name}" %*\nif %errorlevel% neq 0 exit /b %errorlevel%\n'
-    (target / f"{name}.bat").write_text(content, newline="\r\n")
+    path.write_text(content, newline="\r\n")
+    return path
 
 
-def _make_mac_launcher(name: str, target: Path) -> None:
-    """Create a ``.command`` launcher calling *name* in *target* directory."""
+def make_mac_launcher(name: str, target: Path) -> Path:
+    """Create a ``.command`` launcher calling *name* in *target* directory.
+
+    Returns the path to the created launcher file.
+    """
     path = target / f"{name}.command"
     content = (
-        f'#!/bin/bash\n'
-        f'set -e\n'
-        f'if ! command -v {name} >/dev/null 2>&1; then\n'
+        f"#!/bin/bash\n"
+        f"set -e\n"
+        f"if ! command -v {name} >/dev/null 2>&1; then\n"
         f'  echo "Error: {name} not found in PATH." >&2\n'
-        f'  exit 1\n'
-        f'fi\n'
+        f"  exit 1\n"
+        f"fi\n"
         f'{name} "$@"\n'
     )
     path.write_text(content)
     path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return path
 
 
 def main() -> int:
@@ -49,8 +58,8 @@ def main() -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     for script in args.scripts:
-        _make_windows_launcher(script, out_dir)
-        _make_mac_launcher(script, out_dir)
+        make_windows_launcher(script, out_dir)
+        make_mac_launcher(script, out_dir)
     return 0
 
 

--- a/tests/test_create_launchers.py
+++ b/tests/test_create_launchers.py
@@ -1,17 +1,19 @@
+import sys
 from pathlib import Path
 
-from scripts.create_launchers import _make_mac_launcher, _make_windows_launcher
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+
+from scripts.create_launchers import (
+    make_mac_launcher,
+    make_windows_launcher,
+)  # noqa: E402
 
 
 def test_make_launchers(tmp_path):
-    _make_windows_launcher("pa-dashboard", tmp_path)
-from scripts.create_launchers import make_mac_launcher, make_windows_launcher
-
-
-def test_make_launchers(tmp_path):
+    """Launchers for both platforms should be created in the target directory."""
     make_windows_launcher("pa-dashboard", tmp_path)
-    make_mac_launcher("pa-dashboard", tmp_path)
+    cmd = make_mac_launcher("pa-dashboard", tmp_path)
     assert (tmp_path / "pa-dashboard.bat").exists()
-    cmd = tmp_path / "pa-dashboard.command"
     assert cmd.exists()
     assert cmd.stat().st_mode & 0o111

--- a/tests/test_dashboard_error_handling.py
+++ b/tests/test_dashboard_error_handling.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import pytest
 import sys
 
@@ -17,14 +17,16 @@ def test_dashboard_error_handling_filenotfound():
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
+
             # Import and test the dashboard code logic
-            
+
             # This replicates the exact logic from cli.py
             dashboard_path = Path("dashboard/app.py")
             with pytest.raises(FileNotFoundError, match="Dashboard file not found"):
                 if not dashboard_path.exists():
-                    raise FileNotFoundError(f"Dashboard file not found: {dashboard_path}")
+                    raise FileNotFoundError(
+                        f"Dashboard file not found: {dashboard_path}"
+                    )
         finally:
             os.chdir(original_cwd)
 
@@ -37,18 +39,20 @@ def test_dashboard_error_handling_calledprocesserror():
         dashboard_dir.mkdir()
         dashboard_file = dashboard_dir / "app.py"
         dashboard_file.write_text("# fake streamlit app")
-        
+
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
-            with patch('subprocess.run') as mock_run:
-                mock_run.side_effect = subprocess.CalledProcessError(1, 'streamlit')
-                
+
+            with patch("subprocess.run") as mock_run:
+                mock_run.side_effect = subprocess.CalledProcessError(1, "streamlit")
+
                 # This replicates the logic from cli.py
                 dashboard_path = Path("dashboard/app.py")
-                assert dashboard_path.exists()  # File exists, so we proceed to subprocess
-                
+                assert (
+                    dashboard_path.exists()
+                )  # File exists, so we proceed to subprocess
+
                 with pytest.raises(subprocess.CalledProcessError):
                     subprocess.run(
                         [sys.executable, "-m", "streamlit", "run", "dashboard/app.py"],
@@ -62,23 +66,25 @@ def test_dashboard_error_handling_calledprocesserror():
 def test_dashboard_error_handling_general_exception():
     """Test general exception handling."""
     with tempfile.TemporaryDirectory() as temp_dir:
-        # Create fake dashboard file  
+        # Create fake dashboard file
         dashboard_dir = Path(temp_dir) / "dashboard"
         dashboard_dir.mkdir()
         dashboard_file = dashboard_dir / "app.py"
         dashboard_file.write_text("# fake streamlit app")
-        
+
         original_cwd = os.getcwd()
         try:
             os.chdir(temp_dir)
-            
-            with patch('subprocess.run') as mock_run:
+
+            with patch("subprocess.run") as mock_run:
                 mock_run.side_effect = RuntimeError("Simulated runtime error")
-                
+
                 # This replicates the logic from cli.py
                 dashboard_path = Path("dashboard/app.py")
-                assert dashboard_path.exists()  # File exists, so we proceed to subprocess
-                
+                assert (
+                    dashboard_path.exists()
+                )  # File exists, so we proceed to subprocess
+
                 with pytest.raises(RuntimeError, match="Simulated runtime error"):
                     subprocess.run(
                         [sys.executable, "-m", "streamlit", "run", "dashboard/app.py"],

--- a/tests/test_dashboard_pages.py
+++ b/tests/test_dashboard_pages.py
@@ -1,15 +1,12 @@
 import runpy
 import sys
-import types
 from pathlib import Path
 
 root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(root))
-PKG = types.ModuleType("pa_core")
-PKG.__path__ = [str(root / "pa_core")]
-sys.modules.setdefault("pa_core", PKG)
 
 PAGES = [
+    Path("dashboard/app.py"),
     Path("dashboard/pages/1_Asset_Library.py"),
     Path("dashboard/pages/2_Portfolio_Builder.py"),
     Path("dashboard/pages/3_Scenario_Wizard.py"),

--- a/tests/test_dashboard_run_history.py
+++ b/tests/test_dashboard_run_history.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from pa_core.dashboard.app import load_history
+from dashboard.app import load_history
 
 
 def test_load_history(tmp_path):


### PR DESCRIPTION
## Summary
- add public `make_windows_launcher` and `make_mac_launcher` helpers
- exercise Streamlit home page and run-history utilities in tests
- verify launcher files are created for both platforms

## Testing
- `pre-commit run --files scripts/create_launchers.py tests/test_create_launchers.py tests/test_dashboard_pages.py tests/test_dashboard_run_history.py tests/test_dashboard_error_handling.py` *(fails: pyright errors in existing modules)*
- `pytest tests/test_create_launchers.py tests/test_dashboard_pages.py tests/test_dashboard_run_history.py tests/test_dashboard_error_handling.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1650e9f388331b6845b95cf2a1289