### PR TITLE
ci: use supported black version and clarify label workflow security

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install formatters
         run: |
           python -m pip install -U pip
-          pip install "ruff==0.5.0" "black==24.0.0" "isort==5.13.0" "docformatter==1.7.0"
+          pip install "ruff==0.5.0" "black==23.9.1" "isort==5.13.0" "docformatter==1.7.0"
       - name: Run auto-fixers
         run: |
           ruff check --fix .

--- a/.github/workflows/label-agent-prs.yml
+++ b/.github/workflows/label-agent-prs.yml
@@ -1,6 +1,7 @@
 # .github/workflows/label-agent-prs.yml
 name: Label agent PRs (Copilot + Codex)
-# Uses pull_request_target for write permissions; do not checkout untrusted PR code.
+# Uses pull_request_target for write permissions and deliberately avoids actions/checkout
+# to prevent running untrusted PR code. Subsequent steps rely solely on GitHub API calls.
 on:
   pull_request_target:
     types: [opened]


### PR DESCRIPTION
## Summary
- use `black==23.9.1` in autofix workflow
- clarify label workflow avoids `actions/checkout` and relies on GitHub API only

## Testing
- `./dev.sh lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbc70bb10c83319ce6c89217673f4b