### PR TITLE
chore: ensure streamlined debug job has permissions

### DIFF
--- a/.github/workflows/codex-auto-debug.yml
+++ b/.github/workflows/codex-auto-debug.yml
@@ -40,6 +40,12 @@ jobs:
   streamlined-debug:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      actions: read
+
     # Run on codex branches, PRs to main, or manual dispatch (from Option A router)
     if: >
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
## Summary
- add explicit permissions to streamlined debug job in codex auto-debug workflow

## Testing
- `pre-commit run --files .github/workflows/codex-auto-debug.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd2b4fc2c083319510a1d4ec4ed5ad