### PR TITLE
chore: verify gh cli auth in codex auto debug

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -43,6 +43,9 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install GitHub CLI
+      uses: actions/setup-gh@v2
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -50,6 +53,11 @@ jobs:
 
     - name: Authenticate with GitHub CLI
       run: echo $GH_TOKEN | gh auth login --with-token
+
+    - name: Verify GitHub CLI authentication
+      run: |
+        gh auth status >/dev/null 2>&1 || { echo 'gh auth status failed'; exit 1; }
+        gh repo view >/dev/null 2>&1 || { echo 'gh repo view failed'; exit 1; }
 
     - name: Set up Git identity
       run: |

--- a/AUTOMATION_QUICK_START.md
+++ b/AUTOMATION_QUICK_START.md
@@ -10,6 +10,16 @@
 make install-dev
 ```
 
+### GitHub Token Permissions
+
+Automation workflows use the GitHub CLI and require authentication. Provide a personal access token via the `CODEX_PAT` secret or rely on the default `GITHUB_TOKEN` with these permissions:
+
+- contents: write
+- pull-requests: write
+- issues: write
+- actions: read
+- checks: write
+
 ### 2. Run Automation (Any Time)
 ```bash
 # Quick debugging check

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ make dashboard # Start dashboard
 ./setup.sh     # Original setup script
 ```
 
+### GitHub Token Permissions
+
+Workflows such as `codex-auto-debug` require authentication via a personal access token (CODEX_PAT) or the built-in `GITHUB_TOKEN`.
+The token must allow:
+
+- contents: write
+- pull-requests: write
+- issues: write
+- actions: read
+- checks: write
+
+Store a PAT with these scopes as the `CODEX_PAT` repository secret, or ensure the provided `GITHUB_TOKEN` is granted equivalent permissions.
+
 ### VS Code Integration
 
 This project includes comprehensive VS Code configuration:


### PR DESCRIPTION
## Summary
- install GitHub CLI and verify authentication in codex auto debug workflow
- document required CODEX_PAT/GITHUB_TOKEN permissions in setup docs

## Testing
- `pre-commit run --files .github/workflows/codex-auto-debug.yml README.md AUTOMATION_QUICK_START.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68bceda416e88331b8a4381302b44681