### PR TITLE
Fix labeling workflow for forked PRs

### DIFF
--- a/.github/workflows/label-agent-prs.yml
+++ b/.github/workflows/label-agent-prs.yml
@@ -1,7 +1,9 @@
 # .github/workflows/label-agent-prs.yml
 name: Label agent PRs (Copilot + Codex)
+# Use pull_request_target to ensure the workflow has write access even for forks.
+# Do not check out or run untrusted pull request code in this workflow.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary
- ensure labeling workflow uses `pull_request_target` for forked PRs
- document that the workflow must not check out untrusted code

## Testing
- `pre-commit run --files .github/workflows/label-agent-prs.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bbb879b0b083319c8b64562f92c0fc