### PR TITLE
Add stress scenario presets and CLI toggle

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -44,6 +44,7 @@ from .sim.metrics import (
     value_at_risk,
 )
 from .sweep import run_parameter_sweep, run_parameter_sweep_cached, sweep_results_to_dataframe
+from .stress import STRESS_PRESETS, apply_stress_preset
 from .validators import (
     ValidationResult,
     PSDProjectionInfo,
@@ -74,6 +75,8 @@ __all__ = [
     "run_parameter_sweep",
     "run_parameter_sweep_cached",
     "sweep_results_to_dataframe",
+    "apply_stress_preset",
+    "STRESS_PRESETS",
     "tracking_error",
     "value_at_risk",
     "compound",

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -35,6 +35,7 @@ from . import (
     load_index_returns,
 )
 from .agents.registry import build_from_config
+from .stress import STRESS_PRESETS, apply_stress_preset
 from .backend import set_backend
 from .random import spawn_agent_rngs, spawn_rngs
 from .reporting.console import print_summary
@@ -44,6 +45,7 @@ from .sim.metrics import summary_table
 from .simulations import simulate_agents
 from .sweep import run_parameter_sweep
 from .manifest import ManifestWriter
+
 def create_enhanced_summary(
     returns_map: dict[str, np.ndarray],
     *,
@@ -97,6 +99,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         choices=["capital", "returns", "alpha_shares", "vol_mult"],
         default="returns",
         help="Parameter sweep analysis mode",
+    )
+    parser.add_argument(
+        "--stress-preset",
+        choices=sorted(STRESS_PRESETS.keys()),
+        help="Apply predefined stress scenario",
     )
     parser.add_argument(
         "--pivot",
@@ -167,6 +174,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     cfg = load_config(args.config)
     cfg = cfg.model_copy(update={"analysis_mode": args.mode})
+    if args.stress_preset:
+        cfg = apply_stress_preset(cfg, args.stress_preset)
     raw_params = cfg.model_dump()
     idx_series = load_index_returns(args.index)
 

--- a/pa_core/stress.py
+++ b/pa_core/stress.py
@@ -1,0 +1,68 @@
+"""Stress scenario presets for Portable Alpha model.
+
+Provides predefined overrides for common stress tests such as
+liquidity squeezes or volatility regime shifts.  Presets return a new
+``ModelConfig`` instance with the modifications applied.
+"""
+from __future__ import annotations
+
+from typing import Callable, Dict, Mapping
+
+from .config import ModelConfig
+
+Preset = Mapping[str, float | Callable[[ModelConfig], float]]
+
+
+STRESS_PRESETS: Dict[str, Preset] = {
+    "liquidity_squeeze": {
+        "internal_financing_sigma_month": 0.05,
+        "ext_pa_financing_sigma_month": 0.05,
+        "act_ext_financing_sigma_month": 0.05,
+        "internal_spike_prob": 0.1,
+        "internal_spike_factor": 5.0,
+        "ext_pa_spike_prob": 0.1,
+        "ext_pa_spike_factor": 5.0,
+        "act_ext_spike_prob": 0.1,
+        "act_ext_spike_factor": 5.0,
+    },
+    "correlation_breakdown": {
+        "rho_idx_H": 0.95,
+        "rho_idx_E": 0.95,
+        "rho_idx_M": 0.95,
+        "rho_H_E": 0.95,
+        "rho_H_M": 0.95,
+        "rho_E_M": 0.95,
+    },
+    "2008_vol_regime": {
+        "sigma_H": lambda cfg: cfg.sigma_H * 3,
+        "sigma_E": lambda cfg: cfg.sigma_E * 3,
+        "sigma_M": lambda cfg: cfg.sigma_M * 3,
+    },
+    "2020_gap_day": {
+        "mu_H": -0.20,
+        "mu_E": -0.25,
+        "mu_M": -0.15,
+    },
+}
+
+
+def apply_stress_preset(cfg: ModelConfig, name: str) -> ModelConfig:
+    """Return a copy of ``cfg`` with stress preset ``name`` applied.
+
+    Parameters
+    ----------
+    cfg:
+        Base configuration.
+    name:
+        Key in :data:`STRESS_PRESETS`.
+    """
+    if name not in STRESS_PRESETS:
+        raise KeyError(f"Unknown stress preset: {name}")
+    preset = STRESS_PRESETS[name]
+    updates = {
+        k: (v(cfg) if callable(v) else v) for k, v in preset.items()
+    }
+    return cfg.model_copy(update=updates)
+
+__all__ = ["STRESS_PRESETS", "apply_stress_preset"]
+

--- a/tests/test_stress_presets.py
+++ b/tests/test_stress_presets.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pa_core.config import ModelConfig
+from pa_core.stress import STRESS_PRESETS, apply_stress_preset
+
+
+def _base_cfg() -> ModelConfig:
+    return ModelConfig(N_SIMULATIONS=1, N_MONTHS=1)
+
+
+def test_liquidity_squeeze_overrides_financing():
+    cfg = _base_cfg()
+    stressed = apply_stress_preset(cfg, "liquidity_squeeze")
+    assert stressed.internal_spike_prob == pytest.approx(0.1)
+    assert stressed.ext_pa_spike_factor == pytest.approx(5.0)
+
+
+def test_2008_vol_regime_triples_vol():
+    cfg = _base_cfg()
+    stressed = apply_stress_preset(cfg, "2008_vol_regime")
+    assert stressed.sigma_H == pytest.approx(cfg.sigma_H * 3)
+    assert stressed.sigma_E == pytest.approx(cfg.sigma_E * 3)
+
+
+def test_invalid_preset_raises():
+    cfg = _base_cfg()
+    with pytest.raises(KeyError):
+        apply_stress_preset(cfg, "unknown")
+


### PR DESCRIPTION
## Summary
- define preset stress scenarios (liquidity squeeze, correlation breakdown, 2008 vol regime, 2020 gap day)
- add CLI flag to apply stress presets
- expose preset utilities and test coverage

## Testing
- `python -m pytest tests/test_stress_presets.py -q`
- `python -m pytest -q` *(fails: tests/test_data_calibration.py::test_import_daily_returns_to_monthly_returns, tests/test_data_calibration.py::test_daily_to_monthly_robust_frequency_handling)*

------
https://chatgpt.com/codex/tasks/task_e_68b35219de988331b21448de7bd71fb7