### PR TITLE
Fix commit status SHA fallback to use workflow context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const ok = '${{ steps.eval.outputs.ok }}' === 'true';
-            const sha = process.env.GITHUB_SHA || (github && github.context && github.context.sha);
+            const sha =
+              process.env.GITHUB_SHA ||
+              context.sha ||
+              context.payload?.pull_request?.head?.sha;
             if (!sha) {
               throw new Error('sha is not defined. Ensure this code runs within a workflow run context.');
             }


### PR DESCRIPTION
## Summary
- ensure commit status script falls back to `context.sha` or PR head SHA when `GITHUB_SHA` is missing

## Testing
- `pre-commit run --files .github/workflows/ci.yml tests/golden/test_tutorial_golden.py`
- `pytest tests/golden/test_tutorial_golden.py::TestTutorial1ParameterSweeps::test_basic_scenario_single_run -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbbb3b66248331b565941797e3500b