### PR TITLE
Add sensitivity helper and tornado chart

### DIFF
--- a/pa_core/sensitivity.py
+++ b/pa_core/sensitivity.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import pandas as pd
+
+
+def one_factor_deltas(
+    base: pd.DataFrame, scenarios: Mapping[str, pd.DataFrame], *, value: str = "Sharpe"
+) -> pd.Series:
+    """Compute one-factor deltas for ``value`` relative to ``base``.
+
+    Parameters
+    ----------
+    base: DataFrame
+        Baseline results containing ``value`` column.
+    scenarios: Mapping[str, DataFrame]
+        Mapping of scenario name to results with only one parameter changed.
+    value: str
+        Column name to compute delta on. Defaults to ``"Sharpe"``.
+
+    Returns
+    -------
+    Series
+        Delta for each scenario sorted by absolute magnitude.
+    """
+    if value not in base:
+        raise KeyError(f"{value} column missing from base DataFrame")
+
+    base_val = float(base[value].mean())
+    deltas: dict[str, float] = {}
+    for name, df in scenarios.items():
+        if value not in df:
+            raise KeyError(f"{value} column missing from scenario '{name}'")
+        deltas[name] = float(df[value].mean()) - base_val
+
+    series = pd.Series(deltas)
+    return series.reindex(series.abs().sort_values(ascending=False).index)

--- a/pa_core/viz/__init__.py
+++ b/pa_core/viz/__init__.py
@@ -69,6 +69,7 @@ from . import (
     te_cvar_scatter,
     theme,
     triple_scatter,
+    tornado,
     violin,
     waterfall,
     weighted_stack,
@@ -147,5 +148,6 @@ __all__ = [
     "seasonality_heatmap",
     "spark_matrix",
     "triple_scatter",
+    "tornado",
     "weighted_stack",
 ]

--- a/pa_core/viz/tornado.py
+++ b/pa_core/viz/tornado.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import pandas as pd
+import plotly.graph_objects as go
+
+try:  # theme is optional when loading module standalone
+    from . import theme
+
+    TEMPLATE = theme.TEMPLATE
+except Exception:  # pragma: no cover - fallback when package not fully available
+    TEMPLATE = None
+
+
+def make(contrib: Mapping[str, float] | pd.Series) -> go.Figure:
+    """Return tornado chart sorted by absolute contribution.
+
+    Parameters
+    ----------
+    contrib: Mapping[str, float] or Series
+        Mapping of parameter name to delta contribution.
+    """
+    if isinstance(contrib, pd.Series):
+        series = contrib.astype(float)
+    else:
+        series = pd.Series({k: float(v) for k, v in contrib.items()})
+
+    series = series.reindex(series.abs().sort_values(ascending=False).index)
+    layout = dict(template=TEMPLATE) if TEMPLATE else {}
+    fig = go.Figure(layout=layout)
+    fig.add_trace(go.Bar(x=series.values, y=series.index, orientation="h"))
+    fig.update_layout(xaxis_title="Delta", yaxis_title="Parameter")
+    return fig

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,17 +1,6 @@
-import importlib.util
-import pathlib
-
 import pandas as pd
 import pytest
-
-spec = importlib.util.spec_from_file_location(
-    "sensitivity",
-    pathlib.Path(__file__).resolve().parents[1] / "pa_core" / "sensitivity.py",
-)
-sensitivity = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(sensitivity)
-
-
+from pa_core import sensitivity
 def test_one_factor_deltas():
     base = pd.DataFrame({"Sharpe": [1.0]})
     scenarios = {

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,23 @@
+import importlib.util
+import pathlib
+
+import pandas as pd
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "sensitivity",
+    pathlib.Path(__file__).resolve().parents[1] / "pa_core" / "sensitivity.py",
+)
+sensitivity = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sensitivity)
+
+
+def test_one_factor_deltas():
+    base = pd.DataFrame({"Sharpe": [1.0]})
+    scenarios = {
+        "mu": pd.DataFrame({"Sharpe": [1.2]}),
+        "sigma": pd.DataFrame({"Sharpe": [0.9]}),
+    }
+    deltas = sensitivity.one_factor_deltas(base, scenarios)
+    assert pytest.approx(deltas["mu"], rel=1e-6) == 0.2
+    assert pytest.approx(deltas["sigma"], rel=1e-6) == -0.1

--- a/tests/test_tornado_viz.py
+++ b/tests/test_tornado_viz.py
@@ -1,0 +1,18 @@
+import importlib.util
+import pathlib
+
+import plotly.graph_objects as go
+
+spec = importlib.util.spec_from_file_location(
+    "tornado",
+    pathlib.Path(__file__).resolve().parents[1] / "pa_core" / "viz" / "tornado.py",
+)
+tornado = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tornado)
+
+
+def test_tornado_chart():
+    contrib = {"A": 0.1, "B": -0.05, "C": 0.02}
+    fig = tornado.make(contrib)
+    assert isinstance(fig, go.Figure)
+    fig.to_json()

--- a/tests/test_tornado_viz.py
+++ b/tests/test_tornado_viz.py
@@ -1,16 +1,5 @@
-import importlib.util
-import pathlib
-
 import plotly.graph_objects as go
-
-spec = importlib.util.spec_from_file_location(
-    "tornado",
-    pathlib.Path(__file__).resolve().parents[1] / "pa_core" / "viz" / "tornado.py",
-)
-tornado = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(tornado)
-
-
+from pa_core.viz import tornado
 def test_tornado_chart():
     contrib = {"A": 0.1, "B": -0.05, "C": 0.02}
     fig = tornado.make(contrib)


### PR DESCRIPTION
## Summary
- add `one_factor_deltas` utility for computing single-parameter impacts
- add tornado chart visualization and expose in viz package
- test sensitivity deltas and tornado chart rendering

## Testing
- `pytest tests/test_sensitivity.py tests/test_tornado_viz.py -q`
- `pre-commit run --files pa_core/sensitivity.py pa_core/viz/tornado.py pa_core/viz/__init__.py tests/test_sensitivity.py tests/test_tornado_viz.py` *(fails: pyright - unexpected indent and missing modules in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b36077c784833180f4e69a97c23cfc