### PR TITLE
chore: update GitHub CLI setup action

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -44,7 +44,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install GitHub CLI
-      uses: actions/setup-gh@v2
+      uses: actions/setup-gh-cli@v3
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
- use actions/setup-gh-cli@v3 to install GitHub CLI

## Testing
- `pre-commit run --files .github/workflows/codex-auto-debug.yml`
- `act workflow_dispatch -j streamlined-debug -W .github/workflows/codex-auto-debug.yml -s GH_TOKEN=dummy -s GITHUB_TOKEN=dummy` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf6e974e88331a63cdabeee61a887