### PR TITLE
ci: streamline smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,29 @@
+name: Smoke Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: ['3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -e .
+      - name: Run smoke tests
+        run: pytest tests/golden/test_scenario_smoke.py -q


### PR DESCRIPTION
## Summary
- add simplified smoke workflow limited to ubuntu and Python 3.12
- drop multi-OS logic and Chrome installation

## Testing
- `PYTHONPATH=. pytest tests/golden/test_scenario_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86851b61883318689b0f605968006