### PR TITLE
chore: update labels.yml with full agent label set

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,13 +1,60 @@
 # .github/labels.yml
+# Agent assignment labels
+- name: agent:codex
+  color: 0e8a16
+  description: Assign to Codex agent
+- name: agent:copilot
+  color: 1d76db
+  description: Assign to Copilot
+
+# Agent workflow labels
+- name: agents
+  color: fbca04
+  description: Agent automation
+- name: agents:activated
+  color: ededed
+  description: Agent has been activated
+- name: agents:keepalive
+  color: 1d76db
+  description: Enable keepalive monitoring on PR
+- name: agents:pause
+  color: b60205
+  description: Pause agent work
+- name: agents:paused
+  color: c2e0c6
+  description: Pause keepalive for this PR
+- name: agents:allow-change
+  color: ededed
+  description: Permit workflow edits when justification provided
+
+# PR origin labels
 - name: from:codex
   color: 0e8a16
   description: PR was created by or for Codex
 - name: from:copilot
   color: 0366d6
   description: PR was created by or for Copilot
+
+# Autofix labels
+- name: autofix
+  color: 0366d6
+  description: Let bots format/lint automatically
+- name: autofix:applied
+  color: 7057ff
+  description: Autofix was applied
+- name: autofix:clean
+  color: 0e8a16
+  description: Autofix passed - no changes needed
+- name: autofix:patch
+  color: ededed
+  description: Autofix patch available
+
+# Automerge labels
 - name: automerge
   color: 0052cc
   description: Eligible for auto-merge when checks pass
+
+# Risk assessment labels
 - name: risk:low
   color: 0e8a16
   description: Small, safe change (automerge candidate)
@@ -17,12 +64,16 @@
 - name: risk:high
   color: d73a4a
   description: Large or sensitive change
-- name: agent:codex
-  color: 0e8a16
-  description: Route this issue to Codex
-- name: agent:copilot
-  color: c5def5
-  description: Route this issue to Copilot
-- name: autofix
-  color: 0366d6
-  description: Let bots format/lint automatically
+
+# Status labels (used by agents)
+- name: status:in-progress
+  color: fbca04
+  description: Agent work in progress
+- name: status:ready
+  color: 0052cc
+  description: Ready for agent pickup
+
+# Reminder label (for scheduled tasks)
+- name: reminder
+  color: d4c5f9
+  description: Reminder for future action


### PR DESCRIPTION
## Why
The labels.yml file was out of sync with the labels actually needed for the Workflows consumer pattern.

## Labels Added
| Label | Color | Description |
|-------|-------|-------------|
| `agents:activated` | #ededed | Agent has been activated |
| `agents:keepalive` | #1d76db | Enable keepalive monitoring on PR |
| `agents:paused` | #c2e0c6 | Pause keepalive for this PR |
| `agents:allow-change` | #ededed | Permit workflow edits when justification provided |
| `autofix:clean` | #0e8a16 | Autofix passed - no changes needed |
| `autofix:applied` | #7057ff | Autofix was applied |
| `autofix:patch` | #ededed | Autofix patch available |
| `status:in-progress` | #fbca04 | Agent work in progress |
| `status:ready` | #0052cc | Ready for agent pickup |
| `reminder` | #d4c5f9 | Reminder for future action |

## Note
Labels were already created in the repo via `gh label create`. This PR syncs labels.yml for documentation and consistency.

## Related
- Part of Workflows consumer transition
- Follows SETUP_CHECKLIST from stranske/Workflows