### PR TITLE
Run auto-merge workflow in base repo context

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -1,7 +1,8 @@
 # .github/workflows/enable-automerge.yml
 name: Enable auto-merge for eligible PRs
 on:
-  pull_request:
+  pull_request_target:
+    # run in base repository context so automerge can be enabled for forked PRs
     types: [opened, labeled, synchronize, ready_for_review]
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary
- run auto-merge workflow on `pull_request_target` to allow enabling auto-merge for forked PRs
- document why base-repo context is required

## Testing
- `./dev.sh lint`
- `./dev.sh typecheck`
- `./dev.sh test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc06a657c8331b95173bcf3584503