### PR TITLE
Add cross-platform smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,62 @@
+name: Multi-OS Smoke Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.10', '3.11', '3.12']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - name: Cache build
+        id: wheel-cache
+        uses: actions/cache@v4
+        with:
+          path: dist
+          key: ${{ runner.os }}-${{ matrix.python }}-dist-${{ hashFiles('pyproject.toml') }}
+      - name: Build package
+        if: steps.wheel-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Install package
+        run: |
+          pip install dist/*.whl
+          pip install "plotly[kaleido]"
+      - name: Install Chrome (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y chromium-browser
+      - name: Install Chrome (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install chromium
+      - name: Install Chrome (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install chromium -y
+        shell: pwsh
+      - name: Run smoke scenario
+        shell: bash
+        run: |
+          python -m pa_core.cli --config config/ci_smoke.yml --index sp500tr_fred_divyield.csv --output smoke.xlsx --png --packet --seed 42 2>&1 | tee run.log
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-${{ matrix.os }}-py${{ matrix.python }}
+          path: |
+            smoke.xlsx
+            smoke.png
+            smoke.pptx
+            manifest.json
+            run.log
+          if-no-files-found: ignore

--- a/config/ci_smoke.yml
+++ b/config/ci_smoke.yml
@@ -1,0 +1,27 @@
+N_SIMULATIONS: 10
+N_MONTHS: 12
+analysis_mode: returns
+external_pa_capital: 10.0
+active_ext_capital: 5.0
+internal_pa_capital: 15.0
+total_fund_capital: 30.0
+w_beta_H: 0.5
+w_alpha_H: 0.5
+theta_extpa: 0.5
+active_share: 0.5
+mu_H: 0.04
+sigma_H: 0.01
+mu_E: 0.05
+sigma_E: 0.02
+mu_M: 0.03
+sigma_M: 0.02
+rho_idx_H: 0.05
+rho_idx_E: 0.0
+rho_idx_M: 0.0
+rho_H_E: 0.10
+rho_H_M: 0.10
+rho_E_M: 0.0
+risk_metrics:
+  - Return
+  - Risk
+  - ShortfallProb

--- a/pa_core/reporting/console.py
+++ b/pa_core/reporting/console.py
@@ -19,7 +19,8 @@ def print_summary(summary: pd.DataFrame | Mapping[str, float]) -> None:
     """
     console = Console()
     if isinstance(summary, pd.DataFrame):
-        data: dict[str, list[object]] = {str(k): list(v) for k, v in tmp.items()}  # type: ignore[assignment]
+        df = cast(pd.DataFrame, summary)
+        data: dict[str, list[object]] = df.to_dict(orient="list")
     else:
         # Convert mapping to single-row dataframe-like dict
         data = {str(k): [v] for k, v in dict(summary).items()}

--- a/pa_core/viz/waterfall.py
+++ b/pa_core/viz/waterfall.py
@@ -10,10 +10,12 @@ from . import theme
 
 def make(contrib: Mapping[str, float] | pd.Series) -> go.Figure:
     """Return waterfall chart of risk or return contributions."""
-    if not isinstance(contrib, pd.Series):
-        contrib = pd.Series({str(k): float(v) for k, v in contrib.items()})
-    labels = contrib.index.tolist()
-    values = contrib.astype(float).tolist()
+    if isinstance(contrib, pd.Series):
+        series: pd.Series = contrib
+    else:
+        series = pd.Series({str(k): float(v) for k, v in contrib.items()})
+    labels = series.index.tolist()
+    values = series.astype(float).tolist()
     fig = go.Figure(layout_template=theme.TEMPLATE)
     fig.add_trace(
         go.Waterfall(x=labels, y=values, connector=dict(line=dict(color="grey")))

--- a/tests/test_dashboard_run_history.py
+++ b/tests/test_dashboard_run_history.py
@@ -1,11 +1,7 @@
-import sys
-from pathlib import Path
-
 import pandas as pd
 import pytest
 
-from dashboard.app import load_history
-
+from dashboard.app import load_history, save_history
 
 
 def test_load_history(tmp_path):


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and run a smoke scenario on Ubuntu, macOS, and Windows for Python 3.10–3.12
- provide a lightweight `ci_smoke.yml` scenario for fast execution
- tidy CLI imports so `python -m pa_core.cli` runs without package-level errors
- fix summary reporting and dashboard run-history tests
- refine sensitivity tornado handling and type hints for waterfall plots

## Testing
- `pre-commit run --files pa_core/reporting/console.py tests/test_dashboard_run_history.py pa_core/cli.py pa_core/viz/waterfall.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8565fc3b48331aa1ed2e6cd4645a7