### PR TITLE
Fix CLI formatting and workflow run ID handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,10 @@ jobs:
             const sha = process.env.GITHUB_SHA; // PR merge commit on pull_request
             const owner = process.env.GITHUB_REPOSITORY_OWNER;
             const repo = process.env.GITHUB_REPOSITORY.split('/')[1];
+            const runId = process.env.GITHUB_RUN_ID || (github && github.context && github.context.runId);
+            if (!runId) {
+              throw new Error('runId is not defined. Ensure this code runs within a workflow run context.');
+            }
             await github.rest.repos.createCommitStatus({
               owner,
               repo,
@@ -300,7 +304,7 @@ jobs:
               state: ok ? 'success' : 'failure',
               context: 'required/pr-gate',
               description: ok ? 'PR Gate passed' : 'PR Gate failed',
-              target_url: `${github.serverUrl}/${owner}/${repo}/actions/runs/${github.context.runId}`
+              target_url: `${github.serverUrl}/${owner}/${repo}/actions/runs/${runId}`
             });
 
       - name: Fail if any upstream job failed

--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ such as `ShortfallProb` trigger a `ConfigError` during loading.
 
 ### Testing
 
+Install the package and development dependencies first:
+
+```bash
+pip install -r requirements-dev.txt
+pip install -e .
+```
+
 ```bash
 # Run all tests
 ./dev.sh test

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1214,7 +1214,9 @@ def main(
                 return
             except (ValueError, TypeError, KeyError) as e:
                 logger.error(f"Export packet failed due to data/config issue: {e}")
-                print(f"❌ Export packet failed due to data or configuration issue: {e}")
+                print(
+                    f"❌ Export packet failed due to data or configuration issue: {e}"
+                )
                 print("💡 Check your data inputs and configuration settings")
                 return
             except (OSError, PermissionError) as e:


### PR DESCRIPTION
## Summary
- format `pa_core/cli.py` with Black
- guard against missing `runId` in commit status step
- document test dependency setup in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96bd0412083318a15a6bb5cca6dc3