### PR TITLE
ci: checkout PR head before autofix push

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-python@v5
         with: { python-version: "3.12" }
       - name: Install formatters


### PR DESCRIPTION
## Summary
- fix detached HEAD in autofix workflow by checking out PR head before committing

## Testing
- `pre-commit run --files .github/workflows/autofix.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bbc0b965a88331843b65bf46118d96