### PR TITLE
Fix MyPy issues in covariance utilities and RNG module

### DIFF
--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -417,7 +417,7 @@ def main(
         # Create run directory under ./runs/<timestamp>
         ts = pd.Timestamp.utcnow().strftime("%Y%m%dT%H%M%SZ")
         run_dir = Path("runs") / ts
-        run_log_path = run_dir / "run.log"
+        run_log_path = cast(Path, run_dir) / "run.log"
         try:
             setup_json_logging(run_log_path)
         except (OSError, PermissionError, RuntimeError, ValueError) as e:
@@ -537,6 +537,7 @@ def main(
                     from .reporting.export_packet import (
                         create_export_packet as create_export_packet_fn,
                     )
+
                     all_summary = pd.concat(summary_frames, ignore_index=True)
 
                     # Create visualization from consolidated summary

--- a/pa_core/random.py
+++ b/pa_core/random.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TYPE_CHECKING
 
 from .backend import xp
 
-try:  # pragma: no cover - numpy is always available for typing
+if TYPE_CHECKING:  # pragma: no cover - numpy is always available for typing
     from numpy.random import Generator  # type: ignore[reportMissingTypeStubs]
-except Exception:  # pragma: no cover
-    Generator = Any  # fall back for type checking
+else:  # pragma: no cover
+    Generator = Any  # type: ignore[assignment]
 
 __all__ = ["spawn_rngs", "spawn_agent_rngs"]
 
 
-def spawn_rngs(seed: int | None, n: int) -> List[Any]:
+def spawn_rngs(seed: int | None, n: int) -> List[Generator]:
     """Return ``n`` independent generators derived from ``seed``.
 
     Passing ``None`` uses unpredictable entropy from the OS.
@@ -23,7 +23,7 @@ def spawn_rngs(seed: int | None, n: int) -> List[Any]:
     return [xp.random.default_rng(s) for s in ss.spawn(n)]
 
 
-def spawn_agent_rngs(seed: int | None, agent_names: List[str]) -> Dict[str, Any]:
+def spawn_agent_rngs(seed: int | None, agent_names: List[str]) -> Dict[str, Generator]:
     """Return a dedicated RNG for each agent name derived from ``seed``."""
     if not agent_names:
         raise ValueError("agent_names must not be empty")

--- a/pa_core/sim/covariance.py
+++ b/pa_core/sim/covariance.py
@@ -33,7 +33,7 @@ def nearest_psd(mat: NDArray[np.float64]) -> NDArray[np.float64]:
     psd_mat = eigvecs @ xp.diag(eigvals_clipped) @ eigvecs.T
     a3 = 0.5 * (psd_mat + psd_mat.T)
     if _is_psd(a3):
-        return a3
+        return np.asarray(a3, dtype=np.float64)
     # Add jitter until PSD
     spacing = xp.spacing(xp.linalg.norm(mat))
     eye = xp.eye(mat.shape[0])
@@ -43,7 +43,7 @@ def nearest_psd(mat: NDArray[np.float64]) -> NDArray[np.float64]:
         mineig = float(eigvals.min())
         a3 += eye * (-mineig * k**2 + spacing)
         k += 1
-    return a3
+    return np.asarray(a3, dtype=np.float64)
 
 
 def build_cov_matrix(
@@ -90,14 +90,14 @@ def build_cov_matrix(
     cov = xp.outer(sds, sds) * rho
     cov = 0.5 * (cov + cov.T)
     if _is_psd(cov):
-        return cov
+        return np.asarray(cov, dtype=np.float64)
     adjusted = nearest_psd(cov)
     max_delta = float(xp.max(xp.abs(adjusted - cov)))
     warnings.warn(
         f"Covariance matrix was not PSD; projected with max|Δ|={max_delta:.2e}",
         RuntimeWarning,
     )
-    return adjusted
+    return np.asarray(adjusted, dtype=np.float64)
 
 
 def build_cov_matrix_with_validation(
@@ -169,4 +169,4 @@ def build_cov_matrix_with_validation(
         warnings.warn(validation_result.message, RuntimeWarning)
         return nearest_psd(cov), validation_info
     else:
-        return cov, validation_info
+        return np.asarray(cov, dtype=np.float64), validation_info


### PR DESCRIPTION
## Summary
- ensure covariance helpers return np.float64 arrays
- define RNG generator alias safely for type checking
- guard CLI logging path with explicit cast

## Testing
- `pre-commit run --files pa_core/sim/covariance.py pa_core/random.py pa_core/cli.py`
- `mypy pa_core/sim/covariance.py pa_core/random.py`
- `pyright pa_core/sim/covariance.py pa_core/random.py`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9104ec6c08331a0b64637f1468396