### PR TITLE
Fix CLI sensitivity flag and support InternalBetaAgent

### DIFF
--- a/dashboard/pages/1_Asset_Library.py
+++ b/dashboard/pages/1_Asset_Library.py
@@ -110,7 +110,8 @@ def main() -> None:
 
                     text = tmpl_upload.getvalue().decode("utf-8")
                     # Write to temp so from_template can read
-                        t.write(text.encode('utf-8'))
+                    with tempfile.NamedTemporaryFile(suffix=".yaml") as t:
+                        t.write(text.encode("utf-8"))
                         t.flush()
                         importer = _DIA.from_template(t.name)
 

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -151,7 +151,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     parser.add_argument(
         "--sensitivity",
         action="store_true",
-        help="Compute one-factor sensitivity deltas and include tornado in packet/Excel",
+        help="Run one-factor sensitivity analysis on key parameters and include a tornado chart in packet/Excel exports",
     )
     parser.add_argument(
         "--dashboard",
@@ -186,11 +186,6 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         type=float,
         default=0.25,
         help="Grid step size for sleeve suggestions",
-    )
-    parser.add_argument(
-        "--sensitivity",
-        action="store_true",
-        help="Run one-factor sensitivity analysis on key parameters",
     )
     args = parser.parse_args(argv)
 

--- a/pa_core/simulations.py
+++ b/pa_core/simulations.py
@@ -67,11 +67,16 @@ def _(agent: ActiveExtensionAgent, *streams: NDArray[Any]) -> Tuple[NDArray[Any]
     return r_E, f_act_ext
 
 
-# Removed redundant dispatcher for InternalBetaAgent, as BaseAgent's dispatcher covers it.
 @_resolve_streams.register
 def _(agent: InternalPAAgent, *streams: NDArray[Any]) -> Tuple[NDArray[Any], NDArray[Any]]:
     r_beta, r_H, r_E, r_M, f_int, f_ext_pa, f_act_ext = streams
     return r_H, np.zeros_like(r_beta)
+
+
+@_resolve_streams.register
+def _(agent: InternalBetaAgent, *streams: NDArray[Any]) -> Tuple[NDArray[Any], NDArray[Any]]:
+    r_beta, r_H, r_E, r_M, f_int, f_ext_pa, f_act_ext = streams
+    return np.zeros_like(r_beta), f_int
 
 
 def simulate_agents(


### PR DESCRIPTION
## Summary
- remove duplicate `--sensitivity` flag in CLI and clarify its help
- register `InternalBetaAgent` in simulation dispatch
- fix Asset Library template loading to use a temp file

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b670d0ea38833188c1c92d3ab66af0