### PR TITLE
ci: handle failures in streamlined debug step

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -90,11 +90,13 @@ jobs:
       if: steps.streamlined_debug.outputs.streamlined_exit_code != '0'
       run: |
         echo "Streamlined debug found issues. Running detailed analysis..."
-        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit || true
+        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit
         exit_code=$?
         if [ $exit_code -ne 0 ]; then
           echo "ERROR: debug_codex_pr.py failed with exit code $exit_code" >&2
         fi
+        # Prevent workflow failure due to non-zero exit code
+        true
         echo "detailed_exit_code=$exit_code" >> $GITHUB_OUTPUT
         echo "detailed_code=$exit_code" >> $GITHUB_ENV
 

--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -56,23 +56,27 @@ jobs:
         git config --global user.name "GitHub Actions"
         git config --global user.email "actions@github.com"
 
+    - name: Initialize debug status
+      run: |
+        echo "streamlined_code=1" >> $GITHUB_ENV
+        echo "detailed_code=1" >> $GITHUB_ENV
+
     - name: 🚀 Run Streamlined Debug
       id: streamlined_debug
       run: |
-        set +e
         echo "Running streamlined debugging workflow..."
         if [ ! -f scripts/streamlined_debug.py ]; then
           echo "ERROR: scripts/streamlined_debug.py not found!" >&2
           exit_code=2
         else
-          python scripts/streamlined_debug.py
+          python scripts/streamlined_debug.py || true
           exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "ERROR: scripts/streamlined_debug.py failed with exit code $exit_code" >&2
           fi
         fi
-        set -e
         echo "streamlined_exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "streamlined_code=$exit_code" >> $GITHUB_ENV
 
     - name: 📊 Upload Streamlined Debug Report
       uses: actions/upload-artifact@v4
@@ -86,8 +90,13 @@ jobs:
       if: steps.streamlined_debug.outputs.streamlined_exit_code != '0'
       run: |
         echo "Streamlined debug found issues. Running detailed analysis..."
-        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit
-        echo "detailed_exit_code=$?" >> $GITHUB_OUTPUT
+        python scripts/debug_codex_pr.py --branch=${{ github.head_ref || github.ref_name }} --report=detailed_debug_report.md --max-iterations=3 --commit || true
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+          echo "ERROR: debug_codex_pr.py failed with exit code $exit_code" >&2
+        fi
+        echo "detailed_exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "detailed_code=$exit_code" >> $GITHUB_ENV
 
     - name: 📊 Upload Detailed Debug Report
       uses: actions/upload-artifact@v4
@@ -202,8 +211,10 @@ jobs:
     - name: 📋 Set final status
       if: always()
       run: |
-        streamlined_code="${{ steps.streamlined_debug.outputs.streamlined_exit_code }}"
-        detailed_code="${{ steps.detailed_debug.outputs.detailed_exit_code }}"
+        streamlined_code="${streamlined_code}"
+        detailed_code="${detailed_code}"
+        : "${streamlined_code:=1}"
+        : "${detailed_code:=1}"
 
         if [ "$streamlined_code" = "0" ]; then
           echo "✅ Streamlined debug passed - all good!"

--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -69,7 +69,7 @@ jobs:
           echo "ERROR: scripts/streamlined_debug.py not found!" >&2
           exit_code=2
         else
-          python scripts/streamlined_debug.py || true
+          python scripts/streamlined_debug.py
           exit_code=$?
           if [ $exit_code -ne 0 ]; then
             echo "ERROR: scripts/streamlined_debug.py failed with exit code $exit_code" >&2


### PR DESCRIPTION
## Summary
- initialize `streamlined_code` and `detailed_code` with failing defaults
- capture debug script exit codes without `set +e` and export them to outputs and env
- base final workflow status on exported codes with safe fallbacks

## Testing
- `./dev.sh lint`
- `./dev.sh typecheck`
- `./dev.sh test`


------
https://chatgpt.com/codex/tasks/task_e_68bccd29deb48331b2040b143a5fa139