### PR TITLE
feat: allow skipping GitHub checks

### DIFF
--- a/scripts/streamlined_debug.py
+++ b/scripts/streamlined_debug.py
@@ -5,6 +5,7 @@ Automated first-step debugging for Codex updates and issues.
 """
 
 import json
+import os
 import subprocess
 import sys
 import time
@@ -19,6 +20,8 @@ class StreamlinedCodexDebugger:
         self.repo_root = Path.cwd()
         self.debug_steps = []
         self.issues_found = []
+        # Central flag to bypass GitHub-related checks in restricted environments
+        self.skip_github_checks = bool(os.getenv("SKIP_GH_CHECK"))
         
     def run_command(self, cmd: str, timeout: int = 30) -> Tuple[bool, str]:
         """Run command with timeout and capture output."""
@@ -49,29 +52,53 @@ class StreamlinedCodexDebugger:
     
     def check_github_integration(self) -> bool:
         """Quick check of GitHub integration status."""
+        if self.skip_github_checks:
+            self.log_step(
+                "GitHub Integration Check",
+                "ℹ️  SKIPPED",
+                "SKIP_GH_CHECK set; skipping GitHub checks",
+            )
+            return True
+
         self.log_step("GitHub Integration Check", "RUNNING")
-        
+
         # Check if we can access GitHub API
         success, output = self.run_command("gh auth status", timeout=10)
         if not success:
-            self.issues_found.append("GitHub CLI not authenticated")
-            self.log_step("GitHub Auth", "❌ FAILED", "Run: gh auth login")
-            return False
-            
+            self.log_step(
+                "GitHub Auth",
+                "⚠️  WARNING",
+                "GitHub CLI not authenticated - skipping further GitHub checks",
+            )
+            return True
+
         # Check current PR status if in PR context
-        success, output = self.run_command("gh pr status --json number,title", timeout=15)
+        success, output = self.run_command(
+            "gh pr status --json number,title", timeout=15
+        )
         if success and output.strip():
             try:
                 pr_data = json.loads(output)
                 if pr_data.get("currentBranch"):
                     pr_info = pr_data["currentBranch"]
-                    self.log_step("GitHub PR Status", "✅ SUCCESS", 
-                                f"PR #{pr_info.get('number', 'N/A')}: {pr_info.get('title', 'N/A')}")
+                    self.log_step(
+                        "GitHub PR Status",
+                        "✅ SUCCESS",
+                        f"PR #{pr_info.get('number', 'N/A')}: {pr_info.get('title', 'N/A')}",
+                    )
                 else:
-                    self.log_step("GitHub PR Status", "⚠️  INFO", "No active PR on current branch")
+                    self.log_step(
+                        "GitHub PR Status",
+                        "ℹ️  INFO",
+                        "No active PR on current branch",
+                    )
             except json.JSONDecodeError:
-                self.log_step("GitHub PR Status", "⚠️  WARNING", "Could not parse PR data")
-        
+                self.log_step(
+                    "GitHub PR Status",
+                    "⚠️  WARNING",
+                    "Could not parse PR data",
+                )
+
         self.log_step("GitHub Integration Check", "✅ COMPLETE")
         return True
     
@@ -105,19 +132,32 @@ class StreamlinedCodexDebugger:
     
     def check_recent_workflow_runs(self) -> bool:
         """Check recent workflow run status."""
+        if self.skip_github_checks:
+            self.log_step(
+                "Recent Workflow Runs",
+                "ℹ️  SKIPPED",
+                "SKIP_GH_CHECK set; skipping GitHub checks",
+            )
+            return True
+
         self.log_step("Recent Workflow Runs", "RUNNING")
-        
-        success, output = self.run_command("gh run list --limit 3 --json databaseId,conclusion,workflowName", timeout=20)
+
+        success, output = self.run_command(
+            "gh run list --limit 3 --json databaseId,conclusion,workflowName",
+            timeout=20,
+        )
         if not success:
-            self.log_step("Workflow Runs", "⚠️  WARNING", "Could not fetch workflow runs")
-            return False
+            self.log_step(
+                "Workflow Runs", "⚠️  WARNING", "Could not fetch workflow runs"
+            )
+            return True
         
         try:
             runs = json.loads(output)
             codex_runs = [run for run in runs if "Codex" in run.get("workflowName", "")]
             
             if not codex_runs:
-                self.log_step("Codex Workflows", "⚠️  INFO", "No recent Codex workflow runs")
+                self.log_step("Codex Workflows", "ℹ️  INFO", "No recent Codex workflow runs")
                 return True
             
             latest_run = codex_runs[0]
@@ -164,18 +204,18 @@ class StreamlinedCodexDebugger:
             return False
         
         branch = branch.strip()
-        self.log_step("Current Branch", "✅ INFO", f"Branch: {branch}")
+        self.log_step("Current Branch", "ℹ️  INFO", f"Branch: {branch}")
         
         # Check if it's a Codex branch
         if not branch.startswith("codex/"):
-            self.log_step("Branch Type", "⚠️  INFO", "Not a Codex branch - workflow won't trigger")
+            self.log_step("Branch Type", "ℹ️  INFO", "Not a Codex branch - workflow won't trigger")
         else:
             self.log_step("Branch Type", "✅ SUCCESS", "Codex branch - workflow will trigger")
         
         # Check if branch is up to date with remote
         success, output = self.run_command("git status --porcelain -b")
         if success and "ahead" in output:
-            self.log_step("Branch Sync", "⚠️  INFO", "Branch has unpushed commits")
+            self.log_step("Branch Sync", "⚠️  WARNING", "Branch has unpushed commits")
         elif success and "behind" in output:
             self.log_step("Branch Sync", "⚠️  WARNING", "Branch is behind remote")
         else:
@@ -185,13 +225,27 @@ class StreamlinedCodexDebugger:
     
     def quick_test_permissions(self) -> bool:
         """Quick test of GitHub permissions without creating a real PR."""
+        if self.skip_github_checks:
+            self.log_step(
+                "Quick Permissions Test",
+                "ℹ️  SKIPPED",
+                "SKIP_GH_CHECK set; skipping GitHub checks",
+            )
+            return True
+
         self.log_step("Quick Permissions Test", "RUNNING")
-        
+
         # Test if we can access repository info
-        success, output = self.run_command("gh repo view --json name,owner", timeout=10)
+        success, output = self.run_command(
+            "gh repo view --json name,owner", timeout=10
+        )
         if not success:
             self.issues_found.append("Cannot access repository info")
-            self.log_step("Repository Access", "❌ FAILED", "Check repository permissions")
+            self.log_step(
+                "Repository Access",
+                "❌ FAILED",
+                "Check repository permissions",
+            )
             return False
         
         try:
@@ -233,7 +287,15 @@ class StreamlinedCodexDebugger:
         # Detailed steps
         report.append("## 📋 Debugging Steps")
         for step in self.debug_steps:
-            status_icon = "✅" if "SUCCESS" in step["status"] else "❌" if "FAILED" in step["status"] else "⚠️"
+            status = step["status"]
+            if "SUCCESS" in status:
+                status_icon = "✅"
+            elif "FAILED" in status:
+                status_icon = "❌"
+            elif "SKIPPED" in status or "INFO" in status:
+                status_icon = "ℹ️"
+            else:
+                status_icon = "⚠️"
             report.append(f"**{step['timestamp']}** {status_icon} {step['step']}")
             if step["details"]:
                 report.append(f"  - {step['details']}")

--- a/scripts/streamlined_debug.py
+++ b/scripts/streamlined_debug.py
@@ -215,7 +215,7 @@ class StreamlinedCodexDebugger:
         # Check if branch is up to date with remote
         success, output = self.run_command("git status --porcelain -b")
         if success and "ahead" in output:
-            self.log_step("Branch Sync", "⚠️  WARNING", "Branch has unpushed commits")
+            self.log_step("Branch Sync", "ℹ️  INFO", "Branch has unpushed commits")
         elif success and "behind" in output:
             self.log_step("Branch Sync", "⚠️  WARNING", "Branch is behind remote")
         else:


### PR DESCRIPTION
## Summary
- centralize `SKIP_GH_CHECK` flag and apply to GitHub-related checks
- log `gh auth status` failures as warnings without halting debug flow
- treat missing PRs and workflow data as informational
- document the skip flag for restricted environments

## Testing
- `python -m py_compile scripts/streamlined_debug.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bceda38a9c8331a89d490bf67f0147