### PR TITLE
Fix commit status sha and extend golden test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const ok = '${{ steps.eval.outputs.ok }}' === 'true';
-            const sha = process.env.GITHUB_SHA; // PR merge commit on pull_request
+            const sha = process.env.GITHUB_SHA || (github && github.context && github.context.sha);
+            if (!sha) {
+              throw new Error('sha is not defined. Ensure this code runs within a workflow run context.');
+            }
             const owner = process.env.GITHUB_REPOSITORY_OWNER;
             const repo = process.env.GITHUB_REPOSITORY.split('/')[1];
             const runId = process.env.GITHUB_RUN_ID || (github && github.context && github.context.runId);

--- a/tests/golden/test_tutorial_golden.py
+++ b/tests/golden/test_tutorial_golden.py
@@ -36,7 +36,7 @@ class TutorialTestRunner:
             env=env,
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=600,
         )
 
     def assert_file_exists_and_size(self, filepath: Path, min_size: int = 1000):


### PR DESCRIPTION
## Summary
- ensure PR gate defines a valid SHA when posting commit status
- increase tutorial golden test CLI timeout to avoid spurious failures

## Testing
- `pre-commit run --files .github/workflows/ci.yml tests/golden/test_tutorial_golden.py`
- `pytest tests/golden/test_tutorial_golden.py::TestTutorial1ParameterSweeps::test_basic_scenario_single_run -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbb690e45c8331896890db5c1a5de3