### PR TITLE
Fix CI commit status URL and format wizard schema test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
               state: ok ? 'success' : 'failure',
               context: 'required/pr-gate',
               description: ok ? 'PR Gate passed' : 'PR Gate failed',
-              target_url: `${github.context.serverUrl}/${owner}/${repo}/actions/runs/${github.context.runId}`
+              target_url: `${github.serverUrl}/${owner}/${repo}/actions/runs/${github.context.runId}`
             });
 
       - name: Fail if any upstream job failed

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -418,7 +418,7 @@ def main(
         run_dir = Path("runs") / ts
         run_log_path = run_dir / "run.log"
         try:
-            setup_json_logging(run_log_path)
+            setup_json_logging(str(run_log_path))
         except (OSError, PermissionError, RuntimeError, ValueError) as e:
             logger.warning(f"Failed to set up JSON logging: {e}")
 
@@ -1214,9 +1214,7 @@ def main(
                 return
             except (ValueError, TypeError, KeyError) as e:
                 logger.error(f"Export packet failed due to data/config issue: {e}")
-                print(
-                    f"❌ Export packet failed due to data or configuration issue: {e}"
-                )
+                print(f"❌ Export packet failed due to data or configuration issue: {e}")
                 print("💡 Check your data inputs and configuration settings")
                 return
             except (OSError, PermissionError) as e:

--- a/tests/test_wizard_schema.py
+++ b/tests/test_wizard_schema.py
@@ -181,7 +181,9 @@ class TestAnalysisModeProperties:
 
         # Bind the property method to our mock
         description_method = AnalysisMode.description.fget
-        assert description_method is not None, "AnalysisMode.description.fget should not be None"
+        assert (
+            description_method is not None
+        ), "AnalysisMode.description.fget should not be None"
         with pytest.raises(
             ValueError,
             match="No description found for AnalysisMode value 'nonexistent_mode'",


### PR DESCRIPTION
## Summary
- format `tests/test_wizard_schema.py` with Black
- fix commit status URL in CI workflow to use `github.serverUrl`
- ensure CLI logging setup passes a string path to `setup_json_logging`

## Testing
- `pre-commit run --files tests/test_wizard_schema.py .github/workflows/ci.yml pa_core/cli.py`
- `PYTHONPATH=. pytest tests/test_wizard_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68b92c6c9e108331814cd1f13e27e6bd