### PR TITLE
Ensure debug script present and fix workflow permissions

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -15,11 +15,9 @@ on:
 
 # Explicit permissions for GitHub Actions
 permissions:
-  contents: write          # Push commits and access repository
-  pull-requests: write     # Comment on PRs
-  issues: write           # PR comments (PRs are issues)
-  actions: read           # Access workflow artifacts
-  checks: write           # Update check status
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   streamlined-debug:

--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -18,6 +18,8 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: read           # Access workflow artifacts
+  checks: write           # Update check status
 
 jobs:
   streamlined-debug:


### PR DESCRIPTION
## Summary
- Update streamlined debug helper to expect read-only repo access and treat missing Actions access as a warning
- Specify minimal required permissions in codex-auto-debug workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68bd145cd0388331abe19d4b5a8dfce0