### PR TITLE
Ensure tests run on Python 3.10 and clean up unused code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "python-pptx",
     "xlsxwriter",
     "PyYAML>=6",
+    "tomli; python_version < \"3.11\"",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,7 @@ kaleido            # Plotly static export driver
 streamlit>=1.35
 python-pptx        # PPTX helper for board packs
 xlsxwriter         # already implied in reporting/
+tomli; python_version<'3.11'
 
 # Development dependencies
 black              # Code formatting

--- a/tests/test_cli_exception_handling.py
+++ b/tests/test_cli_exception_handling.py
@@ -4,13 +4,10 @@ Tests for improved CLI exception handling to verify specific exceptions
 are caught and logged properly instead of broad Exception catches.
 """
 import logging
-from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pandas as pd
 import pytest
 
-from pa_core.cli import main
 
 
 @pytest.fixture
@@ -111,12 +108,11 @@ def test_sensitivity_parameter_evaluation_value_error(caplog_debug):
     skipped_params = []
 
     param_name = "mu_H"
-    base_value = 0.04
     pos_key = f"{param_name}_+5%"
 
     try:
         pos_value = -0.01  # This will cause ValueError
-        pos_result = mock_evaluator({param_name: pos_value})
+        mock_evaluator({param_name: pos_value})
     except (ValueError, ZeroDivisionError) as e:
         failed_params.append(f"{pos_key}: Configuration error: {str(e)}")
         skipped_params.append(pos_key)
@@ -159,7 +155,7 @@ def test_sensitivity_parameter_evaluation_key_error(caplog_debug):
     pos_key = f"{param_name}_+5%"
 
     try:
-        pos_result = mock_evaluator({param_name: 0.05})
+        mock_evaluator({param_name: 0.05})
     except (ValueError, ZeroDivisionError) as e:
         failed_params.append(f"{pos_key}: Configuration error: {str(e)}")
         skipped_params.append(pos_key)

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import tomllib
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for <3.11
+    import tomli as tomllib
 from pathlib import Path
 
 

--- a/tests/test_tempfile_security_fix.py
+++ b/tests/test_tempfile_security_fix.py
@@ -5,7 +5,6 @@ This test verifies that after the security fix, no temporary files are left
 behind when using the functions that previously used delete=False.
 """
 
-import glob
 import os
 import tempfile
 from pathlib import Path
@@ -99,7 +98,7 @@ def test_temp_files_auto_cleanup_on_exception():
 
             # Even if this raises an exception, the temp file should be cleaned up
             try:
-                series = load_index_returns(f.name)
+                load_index_returns(f.name)
             except Exception:
                 pass  # Ignore any exceptions for this test
     except Exception:

--- a/tests/test_wizard_getattr_fix.py
+++ b/tests/test_wizard_getattr_fix.py
@@ -1,9 +1,8 @@
 """Test that wizard schema has all required attributes, eliminating need for getattr() with defaults."""
 
-import pytest
 
 from pa_core.config import ModelConfig
-from pa_core.wizard_schema import AnalysisMode, DefaultConfigView, get_default_config
+from pa_core.wizard_schema import AnalysisMode, get_default_config
 
 
 class TestWizardConfigConsistency:


### PR DESCRIPTION
## Summary
- Support Python 3.10 by falling back to `tomli` when `tomllib` is missing
- Add `tomli` to project and dev requirements
- Remove unused variables and imports in tests

## Testing
- `ruff check --fix tests/test_entrypoints.py tests/test_cli_exception_handling.py tests/test_tempfile_security_fix.py tests/test_wizard_getattr_fix.py`
- `PYTHONPATH=. pytest tests/test_entrypoints.py tests/test_cli_exception_handling.py tests/test_tempfile_security_fix.py tests/test_wizard_getattr_fix.py` *(fails: ModuleNotFoundError: No module named 'plotly')*

------
https://chatgpt.com/codex/tasks/task_e_68b90478607083318a0d11fbfaa9e051