### PR TITLE
Fix risk-bucket workflow permissions

### DIFF
--- a/.github/workflows/risk-bucket.yml
+++ b/.github/workflows/risk-bucket.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 permissions:
   pull-requests: write
+  issues: write
 jobs:
   risk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- request `issues: write` in risk-bucket workflow so label updates succeed

## Testing
- `./dev.sh lint`
- `./dev.sh typecheck`
- `./dev.sh test` *(partially run: interrupted after ~9 tests due to time)*
- `pytest tests/golden/test_scenario_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbbce240d48331bbeb07194f3b6863