### PR TITLE
Add plugin registry and progress logging

### DIFF
--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -106,7 +106,15 @@ def main() -> None:
                     "active_share_step_pct": float(act_step),
                 })
 
-                results = run_parameter_sweep_cached(cfg, index_series, int(seed))
+                prog = st.progress(0.0)
+
+                def _update(i: int, total: int) -> None:
+                    prog.progress(i / total)
+
+                results = run_parameter_sweep_cached(
+                    cfg, index_series, int(seed), progress=_update
+                )
+                prog.empty()
                 df_res = sweep_results_to_dataframe(results)
                 # Focus on Base agent and compute Sharpe
                 base_rows = df_res[df_res["Agent"] == "Base"].copy()

--- a/pa_core/__init__.py
+++ b/pa_core/__init__.py
@@ -17,7 +17,7 @@ from .agents import (
     RiskMetrics,
 )
 from .agents.registry import build_all as build_agents
-from .agents.registry import build_from_config
+from .agents.registry import build_from_config, register_agent
 from .backend import get_backend, set_backend
 from .config import ConfigError, ModelConfig, load_config
 from .data import load_index_returns
@@ -46,6 +46,7 @@ from .sim.metrics import (
     summary_table,
     tracking_error,
     value_at_risk,
+    register_metric,
 )
 from .sweep import (
     run_parameter_sweep,
@@ -96,6 +97,7 @@ __all__ = [
     "annualised_vol",
     "summary_table",
     "shortfall_probability",
+    "register_metric",
     "Agent",
     "AgentParams",
     "BaseAgent",
@@ -111,6 +113,7 @@ __all__ = [
     "RunFlags",
     "build_agents",
     "build_from_config",
+    "register_agent",
     "SimulatorOrchestrator",
     "viz",
     # Validation functions

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -215,7 +215,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     )
 
     cfg = load_config(args.config)
-    elif args.mode is not None:
+    if args.mode is not None:
         cfg = cfg.model_copy(update={"analysis_mode": args.mode})
     if args.stress_preset:
         cfg = apply_stress_preset(cfg, args.stress_preset)

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -241,11 +241,25 @@ class ModelConfig(BaseModel):
 
 
 def load_config(path: Union[str, Path, Dict[str, Any]]) -> ModelConfig:
-    """Return ``ModelConfig`` parsed from YAML dictionary."""
+    """Return ``ModelConfig`` parsed from YAML dictionary or file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` is a string/Path and the file does not exist.
+    ConfigError
+        If the YAML content cannot be parsed or mandatory fields are missing.
+    """
     if isinstance(path, dict):
         data = path
     else:
-        data = yaml.safe_load(Path(path).read_text())
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Config file not found: {p}")
+        try:
+            data = yaml.safe_load(p.read_text())
+        except yaml.YAMLError as exc:  # pragma: no cover - user input
+            raise ConfigError(f"Invalid YAML in config file {p}: {exc}") from exc
     try:
         cfg = ModelConfig(**data)
     except ValidationError as e:  # pragma: no cover - explicit failure

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pyright[nodejs]
 pydantic
 rich
 pyyaml
+tqdm
 plotly>=5.19
 kaleido            # Plotly static export driver
 streamlit>=1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pyright==1.1.404
 pydantic
 rich
 pyyaml
+tqdm
 # CI/CD dependencies
 flake8             # Code quality checking
 mypy               # Type checking

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,26 @@
+import numpy as np
+from pa_core.agents.base import BaseAgent
+from pa_core.agents.registry import register_agent, build_all
+from pa_core.agents.types import AgentParams
+from pa_core.sim.metrics import register_metric, summary_table
+
+
+class DummyAgent(BaseAgent):
+    def run(self, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act):
+        return {"Dummy": r_beta}
+
+
+def test_register_agent_allows_construction() -> None:
+    register_agent("Dummy", DummyAgent)
+    agents = build_all([AgentParams("Dummy", 1.0, 0.0, 0.0, {})])
+    assert any(isinstance(a, DummyAgent) for a in agents)
+
+
+def test_register_metric_included_in_summary() -> None:
+    def mean_return(arr: np.ndarray) -> float:
+        return float(np.mean(arr))
+
+    register_metric("Mean", mean_return)
+    data = {"A": np.array([[0.1, 0.0], [0.0, 0.1]])}
+    df = summary_table(data)
+    assert "Mean" in df.columns


### PR DESCRIPTION
## Summary
- add progress callbacks and structured logging to parameter sweeps
- introduce agent and risk metric plug-in registries
- surface progress in scenario grid dashboard and tighten config/data file validation

## Testing
- `PYTHONPATH=. pytest` *(fails: argparse.ArgumentError about `--sensitivity` and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b66e2224e48331967a924acfc85152