### PR TITLE
feat: manage alpha presets in asset library

### DIFF
--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -22,6 +22,7 @@ from .backend import get_backend, set_backend
 from .config import ConfigError, ModelConfig, load_config
 from .data import load_index_returns
 from .random import spawn_agent_rngs, spawn_rngs
+
 try:  # pragma: no cover - optional heavy deps
     from .reporting import export_to_excel, print_summary
     from .reporting.sweep_excel import export_sweep_results
@@ -46,8 +47,13 @@ from .sim.metrics import (
     tracking_error,
     value_at_risk,
 )
-from .sweep import run_parameter_sweep, run_parameter_sweep_cached, sweep_results_to_dataframe
+from .sweep import (
+    run_parameter_sweep,
+    run_parameter_sweep_cached,
+    sweep_results_to_dataframe,
+)
 from .stress import STRESS_PRESETS, apply_stress_preset
+from .presets import AlphaPreset, PresetLibrary
 from .validators import (
     ValidationResult,
     PSDProjectionInfo,
@@ -81,6 +87,8 @@ __all__ = [
     "sweep_results_to_dataframe",
     "apply_stress_preset",
     "STRESS_PRESETS",
+    "AlphaPreset",
+    "PresetLibrary",
     "tracking_error",
     "value_at_risk",
     "compound",
@@ -107,7 +115,7 @@ __all__ = [
     "viz",
     # Validation functions
     "ValidationResult",
-    "PSDProjectionInfo", 
+    "PSDProjectionInfo",
     "validate_correlations",
     "validate_covariance_matrix_psd",
     "validate_capital_allocation",

--- a/pa_core/presets.py
+++ b/pa_core/presets.py
@@ -1,0 +1,111 @@
+"""Preset library for alpha streams.
+
+Provides CRUD operations and import/export to YAML or JSON for presets
+that define expected return (mu), volatility (sigma), and correlation
+with the index (rho).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Iterable
+
+import json
+import yaml
+
+
+@dataclass
+class AlphaPreset:
+    """Parameters describing an alpha stream."""
+
+    id: str
+    mu: float
+    sigma: float
+    rho: float
+
+
+class PresetLibrary:
+    """Manage a collection of :class:`AlphaPreset` objects."""
+
+    def __init__(self, presets: Iterable[AlphaPreset] | None = None) -> None:
+        self._presets: Dict[str, AlphaPreset] = {}
+        if presets:
+            for p in presets:
+                self.add(p)
+
+    # CRUD operations
+    def add(self, preset: AlphaPreset) -> None:
+        """Add ``preset`` to the library.
+
+        Raises
+        ------
+        ValueError
+            If a preset with the same id already exists.
+        """
+        if preset.id in self._presets:
+            raise ValueError(f"preset '{preset.id}' already exists")
+        self._presets[preset.id] = preset
+
+    def get(self, preset_id: str) -> AlphaPreset:
+        return self._presets[preset_id]
+
+    def update(self, preset: AlphaPreset) -> None:
+        if preset.id not in self._presets:
+            raise KeyError(preset.id)
+        self._presets[preset.id] = preset
+
+    def delete(self, preset_id: str) -> None:
+        self._presets.pop(preset_id, None)
+
+    # Serialization helpers
+    def to_dict(self) -> Dict[str, Dict[str, float]]:
+        return {pid: asdict(p) for pid, p in self._presets.items()}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Dict[str, float]]) -> "PresetLibrary":
+        presets = [AlphaPreset(**v) for v in data.values()]
+        return cls(presets)
+
+    # YAML/JSON import/export
+    def to_yaml(self, path: str | Path) -> None:
+        Path(path).write_text(yaml.safe_dump(self.to_dict()))
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "PresetLibrary":
+        data = yaml.safe_load(Path(path).read_text()) or {}
+        return cls.from_dict(data)
+
+    def to_json(self, path: str | Path) -> None:
+        Path(path).write_text(json.dumps(self.to_dict()))
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "PresetLibrary":
+        data = json.loads(Path(path).read_text())
+        return cls.from_dict(data)
+
+    # Convenience methods for strings (used by dashboard)
+    def to_yaml_str(self) -> str:
+        return yaml.safe_dump(self.to_dict())
+
+    def to_json_str(self) -> str:
+        return json.dumps(self.to_dict())
+
+    def load_yaml_str(self, text: str) -> None:
+        data = yaml.safe_load(text) or {}
+        self._presets = {}
+        for p in data.values():
+            self.add(AlphaPreset(**p))
+
+    def load_json_str(self, text: str) -> None:
+        data = json.loads(text)
+        self._presets = {}
+        for p in data.values():
+            self.add(AlphaPreset(**p))
+
+    @property
+    def presets(self) -> Dict[str, AlphaPreset]:
+        return self._presets
+
+
+__all__ = ["AlphaPreset", "PresetLibrary"]

--- a/pa_core/presets.py
+++ b/pa_core/presets.py
@@ -101,10 +101,14 @@ class PresetLibrary:
 
     def load_yaml_str(self, text: str) -> None:
         data = yaml.safe_load(text) or {}
+        # Validate for duplicate IDs before clearing existing presets
+        ids = [p.get("id") for p in data.values()]
+        duplicate_ids = {id for id in ids if ids.count(id) > 1}
+        if duplicate_ids:
+            raise ValueError(f"Duplicate preset IDs found in input: {', '.join(duplicate_ids)}")
         self._presets = {}
         for p in data.values():
             self.add(AlphaPreset(**p))
-
     def load_json_str(self, text: str) -> None:
         data = json.loads(text)
         self._presets = {}

--- a/pa_core/presets.py
+++ b/pa_core/presets.py
@@ -56,8 +56,16 @@ class PresetLibrary:
         self._presets[preset.id] = preset
 
     def delete(self, preset_id: str) -> None:
-        self._presets.pop(preset_id, None)
+        """Delete the preset with the given id.
 
+        Raises
+        ------
+        KeyError
+            If the preset with the given id does not exist.
+        """
+        if preset_id not in self._presets:
+            raise KeyError(preset_id)
+        self._presets.pop(preset_id)
     # Serialization helpers
     def to_dict(self) -> Dict[str, Dict[str, float]]:
         return {pid: asdict(p) for pid, p in self._presets.items()}

--- a/tests/test_dashboard_asset_library.py
+++ b/tests/test_dashboard_asset_library.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 import runpy
 import sys
-import types
 from pathlib import Path
 
 
 root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(root))
-PKG = types.ModuleType("pa_core")
-PKG.__path__ = [str(root / "pa_core")]
-sys.modules.setdefault("pa_core", PKG)
 
 
 class Uploaded:
@@ -31,15 +27,42 @@ def test_asset_library_calibration(monkeypatch):
     )
     module["main"].__globals__["apply_theme"] = lambda *a, **k: None
     monkeypatch.setattr(st_mod, "title", lambda *a, **k: None)
-    monkeypatch.setattr(st_mod, "file_uploader", lambda *a, **k: uploaded)
+
+    uploads = [uploaded, None]
+
+    def fake_uploader(*a, **k):
+        return uploads.pop(0)
+
+    monkeypatch.setattr(st_mod, "file_uploader", fake_uploader)
     monkeypatch.setattr(st_mod, "dataframe", lambda *a, **k: None)
     monkeypatch.setattr(st_mod, "json", lambda *a, **k: None)
-    monkeypatch.setattr(st_mod, "selectbox", lambda *a, **k: "SP500_TR")
-    monkeypatch.setattr(st_mod, "button", lambda *a, **k: True)
+
+    selects = ["SP500_TR", ""]
+    monkeypatch.setattr(st_mod, "selectbox", lambda *a, **k: selects.pop(0))
+
+    buttons = [True, False]
+    monkeypatch.setattr(st_mod, "button", lambda *a, **k: buttons.pop(0))
+
+    monkeypatch.setattr(st_mod, "subheader", lambda *a, **k: None)
+    st_mod.session_state = {}
+
+    class DummyForm:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(st_mod, "form", lambda *a, **k: DummyForm())
+    monkeypatch.setattr(st_mod, "text_input", lambda *a, **k: "")
+    monkeypatch.setattr(st_mod, "number_input", lambda *a, **k: 0.0)
+    monkeypatch.setattr(st_mod, "form_submit_button", lambda *a, **k: False)
+
     captured: dict[str, str] = {}
 
     def fake_download(label, data, **kwargs):
-        captured["data"] = data
+        if label == "Download Asset Library YAML":
+            captured["data"] = data
 
     monkeypatch.setattr(st_mod, "download_button", fake_download)
     from pa_core.data import DataImportAgent as RealImporter
@@ -49,4 +72,3 @@ def test_asset_library_calibration(monkeypatch):
     )
     module["main"]()
     assert "SP500_TR" in captured["data"]
-

--- a/tests/test_preset_library.py
+++ b/tests/test_preset_library.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+# ruff: noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from pa_core.presets import AlphaPreset, PresetLibrary
+
+
+def test_preset_library_crud(tmp_path):
+    lib = PresetLibrary()
+    p = AlphaPreset(id="A", mu=0.1, sigma=0.2, rho=0.3)
+    lib.add(p)
+    assert lib.get("A").mu == 0.1
+    lib.update(AlphaPreset(id="A", mu=0.2, sigma=0.2, rho=0.3))
+    assert lib.get("A").mu == 0.2
+    lib.delete("A")
+    assert "A" not in lib.presets
+
+
+def test_preset_import_export(tmp_path):
+    lib = PresetLibrary([AlphaPreset(id="A", mu=0.1, sigma=0.2, rho=0.3)])
+    yaml_path = tmp_path / "presets.yaml"
+    json_path = tmp_path / "presets.json"
+    lib.to_yaml(yaml_path)
+    lib.to_json(json_path)
+    lib_yaml = PresetLibrary.from_yaml(yaml_path)
+    lib_json = PresetLibrary.from_json(json_path)
+    assert lib_yaml.get("A").rho == 0.3
+    assert lib_json.get("A").sigma == 0.2


### PR DESCRIPTION
## Summary
- add PresetLibrary for CRUD and YAML/JSON import/export of alpha presets
- expose preset library in Asset Library dashboard page
- test preset library logic and dashboard integration

## Testing
- `pytest tests/test_preset_library.py tests/test_dashboard_asset_library.py`
- `ruff check pa_core/presets.py tests/test_preset_library.py tests/test_dashboard_asset_library.py dashboard/pages/1_Asset_Library.py pa_core/__init__.py`
- `pytest` *(fails: ImportError cannot import name 'RunFlags' from 'pa_core' and missing WizardScenarioConfig)*
- `pre-commit run --files pa_core/presets.py pa_core/__init__.py dashboard/pages/1_Asset_Library.py tests/test_preset_library.py tests/test_dashboard_asset_library.py` *(fails: pyright reports numerous existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3682490c08331a47b18a9c37140da