### PR TITLE
feat: configurable backend with manifest tracking

### DIFF
--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -25,7 +25,6 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     parser.add_argument(
         "--backend",
         choices=["numpy", "cupy"],
-        default="numpy",
         help="Computation backend",
     )
     parser.add_argument(
@@ -36,7 +35,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    set_backend(args.backend)
+    cfg = load_config(args.config)
+    backend_choice = args.backend or cfg.backend
+    set_backend(backend_choice)
+    args.backend = backend_choice
 
     rng_returns = spawn_rngs(args.seed, 1)[0]
     fin_rngs = spawn_agent_rngs(
@@ -44,7 +46,6 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         ["internal", "external_pa", "active_ext"],
     )
 
-    cfg = load_config(args.config)
     raw_params = cfg.model_dump()
     idx_series = load_index_returns(args.index)
     mu_idx = float(idx_series.mean())

--- a/pa_core/backend.py
+++ b/pa_core/backend.py
@@ -19,7 +19,10 @@ def set_backend(name: str) -> None:
             ImportError,
             ModuleNotFoundError,
         ) as e:  # pragma: no cover - depends on optional dep
-            raise ImportError("CuPy backend requested but not installed") from e
+            raise ImportError(
+                "CuPy backend requested but not installed. Install CuPy or run with "
+                "--backend numpy."
+            ) from e
     else:
         raise ValueError(f"Unknown backend: {name}")
 

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Literal
 
 import yaml
 from pydantic import (
@@ -58,6 +58,7 @@ class ModelConfig(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, frozen=True)
 
+    backend: Literal["numpy", "cupy"] = Field(default="numpy")
     N_SIMULATIONS: int = Field(gt=0, alias="Number of simulations")
     N_MONTHS: int = Field(gt=0, alias="Number of months")
 

--- a/pa_core/manifest.py
+++ b/pa_core/manifest.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 import yaml
+from .backend import get_backend
 
 
 @dataclass
@@ -19,6 +20,7 @@ class Manifest:
     config: Mapping[str, Any]
     data_files: Mapping[str, str]
     cli_args: Mapping[str, Any]
+    backend: str
     previous_run: str | None = None
     run_log: str | None = None
 
@@ -66,6 +68,7 @@ class ManifestWriter:
             config=cfg,
             data_files=hashes,
             cli_args=dict(cli_args),
+            backend=get_backend(),
             previous_run=previous_run,
             run_log=str(run_log) if run_log else None,
         )

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+import sys
+import types
+
+import pytest
+import yaml
+
+sys.modules.setdefault("streamlit", types.ModuleType("streamlit"))
+pptx_mod = types.ModuleType("pptx")
+pptx_util = types.ModuleType("pptx.util")
+pptx_mod.Presentation = object
+pptx_util.Inches = lambda x: x
+pptx_mod.util = pptx_util
+sys.modules.setdefault("pptx", pptx_mod)
+sys.modules.setdefault("pptx.util", pptx_util)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pa_core.cli import main
+
+
+def _write_cfg(tmp_path, backend=None):
+    cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1}
+    if backend:
+        cfg["backend"] = backend
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    idx_csv = Path(__file__).resolve().parents[1] / "sp500tr_fred_divyield.csv"
+    return cfg_path, idx_csv
+
+
+def test_backend_cli_numpy(tmp_path):
+    cfg_path, idx_csv = _write_cfg(tmp_path)
+    out_file = tmp_path / "out.xlsx"
+    main([
+        "--config",
+        str(cfg_path),
+        "--index",
+        str(idx_csv),
+        "--output",
+        str(out_file),
+        "--backend",
+        "numpy",
+    ])
+    assert out_file.exists()
+
+
+def test_backend_cli_cupy_missing(tmp_path):
+    cfg_path, idx_csv = _write_cfg(tmp_path)
+    with pytest.raises(ImportError, match="CuPy backend requested"):
+        main([
+            "--config",
+            str(cfg_path),
+            "--index",
+            str(idx_csv),
+            "--backend",
+            "cupy",
+        ])
+
+
+def test_backend_config_cupy_missing(tmp_path):
+    cfg_path, idx_csv = _write_cfg(tmp_path, backend="cupy")
+    with pytest.raises(ImportError, match="CuPy backend requested"):
+        main([
+            "--config",
+            str(cfg_path),
+            "--index",
+            str(idx_csv),
+        ])

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,7 +1,19 @@
 import json
 from pathlib import Path
+import sys
+import types
 
 import yaml
+
+sys.modules.setdefault("streamlit", types.ModuleType("streamlit"))
+pptx_mod = types.ModuleType("pptx")
+pptx_util = types.ModuleType("pptx.util")
+pptx_mod.Presentation = object
+pptx_util.Inches = lambda x: x
+pptx_mod.util = pptx_util
+sys.modules.setdefault("pptx", pptx_mod)
+sys.modules.setdefault("pptx.util", pptx_util)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from pa_core.cli import main
 
@@ -33,3 +45,4 @@ def test_manifest_written(tmp_path):
     assert manifest["seed"] == seed
     assert manifest["config"]["N_SIMULATIONS"] == 1
     assert str(cfg_path) in manifest["data_files"]
+    assert manifest["backend"] == "numpy"


### PR DESCRIPTION
## Summary
- allow selecting NumPy or CuPy backend via CLI flag or YAML config
- record active backend in manifest
- raise clear guidance if CuPy is requested but missing
- validate backend options in ModelConfig

## Testing
- `pytest tests/test_manifest.py tests/test_backend_selection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8ba08f2888331be929a4110135cbf