### PR TITLE
Fix debug env defaults in Codex workflow

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -58,8 +58,8 @@ jobs:
 
     - name: Initialize debug status
       run: |
-        echo "streamlined_code=1" >> $GITHUB_ENV
-        echo "detailed_code=1" >> $GITHUB_ENV
+        echo "streamlined_code=0" >> $GITHUB_ENV
+        echo "detailed_code=0" >> $GITHUB_ENV
 
     - name: 🚀 Run Streamlined Debug
       id: streamlined_debug
@@ -74,8 +74,9 @@ jobs:
           if [ $exit_code -ne 0 ]; then
             echo "ERROR: scripts/streamlined_debug.py failed with exit code $exit_code" >&2
           fi
-          echo "streamlined_exit_code=$exit_code" >> $GITHUB_OUTPUT
-          echo "streamlined_code=$exit_code" >> $GITHUB_ENV
+        fi
+        echo "streamlined_exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "streamlined_code=$exit_code" >> $GITHUB_ENV
 
     - name: 📊 Upload Streamlined Debug Report
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- default `streamlined_code` and `detailed_code` env vars to 0
- close conditional block in streamlined debug step to ensure exit codes are exported

## Testing
- `pre-commit run --files .github/workflows/codex-auto-debug.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bcd43e290c83319dbf56e1cff30d65