### PR TITLE
Define commit SHA in CI status and extend tutorial CLI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const ok = '${{ steps.eval.outputs.ok }}' === 'true';
-            const sha = process.env.GITHUB_SHA; // PR merge commit on pull_request
+            const sha = process.env.GITHUB_SHA || (github && github.context && github.context.sha);
+            if (!sha) {
+              throw new Error('sha is not defined. Ensure this code runs within a workflow run context and GITHUB_SHA is available.');
+            }
             const owner = process.env.GITHUB_REPOSITORY_OWNER;
             const repo = process.env.GITHUB_REPOSITORY.split('/')[1];
             const runId = process.env.GITHUB_RUN_ID || (github && github.context && github.context.runId);

--- a/tests/golden/test_tutorial_golden.py
+++ b/tests/golden/test_tutorial_golden.py
@@ -25,7 +25,9 @@ class TutorialTestRunner:
         self.project_root = Path(__file__).parent.parent.parent
         self.pythonpath = str(self.project_root)
 
-    def run_cli(self, args: List[str]) -> subprocess.CompletedProcess:
+    def run_cli(
+        self, args: List[str], timeout: int = 600
+    ) -> subprocess.CompletedProcess:
         """Run CLI command with PYTHONPATH set."""
         cmd = [sys.executable, "-m", "pa_core.cli"] + args
         env = os.environ.copy()
@@ -36,7 +38,7 @@ class TutorialTestRunner:
             env=env,
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=timeout,
         )
 
     def assert_file_exists_and_size(self, filepath: Path, min_size: int = 1000):


### PR DESCRIPTION
## Summary
- handle missing `sha` when posting commit status in CI
- allow 10 minute runs for tutorial CLI golden tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml tests/golden/test_tutorial_golden.py`
- `pytest tests/golden/test_tutorial_golden.py -k test_basic_scenario_single_run -vv`

------
https://chatgpt.com/codex/tasks/task_e_68bbb250ff4883319f403e17487aef70