### PR TITLE
ci: handle failures in streamlined debug step

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -56,23 +56,27 @@ jobs:
         git config --global user.name "GitHub Actions"
         git config --global user.email "actions@github.com"
 
+    - name: Initialize debug status
+      run: |
+        echo "streamlined_code=1" >> $GITHUB_ENV
+        echo "detailed_code=1" >> $GITHUB_ENV
+
     - name: 🚀 Run Streamlined Debug
       id: streamlined_debug
       run: |
-        set +e
         echo "Running streamlined debugging workflow..."
         if [ ! -f scripts/streamlined_debug.py ]; then
           echo "ERROR: scripts/streamlined_debug.py not found!" >&2
           exit_code=2
         else
-          python scripts/streamlined_debug.py
+          python scripts/streamlined_debug.py || true
           exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "ERROR: scripts/streamlined_debug.py failed with exit code $exit_code" >&2
           fi
         fi
-        set -e
         echo "streamlined_exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "streamlined_code=$exit_code" >> $GITHUB_ENV
 
     - name: 📊 Upload Streamlined Debug Report
       uses: actions/upload-artifact@v4
@@ -86,8 +90,13 @@ jobs:
       if: steps.streamlined_debug.outputs.streamlined_exit_code != '0'
       run: |
         echo "Streamlined debug found issues. Running detailed analysis..."
-        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit
-        echo "detailed_exit_code=$?" >> $GITHUB_OUTPUT
+        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit || true
+        exit_code=$?
+        echo "detailed_exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "detailed_code=$exit_code" >> $GITHUB_ENV
+        if [ $exit_code -ne 0 ]; then
+          echo "ERROR: scripts/debug_codex_pr.py failed with exit code $exit_code" >&2
+        fi
 
     - name: 📊 Upload Detailed Debug Report
       uses: actions/upload-artifact@v4
@@ -202,9 +211,6 @@ jobs:
     - name: 📋 Set final status
       if: always()
       run: |
-        streamlined_code="${{ steps.streamlined_debug.outputs.streamlined_exit_code }}"
-        detailed_code="${{ steps.detailed_debug.outputs.detailed_exit_code }}"
-
         if [ "$streamlined_code" = "0" ]; then
           echo "✅ Streamlined debug passed - all good!"
           exit 0

--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -69,7 +69,7 @@ jobs:
           echo "ERROR: scripts/streamlined_debug.py not found!" >&2
           exit_code=2
         else
-          python scripts/streamlined_debug.py || true
+          python scripts/streamlined_debug.py
           exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "ERROR: scripts/streamlined_debug.py failed with exit code $exit_code" >&2

--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -90,7 +90,7 @@ jobs:
       if: steps.streamlined_debug.outputs.streamlined_exit_code != '0'
       run: |
         echo "Streamlined debug found issues. Running detailed analysis..."
-        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit || true
+        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit
         exit_code=$?
         echo "detailed_exit_code=$exit_code" >> $GITHUB_OUTPUT
         echo "detailed_code=$exit_code" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- initialize debug status variables and propagate exit codes from streamlined and detailed debug steps
- fall back to failure unless either debug stage reports success

## Testing
- `./dev.sh lint`
- `./dev.sh typecheck`
- `./dev.sh test`


------
https://chatgpt.com/codex/tasks/task_e_68bccab3cd688331a8481f5913142fd3