### PR TITLE
feat: add reproducibility manifest writer

### DIFF
--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+import json
 from pathlib import Path
 
 import streamlit as st
@@ -26,6 +27,13 @@ def main() -> None:
         st.warning(f"File {xlsx} not found")
         st.stop()
     summary, paths = load_data(xlsx)
+
+    manifest_path = Path(xlsx).with_name("manifest.json")
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+        seed = manifest.get("seed")
+        if seed is not None:
+            st.caption(f"Seed: {seed}")
 
     months = st.sidebar.slider("Months", 1, summary.shape[0], summary.shape[0])
 

--- a/pa_core/manifest.py
+++ b/pa_core/manifest.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import hashlib
+import yaml
+
+
+@dataclass
+class Manifest:
+    git_commit: str
+    timestamp: str
+    seed: int | None
+    config: Mapping[str, Any]
+    data_files: Mapping[str, str]
+    cli_args: Mapping[str, Any]
+
+
+class ManifestWriter:
+    """Write a reproducibility manifest for simulation runs."""
+
+    def __init__(self, path: str | Path = "manifest.json") -> None:
+        self.path = Path(path)
+
+    @staticmethod
+    def _hash_file(path: str | Path) -> str:
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            h.update(fh.read())
+        return h.hexdigest()
+
+    def write(
+        self,
+        *,
+        config_path: str | Path,
+        data_files: Sequence[str | Path],
+        seed: int | None,
+        cli_args: Mapping[str, Any],
+    ) -> None:
+        """Write manifest to ``self.path``."""
+
+        repo_root = Path(__file__).resolve().parents[1]
+        try:
+            commit = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True
+            ).strip()
+        except Exception:
+            commit = "unknown"
+        cfg = yaml.safe_load(Path(config_path).read_text())
+        hashes = {
+            str(Path(p)): self._hash_file(p)
+            for p in data_files
+            if Path(p).exists()
+        }
+        manifest = Manifest(
+            git_commit=commit,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            seed=seed,
+            config=cfg,
+            data_files=hashes,
+            cli_args=dict(cli_args),
+        )
+        self.path.write_text(json.dumps(asdict(manifest), indent=2))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import json
+import yaml
+
+from pa_core.cli import main
+
+
+def test_manifest_written(tmp_path):
+    cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    idx_csv = Path(__file__).resolve().parents[1] / "sp500tr_fred_divyield.csv"
+    out_file = tmp_path / "out.xlsx"
+    seed = 123
+
+    main(
+        [
+            "--config",
+            str(cfg_path),
+            "--index",
+            str(idx_csv),
+            "--output",
+            str(out_file),
+            "--seed",
+            str(seed),
+        ]
+    )
+
+    manifest_path = out_file.with_name("manifest.json")
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["seed"] == seed
+    assert manifest["config"]["N_SIMULATIONS"] == 1
+    assert str(cfg_path) in manifest["data_files"]


### PR DESCRIPTION
## Summary
- generate manifest.json capturing commit, config, seed and inputs
- surface run seed in Streamlit results page
- test manifest writing via CLI

## Testing
- `python -m pytest tests/test_manifest.py tests/test_cli.py::test_main_with_yaml tests/test_cli.py::test_main_with_png -q`
- `python -m pytest tests/test_dashboard_pages.py::test_pages_import -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32f056e808331bc01266cf2a08994