### PR TITLE
Add frequency mapping and register slow test marker

### DIFF
--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -8,9 +8,18 @@ import json
 import numpy as np
 import pandas as pd
 import logging
-# tqdm is optional; provide a no-op fallback wrapper to avoid hard dependency at import time
+
+# tqdm is optional; provide a no-op fallback wrapper to avoid hard dependency
+# at import time.  If ``tqdm`` isn't installed we silently fall back to an
+# identity wrapper so that the module can still be imported during testing.
+try:  # pragma: no cover - exercised in environments without tqdm
+    from tqdm.auto import tqdm as _tqdm
+    _HAS_TQDM = True
 except ImportError:  # pragma: no cover - fallback when tqdm is unavailable
     _HAS_TQDM = False
+
+    def _tqdm(iterable, total=None, desc=None):
+        return iterable
 
 from .agents.registry import build_from_config
 from .config import ModelConfig

--- a/pa_core/validators.py
+++ b/pa_core/validators.py
@@ -43,9 +43,51 @@ multivariate normal sampling and other matrix operations.
 TEST_TOLERANCE_EPSILON = 1e-12
 """float: Very small tolerance for numerical test assertions.
 
-This constant is used as an absolute tolerance when testing that values are 
+This constant is used as an absolute tolerance when testing that values are
 approximately zero in unit tests, particularly for tracking error calculations.
 """
+
+# Frequency mapping
+# ---------------
+#
+# Some validation routines need to convert human friendly frequency names to
+# pandas frequency codes.  Centralising the mapping here keeps the behaviour
+# consistent across the code base and makes it easy to extend in the future.
+
+FREQUENCY_MAP = {
+    "daily": "B",  # business day
+    "weekly": "W",
+    "monthly": "M",
+    "quarterly": "Q",
+    "annual": "A",
+}
+"""Mapping from common frequency aliases to pandas offset codes."""
+
+
+def get_frequency_code(alias: str) -> str:
+    """Return the pandas frequency code for a human readable alias.
+
+    Parameters
+    ----------
+    alias:
+        Frequency alias such as ``"monthly"`` or ``"daily"``.  The lookup is
+        case-insensitive.
+
+    Returns
+    -------
+    str
+        The pandas frequency string understood by :func:`pandas.date_range`.
+
+    Raises
+    ------
+    KeyError
+        If the alias is unknown.
+    """
+
+    try:
+        return FREQUENCY_MAP[alias.lower()]
+    except KeyError as exc:  # pragma: no cover - explicit for clarity
+        raise KeyError(f"Unknown frequency alias: {alias}") from exc
 
 
 class ValidationResult(NamedTuple):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -15,7 +15,29 @@ from pa_core.validators import (
     calculate_margin_requirement,
     load_margin_schedule,
     format_validation_messages,
+    FREQUENCY_MAP,
+    get_frequency_code,
 )
+
+
+class TestFrequencyMap:
+    """Tests for the human friendly frequency mapping."""
+
+    @pytest.mark.parametrize(
+        "alias, expected",
+        [
+            ("daily", "B"),
+            ("weekly", "W"),
+            ("monthly", "M"),
+            ("quarterly", "Q"),
+            ("annual", "A"),
+        ],
+    )
+    def test_frequency_map_mappings(self, alias: str, expected: str) -> None:
+        """Ensure each alias resolves to the correct pandas frequency code."""
+
+        assert FREQUENCY_MAP[alias] == expected
+        assert get_frequency_code(alias) == expected
 
 
 class TestCorrelationValidation:

--- a/tests/test_wizard_schema.py
+++ b/tests/test_wizard_schema.py
@@ -164,9 +164,11 @@ class TestAnalysisModeProperties:
         """Test that description property handles missing values appropriately."""
         # Create a mock enum value that's not in the constants
         # This tests the error path without modifying the actual constants
-        from unittest.mock import Mock
-        
-        mock_mode = Mock()
+        from unittest.mock import MagicMock
+
+        mock_mode = MagicMock()
+        mock_mode.__enter__.return_value = mock_mode
+        mock_mode.__exit__.return_value = None
         mock_mode.value = "nonexistent_mode"
         
         # Bind the property method to our mock


### PR DESCRIPTION
## Summary
- map human-friendly frequency names to pandas codes and expose `get_frequency_code`
- add tests for frequency mapping and adjust wizard schema test mocks to use `MagicMock`
- register `slow` pytest marker and restore optional `tqdm` import fallback

## Testing
- `pytest tests/test_validators.py::TestFrequencyMap::test_frequency_map_mappings -q`
- `pytest tests/test_wizard_schema.py -k description_error_handling -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71f8064348331a9beaea6288f3008