### PR TITLE
Remove unused ValidationResult import

### DIFF
--- a/tests/test_validators_constants.py
+++ b/tests/test_validators_constants.py
@@ -14,7 +14,6 @@ try:
         SYNTHETIC_DATA_STD,
         TEST_TOLERANCE_EPSILON,
         VOLATILITY_STRESS_MULTIPLIER,
-        ValidationResult,
         validate_simulation_parameters,
     )
 except ImportError:


### PR DESCRIPTION
## Summary
- remove unused `ValidationResult` import from validator constants tests

## Testing
- `./ruff-x86_64-unknown-linux-gnu/ruff check tests/test_validators_constants.py`
- `python3 -m pytest tests/test_validators_constants.py` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b91e66edf48331af2dd955a1f44233