### PR TITLE
feat: manifest embedding across CLI/UI; importer parsing templates (#378) + unit labels/docs (#379)

### DIFF
--- a/dashboard/pages/1_Asset_Library.py
+++ b/dashboard/pages/1_Asset_Library.py
@@ -60,9 +60,9 @@ def main() -> None:
                 )
             with st.form("preset_form"):
                 pid = st.text_input("Preset ID")
-                mu = st.number_input("mu", value=0.0, format="%.4f")
-                sigma = st.number_input("sigma", value=0.0, format="%.4f")
-                rho = st.number_input("rho", value=0.0, format="%.4f")
+                mu = st.number_input("mu [annual %]", value=0.0, format="%.4f", help="Expected annual return as a decimal (e.g., 0.04 for 4%)")
+                sigma = st.number_input("sigma [annual %]", value=0.0, format="%.4f", help="Annual volatility as a decimal (e.g., 0.10 for 10%)")
+                rho = st.number_input("rho [-1..1]", value=0.0, format="%.4f", help="Correlation coefficient between -1 and 1")
                 if st.form_submit_button("Save Preset") and pid:
                     preset = AlphaPreset(id=pid, mu=mu, sigma=sigma, rho=rho)
                     if pid in lib.presets:

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -35,11 +35,11 @@ def main() -> None:
         st.warning("No assets found in file.")
         return
 
-    st.subheader("Weights") 
+    st.subheader("Weights [sum to 1.0]") 
     weight_inputs: dict[str, float] = {}
     for asset in scenario.assets:
         weight_inputs[asset.id] = st.number_input(
-            asset.id, min_value=0.0, max_value=1.0, step=0.01, value=0.0
+            f"{asset.id} [0..1]", min_value=0.0, max_value=1.0, step=0.01, value=0.0,
         )
     total = sum(weight_inputs.values())
     if total == 0:

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -31,12 +31,17 @@ def main() -> None:
         st.stop()
     summary, paths = load_data(xlsx)
 
+    # Load manifest if available for display and export embedding
+    manifest_data = None
     manifest_path = Path(xlsx).with_name("manifest.json")
     if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text())
-        seed = manifest.get("seed")
-        if seed is not None:
-            st.caption(f"Seed: {seed}")
+        try:
+            manifest_data = json.loads(manifest_path.read_text())
+            seed = manifest_data.get("seed")
+            if seed is not None:
+                st.caption(f"Seed: {seed}")
+        except Exception:
+            manifest_data = None
 
     months = st.sidebar.slider("Months", 1, summary.shape[0], summary.shape[0])
 
@@ -133,6 +138,7 @@ def main() -> None:
                         raw_returns_dict=raw_returns_dict,
                         inputs_dict=inputs_dict,
                         base_filename=base_name,
+                        manifest=manifest_data,
                     )
                 
                 st.success("✅ Export packet created!")


### PR DESCRIPTION
This PR completes:

- #378 Manifest reproducibility and embedding
  - Adds ManifestWriter to capture git commit, UTC timestamp, seed, config snapshot, data file hashes, and CLI args
  - CLI writes manifest.json for single runs and sweeps
  - Export packet (PPTX) now includes a Reproducibility Manifest appendix slide when provided
  - Dashboard exports pass through the manifest so UI-generated packets also embed it

- #379 Plain-English docs, tooltips, and unit labels
  - docs/primer.md exists and README links to it
  - Glossary + tooltip helpers added to dashboard; tests verify key terms
  - Unit labels clarified for Portfolio Builder and Asset Library inputs (weights [0..1], total [sum to 1.0])

Quality gates:
- Lint: PASS
- Typecheck (pyright 1.1.404): PASS
- Tests: 261 passed, 3 skipped

Once merged, we can close #378 and #379.
