### PR TITLE
feat: integrate sleeve suggestor into wizard

### DIFF
--- a/pa_core/reporting/run_diff.py
+++ b/pa_core/reporting/run_diff.py
@@ -49,6 +49,8 @@ def build_run_diff(
             ):
                 cur_val = current_summary[col].iloc[0]
                 prev_val = previous_summary[col].iloc[0]
+                try:
+                    delta = cur_val - prev_val
                 except (TypeError, ValueError):
                     continue
                 metric_records.append(

--- a/tests/test_sleeve_suggestor.py
+++ b/tests/test_sleeve_suggestor.py
@@ -29,6 +29,27 @@ def test_suggest_sleeve_sizes_returns_feasible():
     }.issubset(df.columns)
 
 
+def test_suggest_sleeve_sizes_respects_bounds():
+    cfg = load_config("test_params.yml")
+    cfg = cfg.model_copy(update={"N_SIMULATIONS": 50})
+    idx_series = pd.Series([0.0] * cfg.N_MONTHS)
+    max_te = 0.02
+    max_breach = 0.5
+    max_cvar = 0.05
+    df = suggest_sleeve_sizes(
+        cfg,
+        idx_series,
+        max_te=max_te,
+        max_breach=max_breach,
+        max_cvar=max_cvar,
+        step=0.5,
+        seed=1,
+    )
+    assert (df.filter(regex="_TE").fillna(0) <= max_te).all().all()
+    assert (df.filter(regex="_BreachProb").fillna(0) <= max_breach).all().all()
+    assert (df.filter(regex="_CVaR").fillna(0).abs() <= max_cvar).all().all()
+
+
 def test_cli_sleeve_suggestion(tmp_path, monkeypatch):
     cfg = {"N_SIMULATIONS": 10, "N_MONTHS": 1}
     cfg_path = tmp_path / "cfg.yaml"


### PR DESCRIPTION
## Summary
- add sleeve suggestor section to wizard to compute allocations under TE/breach/CVaR limits
- require confirmation after applying a suggestion before simulation can run
- verify sleeve suggestions respect constraint bounds
- fix run diff delta calculation to avoid syntax error in export packet tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b890cd97d88331b1c18a3e29a5ca74