### PR TITLE
fix: use https in commit status target_url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
               state: ok ? 'success' : 'failure',
               context: 'required/pr-gate',
               description: ok ? 'PR Gate passed' : 'PR Gate failed',
-              target_url: `${github.serverUrl}/${owner}/${repo}/actions/runs/${runId}`
+              target_url: `https://github.com/${owner}/${repo}/actions/runs/${runId}`
             });
 
       - name: Fail if any upstream job failed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,12 +67,4 @@ def ensure_pa_core_importable() -> None:
         sys.path.insert(0, root_str)
 
 
-@pytest.fixture
-def ensure_imports():
-    """Fixture to ensure modules are importable for legacy tests.
-
-    This fixture handles the setup that was previously duplicated across test files.
-    New tests should preferably use proper PYTHONPATH setup instead.
-    """
-    ensure_pa_core_importable()
-    # Cleanup is handled automatically by pytest fixture teardown
+ensure_pa_core_importable()


### PR DESCRIPTION
## Summary
- ensure commit status uses https URL to workflow run
- auto-add project root to Python path so tests import project modules without extra setup

## Testing
- `pre-commit run --files tests/conftest.py .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e96374988331a5ad5d788dacd509