### PR TITLE
ci: handle failures in streamlined debug step

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -64,8 +64,8 @@ jobs:
           echo "ERROR: scripts/streamlined_debug.py not found!" >&2
           exit_code=2
         else
-          python scripts/streamlined_debug.py || exit_code=$?
-          exit_code=${exit_code:-0}
+          python scripts/streamlined_debug.py
+          exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "ERROR: scripts/streamlined_debug.py failed with exit code $exit_code" >&2
           fi

--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -59,20 +59,19 @@ jobs:
     - name: 🚀 Run Streamlined Debug
       id: streamlined_debug
       run: |
-        set +e
         echo "Running streamlined debugging workflow..."
         if [ ! -f scripts/streamlined_debug.py ]; then
           echo "ERROR: scripts/streamlined_debug.py not found!" >&2
-          exit_code=127
+          exit_code=2
         else
-          python scripts/streamlined_debug.py
-          exit_code=$?
+          python scripts/streamlined_debug.py || exit_code=$?
+          exit_code=${exit_code:-0}
           if [ $exit_code -ne 0 ]; then
             echo "ERROR: scripts/streamlined_debug.py failed with exit code $exit_code" >&2
           fi
         fi
-        set -e
         echo "streamlined_exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "streamlined_code=$exit_code" >> $GITHUB_ENV
 
     - name: 📊 Upload Streamlined Debug Report
       uses: actions/upload-artifact@v4
@@ -86,8 +85,14 @@ jobs:
       if: steps.streamlined_debug.outputs.streamlined_exit_code != '0'
       run: |
         echo "Streamlined debug found issues. Running detailed analysis..."
-        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit
-        echo "detailed_exit_code=$?" >> $GITHUB_OUTPUT
+        if python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit; then
+          exit_code=0
+        else
+          exit_code=$?
+          echo "ERROR: scripts/debug_codex_pr.py failed with exit code $exit_code" >&2
+        fi
+        echo "detailed_exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "detailed_code=$exit_code" >> $GITHUB_ENV
 
     - name: 📊 Upload Detailed Debug Report
       uses: actions/upload-artifact@v4
@@ -202,8 +207,8 @@ jobs:
     - name: 📋 Set final status
       if: always()
       run: |
-        streamlined_code="${{ steps.streamlined_debug.outputs.streamlined_exit_code }}"
-        detailed_code="${{ steps.detailed_debug.outputs.detailed_exit_code }}"
+        streamlined_code="${streamlined_code:-1}"
+        detailed_code="${detailed_code:-1}"
 
         if [ "$streamlined_code" = "0" ]; then
           echo "✅ Streamlined debug passed - all good!"


### PR DESCRIPTION
## Summary
- capture exit codes for streamlined and detailed debug steps without masking errors
- set `streamlined_code`/`detailed_code` env vars to prevent empty values
- default final status to failure unless one debug step exits cleanly

## Testing
- `./dev.sh lint`
- `./dev.sh typecheck`
- `./dev.sh test`


------
https://chatgpt.com/codex/tasks/task_e_68bca4c364dc8331b966e645a96930a3