### PR TITLE
fix: use official gh setup action in auto-debug workflow

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -48,6 +48,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Set up GitHub CLI
+      uses: actions/setup-gh@v3
+
     - name: Authenticate with GitHub CLI
       run: echo $GH_TOKEN | gh auth login --with-token
 


### PR DESCRIPTION
## Summary
- replace missing `actions/setup-gh-cli` with official `actions/setup-gh@v3`

## Testing
- `python -m py_compile scripts/streamlined_debug.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'rich')*


------
https://chatgpt.com/codex/tasks/task_e_68bcfa6fb5d88331a2cf20cb36c324f3