### PR TITLE
fix: ensure commit status uses https target_url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
             if (!runId) {
               throw new Error('runId is not defined. Ensure this code runs within a workflow run context.');
             }
-            const serverUrl = github.serverUrl && github.serverUrl.startsWith('http')
+            const serverUrl = github.serverUrl && github.serverUrl.startsWith('https')
               ? github.serverUrl
               : 'https://github.com';
             await github.rest.repos.createCommitStatus({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,9 @@ jobs:
             if (!runId) {
               throw new Error('runId is not defined. Ensure this code runs within a workflow run context.');
             }
+            const serverUrl = github.serverUrl && github.serverUrl.startsWith('http')
+              ? github.serverUrl
+              : 'https://github.com';
             await github.rest.repos.createCommitStatus({
               owner,
               repo,
@@ -304,7 +307,7 @@ jobs:
               state: ok ? 'success' : 'failure',
               context: 'required/pr-gate',
               description: ok ? 'PR Gate passed' : 'PR Gate failed',
-              target_url: `${github.serverUrl}/${owner}/${repo}/actions/runs/${runId}`
+              target_url: `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`
             });
 
       - name: Fail if any upstream job failed


### PR DESCRIPTION
## Summary
- ensure commit status uses https target_url when posting to GitHub

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bbb45be7f8833190b497675202827e