### PR TITLE
Add constraint-aware sleeve suggestor

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -22,8 +22,11 @@ from .backend import get_backend, set_backend
 from .config import ConfigError, ModelConfig, load_config
 from .data import load_index_returns
 from .random import spawn_agent_rngs, spawn_rngs
-from .reporting import export_to_excel, print_summary
-from .reporting.sweep_excel import export_sweep_results
+try:  # pragma: no cover - optional heavy deps
+    from .reporting import export_to_excel, print_summary
+    from .reporting.sweep_excel import export_sweep_results
+except Exception:  # pragma: no cover
+    export_to_excel = print_summary = export_sweep_results = None
 from .run_flags import RunFlags
 from .orchestrator import SimulatorOrchestrator
 from .sim import (

--- a/pa_core/data/importer.py
+++ b/pa_core/data/importer.py
@@ -161,5 +161,10 @@ class DataImportAgent:
     def from_template(cls, path: str | Path) -> "DataImportAgent":
         """Create an instance from a previously saved mapping template."""
 
-            raise TypeError(f"Invalid template file: expected YAML dictionary but got {type(data).__name__}")
+        p = Path(path)
+        data = yaml.safe_load(p.read_text())
+        if not isinstance(data, dict):
+            raise TypeError(
+                f"Invalid template file: expected YAML dictionary but got {type(data).__name__}"
+            )
         return cls(**data)

--- a/pa_core/sleeve_suggestor.py
+++ b/pa_core/sleeve_suggestor.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .config import ModelConfig
+from .orchestrator import SimulatorOrchestrator
+
+
+def suggest_sleeve_sizes(
+    cfg: ModelConfig,
+    idx_series: pd.Series,
+    *,
+    max_te: float,
+    max_breach: float,
+    max_cvar: float,
+    step: float = 0.25,
+    seed: int | None = None,
+) -> pd.DataFrame:
+    """Suggest sleeve allocations that respect risk constraints.
+
+    Performs a simple grid search over capital allocations for the three
+    sleeves (external portable alpha, active extension and internal PA).
+    Combinations where any sleeve breaches the supplied risk limits are
+    discarded.
+
+    Parameters
+    ----------
+    cfg:
+        Base :class:`~pa_core.config.ModelConfig` used as a template.
+    idx_series:
+        Benchmark return series used by :class:`SimulatorOrchestrator`.
+    max_te:
+        Maximum allowed tracking error per sleeve.
+    max_breach:
+        Maximum allowed breach probability per sleeve.
+    max_cvar:
+        Absolute CVaR cap per sleeve.
+    step:
+        Grid step as a fraction of ``total_fund_capital``.
+    seed:
+        Optional random seed for reproducibility.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Table of feasible capital combinations and associated metrics.
+    """
+
+    total = cfg.total_fund_capital
+    grid = np.arange(0.0, total + 1e-9, total * step)
+    records: list[dict[str, float]] = []
+    for ext_cap in grid:
+        for act_cap in grid:
+            int_cap = total - ext_cap - act_cap
+            if int_cap < 0:
+                continue
+            test_cfg = cfg.model_copy(
+                update={
+                    "external_pa_capital": float(ext_cap),
+                    "active_ext_capital": float(act_cap),
+                    "internal_pa_capital": float(int_cap),
+                }
+            )
+            orch = SimulatorOrchestrator(test_cfg, idx_series)
+            _, summary = orch.run(seed=seed)
+            meets = True
+            metrics: dict[str, float] = {}
+            for agent in ["ExternalPA", "ActiveExt", "InternalPA"]:
+                sub = summary[summary["Agent"] == agent]
+                if sub.empty:
+                    continue
+                row = sub.iloc[0]
+                te = row["TE"] if row["TE"] is not None else 0.0
+                bprob = row["BreachProb"]
+                cvar = row["CVaR"]
+                metrics[f"{agent}_TE"] = te
+                metrics[f"{agent}_BreachProb"] = bprob
+                metrics[f"{agent}_CVaR"] = cvar
+                if te > max_te or bprob > max_breach or abs(cvar) > max_cvar:
+                    meets = False
+            if meets:
+                record = {
+                    "external_pa_capital": float(ext_cap),
+                    "active_ext_capital": float(act_cap),
+                    "internal_pa_capital": float(int_cap),
+                }
+                record.update(metrics)
+                records.append(record)
+    return pd.DataFrame.from_records(records)

--- a/pa_core/validators.py
+++ b/pa_core/validators.py
@@ -145,6 +145,10 @@ def load_margin_schedule(path: Path) -> pd.DataFrame:
     frame is sorted by term to support interpolation.
     """
 
+    df = pd.read_csv(path)
+    required = {"term", "multiplier"}
+    missing = required - set(df.columns)
+    if missing:
         raise ValueError(f"Margin schedule CSV file missing required columns: {missing}")
     return df.sort_values("term")
 

--- a/tests/test_sleeve_suggestor.py
+++ b/tests/test_sleeve_suggestor.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pandas as pd
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from pa_core.config import load_config
 from pa_core.sleeve_suggestor import suggest_sleeve_sizes

--- a/tests/test_sleeve_suggestor.py
+++ b/tests/test_sleeve_suggestor.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from pa_core.config import load_config
+from pa_core.sleeve_suggestor import suggest_sleeve_sizes
+
+
+def test_suggest_sleeve_sizes_returns_feasible():
+    cfg = load_config('test_params.yml')
+    cfg = cfg.model_copy(update={"N_SIMULATIONS": 50})
+    idx_series = pd.Series([0.0] * cfg.N_MONTHS)
+    df = suggest_sleeve_sizes(
+        cfg,
+        idx_series,
+        max_te=0.02,
+        max_breach=0.5,
+        max_cvar=0.05,
+        step=0.5,
+        seed=1,
+    )
+    assert not df.empty
+    assert {"external_pa_capital", "active_ext_capital", "internal_pa_capital"}.issubset(df.columns)


### PR DESCRIPTION
## Summary
- implement grid-search utility to propose sleeve allocations under TE, breach and CVaR limits
- handle missing optional dependencies in `pa_core.__init__`
- fix `DataImportAgent.from_template` and `load_margin_schedule`

## Testing
- `pytest tests/test_sleeve_suggestor.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ipywidgets')*


------
https://chatgpt.com/codex/tasks/task_e_68b36512b2c083319ab0241078072585