### PR TITLE
Add plain-English primer and glossary tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 Portable Alpha + Active Extension Model Specification
 Below is a comprehensive description of the updated portable‐alpha + active‐extension model, ready to paste into a Markdown cell. Every section is clearly labeled, and all equations use LaTeX delimiters.
 
+## Plain-English Primer
+
+If you're new to the project, start with the [primer](docs/primer.md) for simple definitions of terms like **active share**, **tracking error (TE)** and **CVaR**. A quick way to explore the model is via the command line:
+
+```bash
+python -m pa_core.cli --config config/params_template.yml --index sp500tr_fred_divyield.csv
+python -m dashboard.cli  # launch Streamlit dashboard
+```
+
 ## Quick Start
 
 ### 🚀 GitHub Codespaces (Recommended)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -10,6 +10,8 @@ from types import ModuleType
 import pandas as pd
 import streamlit as st
 
+from dashboard.glossary import GLOSSARY
+
 PLOTS: dict[str, str] = {
     "Headline": "pa_core.viz.risk_return.make",
     "Funding fan": "pa_core.viz.fan.make",
@@ -72,6 +74,10 @@ def main() -> None:
 
     st.title("Portable Alpha Dashboard")
     st.write("Select a page from the sidebar or use the links below to begin.")
+
+    with st.sidebar.expander("Glossary"):
+        for term, definition in GLOSSARY.items():
+            st.markdown(f"**{term}** – {definition}")
 
     st.page_link("pages/1_Asset_Library.py", label="Asset Library")
     st.page_link("pages/2_Portfolio_Builder.py", label="Portfolio Builder")

--- a/dashboard/glossary.py
+++ b/dashboard/glossary.py
@@ -1,0 +1,14 @@
+"""Glossary of finance terms for dashboard tooltips."""
+
+GLOSSARY = {
+    "active share": "Portion of a portfolio that differs from its benchmark; 0% means identical holdings, 100% fully independent.",
+    "buffer multiple": "Multiplier applied to volatility to set the cash buffer threshold for drawdowns.",
+    "breach probability": "Likelihood that returns fall below the buffer threshold in a given period.",
+    "TE": "Tracking error — standard deviation of portfolio returns minus benchmark returns.",
+    "CVaR": "Conditional Value at Risk — expected loss given that losses exceed the VaR cutoff.",
+}
+
+
+def tooltip(term: str) -> str:
+    """Return plain-English definition for ``term`` if available."""
+    return GLOSSARY.get(term.lower(), GLOSSARY.get(term, ""))

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -10,6 +10,7 @@ from typing import Dict, Any
 import streamlit as st
 
 from dashboard.app import _DEF_THEME, _DEF_XLSX, apply_theme
+from dashboard.glossary import tooltip
 from pa_core import cli as pa_cli
 from pa_core.wizard_schema import WizardScenarioConfig, AnalysisMode, RiskMetric, get_default_config
 
@@ -83,7 +84,7 @@ def _render_step_1_analysis_mode(config: WizardScenarioConfig) -> WizardScenario
         )
         
         config.n_months = st.number_input(
-            "Simulation Horizon (months)",
+            "Simulation Horizon [months]",
             min_value=1,
             max_value=60,
             value=config.n_months,
@@ -122,7 +123,7 @@ def _render_step_2_capital(config: WizardScenarioConfig) -> WizardScenarioConfig
         )
         
         config.external_pa_capital = st.number_input(
-            "External PA Capital",
+            "External PA Capital [$M]",
             min_value=0.0,
             max_value=config.total_fund_capital,
             value=config.external_pa_capital,
@@ -132,7 +133,7 @@ def _render_step_2_capital(config: WizardScenarioConfig) -> WizardScenarioConfig
         )
         
         config.active_ext_capital = st.number_input(
-            "Active Extension Capital", 
+            "Active Extension Capital [$M]", 
             min_value=0.0,
             max_value=config.total_fund_capital,
             value=config.active_ext_capital,
@@ -144,7 +145,7 @@ def _render_step_2_capital(config: WizardScenarioConfig) -> WizardScenarioConfig
         # Calculate remaining capital
         remaining = config.total_fund_capital - config.external_pa_capital - config.active_ext_capital
         config.internal_pa_capital = st.number_input(
-            "Internal PA Capital",
+            "Internal PA Capital [$M]",
             min_value=0.0,
             value=max(0.0, remaining),
             step=5.0,
@@ -182,7 +183,7 @@ def _render_step_2_capital(config: WizardScenarioConfig) -> WizardScenarioConfig
             max_value=1.0,
             value=config.active_share,
             step=0.05,
-            help="Active share for equity overlay strategy"
+            help=tooltip("active share")
         )
     
     # Validation and visualization
@@ -235,7 +236,7 @@ def _render_step_3_returns_risk(config: WizardScenarioConfig) -> WizardScenarioC
         st.markdown("**Expected Returns (Annual %):**")
         
         config.mu_h = st.number_input(
-            "In-House Alpha Return",
+            "In-House Alpha Return [annual %]",
             value=config.mu_h * 100,
             step=0.5,
             format="%.2f",
@@ -243,7 +244,7 @@ def _render_step_3_returns_risk(config: WizardScenarioConfig) -> WizardScenarioC
         ) / 100
         
         config.mu_e = st.number_input(
-            "Extension Alpha Return",
+            "Extension Alpha Return [annual %]",
             value=config.mu_e * 100,
             step=0.5,
             format="%.2f", 
@@ -251,7 +252,7 @@ def _render_step_3_returns_risk(config: WizardScenarioConfig) -> WizardScenarioC
         ) / 100
         
         config.mu_m = st.number_input(
-            "External PA Alpha Return",
+            "External PA Alpha Return [annual %]",
             value=config.mu_m * 100,
             step=0.5,
             format="%.2f",
@@ -262,7 +263,7 @@ def _render_step_3_returns_risk(config: WizardScenarioConfig) -> WizardScenarioC
         st.markdown("**Volatility (Annual %):**")
         
         config.sigma_h = st.number_input(
-            "In-House Alpha Volatility",
+            "In-House Alpha Volatility [annual %]",
             min_value=0.01,
             value=config.sigma_h * 100,
             step=0.1,
@@ -271,7 +272,7 @@ def _render_step_3_returns_risk(config: WizardScenarioConfig) -> WizardScenarioC
         ) / 100
         
         config.sigma_e = st.number_input(
-            "Extension Alpha Volatility",
+            "Extension Alpha Volatility [annual %]",
             min_value=0.01,
             value=config.sigma_e * 100,
             step=0.1,
@@ -280,7 +281,7 @@ def _render_step_3_returns_risk(config: WizardScenarioConfig) -> WizardScenarioC
         ) / 100
         
         config.sigma_m = st.number_input(
-            "External PA Alpha Volatility",
+            "External PA Alpha Volatility [annual %]",
             min_value=0.01,
             value=config.sigma_m * 100,
             step=0.1,

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -18,6 +18,7 @@ from dashboard.app import (
     apply_theme,
     load_data,
 )
+from dashboard.glossary import tooltip
 
 
 def main() -> None:
@@ -38,6 +39,15 @@ def main() -> None:
             st.caption(f"Seed: {seed}")
 
     months = st.sidebar.slider("Months", 1, summary.shape[0], summary.shape[0])
+
+    st.subheader("Key Metrics")
+    col1, col2, col3 = st.columns(3)
+    if "TrackingErr" in summary:
+        col1.metric("Tracking Error", f"{summary['TrackingErr'].mean():.2%}", help=tooltip("TE"))
+    if "CVaR" in summary:
+        col2.metric("CVaR", f"{summary['CVaR'].mean():.2%}", help=tooltip("CVaR"))
+    if "BreachProb" in summary:
+        col3.metric("Breach Prob", f"{summary['BreachProb'].mean():.2%}", help=tooltip("breach probability"))
 
     if "Config" in summary.columns:
         config_options = summary["Config"].unique().tolist()

--- a/docs/primer.md
+++ b/docs/primer.md
@@ -1,0 +1,25 @@
+# Portable Alpha Primer
+
+This brief guide explains key terms in plain English and shows how to run the model.
+
+## Key Terms
+
+- **Active share** – Percentage of holdings that differ from a benchmark. Higher values mean the portfolio departs more from the index.
+- **Buffer multiple** – Multiplier on volatility used to size the cash buffer for downside protection.
+- **Breach probability** – Chance that returns fall below the buffer threshold during a period.
+- **Tracking error (TE)** – Standard deviation of the portfolio's return minus the benchmark return.
+- **Conditional Value at Risk (CVaR)** – Expected loss once losses exceed the usual Value‑at‑Risk cutoff.
+
+## Quick CLI examples
+
+Run a simulation and save results:
+
+```bash
+python -m pa_core.cli --config config/params_template.yml --index sp500tr_fred_divyield.csv
+```
+
+Launch the interactive dashboard:
+
+```bash
+python -m dashboard.cli
+```

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -1,7 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from dashboard.glossary import GLOSSARY, tooltip
 

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dashboard.glossary import GLOSSARY, tooltip
+
+TERMS = ["active share", "buffer multiple", "breach probability", "TE", "CVaR"]
+
+
+def test_glossary_terms_present() -> None:
+    for term in TERMS:
+        assert term in GLOSSARY
+        assert GLOSSARY[term]
+
+
+def test_tooltip_lookup_case_insensitive() -> None:
+    assert tooltip("Active Share") == GLOSSARY["active share"]


### PR DESCRIPTION
## Summary
- document key finance terms in new docs/primer.md
- surface glossary sidebar and metric tooltips in dashboard
- label input units and add active share tooltip in scenario wizard

## Testing
- `pytest tests/test_glossary.py -q`
- `pytest tests/test_dashboard_pages.py -q` *(fails: PydanticUserError: A non-annotated attribute was detected: `CAPITAL = 'capital'`)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a675bf108331ac778c2cae7d02a6