### PR TITLE
Fix parameter display logic in export packet

### DIFF
--- a/pa_core/reporting/export_packet.py
+++ b/pa_core/reporting/export_packet.py
@@ -137,11 +137,11 @@ def _create_appendix_slide(pres: Presentation, inputs_dict: Dict[str, Any]) -> N
                     display_value = str(value)
             else:
                 display_value = "N/A"
-                
-                p = tf.add_paragraph()
-                p.text = f"  {param}: {display_value}"
-                p.font.size = Pt(12)
-                p.level = 1
+
+            p = tf.add_paragraph()
+            p.text = f"  {param}: {display_value}"
+            p.font.size = Pt(12)
+            p.level = 1
 
 
 def _create_comprehensive_pptx(


### PR DESCRIPTION
## Summary
- ensure all appendix parameters render in export packet

## Testing
- `pytest tests/test_reporting.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis'; pydantic.errors.PydanticUserError: A non-annotated attribute was detected)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a18b21908331bc78241c4a617fc4