### PR TITLE
fix: make debug workflow configurable

### DIFF
--- a/.github/workflows/debug-on-failure.yml
+++ b/.github/workflows/debug-on-failure.yml
@@ -9,10 +9,13 @@ permissions:
   actions: write
   checks: read
   pull-requests: write
+  issues: write
 jobs:
   run-debug:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
+    env:
+      DEBUG_WORKFLOW_FILE: ${{ vars.DEBUG_WORKFLOW_FILE || 'codex-auto-debug.yml' }}
     steps:
       - name: Dispatch Codex Auto-Debug on PR head
         uses: actions/github-script@v7
@@ -28,10 +31,12 @@ jobs:
             const { data: pr } = await github.rest.pulls.get({owner, repo, pull_number: prNum});
             const headRef = pr.head.ref;
 
-            // Fire codex-auto-debug.yml (it already supports workflow_dispatch)
+            const debugWorkflow = process.env.DEBUG_WORKFLOW_FILE;
+
+            // Fire the configured debug workflow (supports workflow_dispatch)
             await github.rest.actions.createWorkflowDispatch({
               owner, repo,
-              workflow_id: 'codex-auto-debug.yml',
+              workflow_id: debugWorkflow,
               ref: headRef,
               inputs: { debug_mode: 'true' }
             });


### PR DESCRIPTION
## Summary
- allow customizing debug workflow filename via DEBUG_WORKFLOW_FILE env
- add `issues: write` permission so PR comments succeed

## Testing
- `pre-commit run --files .github/workflows/debug-on-failure.yml`
- `./dev.sh test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc63cf6288331899fd9c40260bae9