### PR TITLE
Add missing agent workflows for keepalive and autofix

### DIFF
--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -1,0 +1,499 @@
+name: Agents Autofix Loop
+
+on:
+  workflow_run:
+    workflows:
+      - Gate
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: agents-autofix-loop-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare autofix context
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    outputs:
+      should_run: ${{ steps.evaluate.outputs.should_run }}
+      pr_number: ${{ steps.evaluate.outputs.pr_number }}
+      head_ref: ${{ steps.evaluate.outputs.head_ref }}
+      head_sha: ${{ steps.evaluate.outputs.head_sha }}
+      appendix: ${{ steps.evaluate.outputs.appendix }}
+      stop_reason: ${{ steps.evaluate.outputs.stop_reason }}
+      attempts: ${{ steps.evaluate.outputs.attempts }}
+      max_attempts: ${{ steps.evaluate.outputs.max_attempts }}
+      trigger_reason: ${{ steps.evaluate.outputs.trigger_reason }}
+      trigger_job: ${{ steps.evaluate.outputs.trigger_job }}
+      trigger_step: ${{ steps.evaluate.outputs.trigger_step }}
+      gate_conclusion: ${{ steps.evaluate.outputs.gate_conclusion }}
+      gate_run_id: ${{ steps.evaluate.outputs.gate_run_id }}
+      security_blocked: ${{ steps.security_gate.outputs.blocked }}
+      security_reason: ${{ steps.security_gate.outputs.reason }}
+    steps:
+      - name: Checkout (for security gate)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/scripts/prompt_injection_guard.js
+          sparse-checkout-cone-mode: false
+
+      - name: Security gate - prompt injection guard
+        id: security_gate
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const guardPath = './.github/scripts/prompt_injection_guard.js';
+
+            // Check if guard exists (may not exist on older branches)
+            if (!fs.existsSync(guardPath)) {
+              core.info('Prompt injection guard not found, skipping security check.');
+              core.setOutput('blocked', 'false');
+              core.setOutput('reason', 'guard-not-found');
+              return;
+            }
+
+            const { evaluatePromptInjectionGuard } = require(guardPath);
+
+            const run = context.payload.workflow_run;
+            if (!run) {
+              core.setOutput('blocked', 'false');
+              core.setOutput('reason', 'no-workflow-run');
+              return;
+            }
+
+            const prInfo = Array.isArray(run.pull_requests) ? run.pull_requests[0] : undefined;
+            if (!prInfo?.number) {
+              core.setOutput('blocked', 'false');
+              core.setOutput('reason', 'no-pr-context');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prInfo.number,
+            });
+
+            const result = await evaluatePromptInjectionGuard({
+              github,
+              context,
+              pr,
+              actor: run.actor?.login || context.actor,
+              promptContent: pr.body || '',
+              core,
+            });
+
+            core.setOutput('blocked', String(result.blocked));
+            core.setOutput('reason', result.reason);
+
+            if (result.blocked) {
+              core.setFailed(`Security gate blocked: ${result.reason}`);
+            }
+
+      - name: Evaluate workflow_run
+        id: evaluate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const outputs = {
+              should_run: 'false',
+              pr_number: '',
+              head_ref: '',
+              head_sha: '',
+              appendix: '',
+              stop_reason: '',
+              attempts: '0',
+              max_attempts: '3',
+              trigger_reason: 'unknown',
+              trigger_job: '',
+              trigger_step: '',
+              gate_conclusion: String(run?.conclusion || run?.status || ''),
+              gate_run_id: String(run?.id || ''),
+            };
+
+            const stop = (reason, stopReason = '') => {
+              core.info(`Autofix loop skipped: ${reason}.`);
+              outputs.stop_reason = stopReason || reason;
+              for (const [key, value] of Object.entries(outputs)) {
+                core.setOutput(key, value);
+              }
+            };
+
+            if (!run) {
+              return stop('missing workflow_run payload');
+            }
+
+            if ((run.conclusion || '').toLowerCase() === 'success') {
+              return stop('upstream Gate succeeded');
+            }
+
+            if ((run.event || '').toLowerCase() !== 'pull_request') {
+              return stop(`unsupported event type: ${run.event || 'unknown'}`);
+            }
+
+            const prInfo = Array.isArray(run.pull_requests) ? run.pull_requests[0] : undefined;
+            if (!prInfo?.number) {
+              return stop('no pull request context on workflow_run');
+            }
+
+            outputs.pr_number = String(prInfo.number);
+
+            const { owner, repo } = context.repo;
+            const prNumber = Number(prInfo.number);
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const prData = pr.data;
+
+            if (!prData || prData.state !== 'open') {
+              return stop('pull request is not open');
+            }
+
+            if (prData.draft) {
+              return stop('draft pull request');
+            }
+
+            const headSha = prData.head?.sha;
+            if (!headSha || headSha !== run.head_sha) {
+              return stop('head SHA drifted since Gate started');
+            }
+
+            const sameRepo = prData.head?.repo?.full_name === `${owner}/${repo}`;
+            if (!sameRepo) {
+              return stop('head repository mismatch (likely fork)');
+            }
+
+            const labels = Array.isArray(prData.labels)
+              ? prData.labels
+                  .map((label) => (label?.name || '').toLowerCase())
+                  .filter(Boolean)
+              : [];
+            const hasAgentLabel = labels.includes('agent:codex');
+
+            const body = prData.body || '';
+            const configMatch = body.match(/autofix\s*:\s*(true|false)/i);
+            const autofixEnabled = configMatch
+              ? configMatch[1].toLowerCase() === 'true'
+              : hasAgentLabel;
+
+            if (!autofixEnabled) {
+              return stop('autofix disabled for this pull request');
+            }
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner,
+              repo,
+              run_id: run.id,
+              per_page: 100,
+            });
+
+            const workflowFile = 'agents-autofix-loop.yml';
+            const maxAttempts = Number(outputs.max_attempts);
+            const previousRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: workflowFile,
+              head_sha: run.head_sha,
+              per_page: 100,
+              status: 'completed',
+            });
+
+            const attemptCount = previousRuns.length + 1;
+            outputs.attempts = String(attemptCount);
+            outputs.max_attempts = String(maxAttempts);
+
+            const failingJobs = [];
+            let triggerJob = null;
+            let triggerStep = null;
+            for (const job of jobs) {
+              const conclusion = (job.conclusion || job.status || '').toLowerCase();
+              if (!conclusion || ['success', 'skipped'].includes(conclusion)) {
+                continue;
+              }
+
+              const failingSteps =
+                Array.isArray(job.steps)
+                  ? job.steps
+                      .filter((step) => {
+                        const stepConclusion = (step.conclusion || step.status || '').toLowerCase();
+                        return stepConclusion && !['success', 'skipped'].includes(stepConclusion);
+                      })
+                      .map((step) => `${step.name} (${step.conclusion || step.status || 'unknown'})`)
+                  : [];
+
+              const detailLines = [`- ${job.name} (${job.conclusion || job.status || 'unknown'})`];
+              if (failingSteps.length > 0) {
+                detailLines.push(`  - steps: ${failingSteps.join('; ')}`);
+              }
+              failingJobs.push(detailLines.join('\n'));
+
+              if (!triggerJob) {
+                triggerJob = job;
+                const failingStep = Array.isArray(job.steps)
+                  ? job.steps.find((step) => {
+                      const stepConclusion = (step.conclusion || step.status || '').toLowerCase();
+                      return stepConclusion && !['success', 'skipped'].includes(stepConclusion);
+                    })
+                  : null;
+                triggerStep = failingStep || null;
+              }
+            }
+
+            const inferTriggerReason = (job, step) => {
+              const text = [job?.name, step?.name]
+                .filter(Boolean)
+                .map((value) => String(value).toLowerCase())
+                .join(' ');
+
+              if (!text) return 'unknown';
+              if (text.includes('mypy')) return 'mypy';
+              if (text.includes('lint') || text.includes('flake8') || text.includes('ruff')) return 'lint';
+              if (text.includes('pytest') || text.includes('test')) return 'pytest';
+              return 'unknown';
+            };
+
+            outputs.trigger_reason = inferTriggerReason(triggerJob, triggerStep);
+            outputs.trigger_job = triggerJob?.name || triggerJob?.id || '';
+            outputs.trigger_step = triggerStep?.name || '';
+
+            const appendixLines = [
+              `Gate run: ${run.html_url || run.id}`,
+              `Conclusion: ${run.conclusion || run.status || 'unknown'}`,
+              `PR: #${prNumber}`,
+              `Head SHA: ${headSha}`,
+              `Autofix attempts for this head: ${attemptCount} / ${maxAttempts}`,
+              'Fix scope: src/, tests/, tools/, scripts/, agents/, templates/, .github/',
+            ];
+
+            if (failingJobs.length > 0) {
+              appendixLines.push('Failing jobs:', ...failingJobs);
+            } else {
+              appendixLines.push('Failing jobs: none reported.');
+            }
+
+            outputs.appendix = appendixLines.join('\n');
+
+            if (attemptCount > maxAttempts) {
+              return stop(`autofix attempt limit reached (${attemptCount} > ${maxAttempts})`, 'max_attempts');
+            }
+
+            outputs.should_run = 'true';
+            outputs.head_ref = prData.head.ref || '';
+            outputs.head_sha = headSha;
+
+            for (const [key, value] of Object.entries(outputs)) {
+              core.setOutput(key, value);
+            }
+
+  autofix:
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
+    name: Run Codex autofix
+    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    with:
+      prompt_file: .github/codex/prompts/autofix_from_ci_failure.md
+      mode: autofix
+      pr_number: ${{ needs.prepare.outputs.pr_number }}
+      pr_ref: ${{ needs.prepare.outputs.head_ref }}
+      appendix: ${{ needs.prepare.outputs.appendix }}
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+
+  needs-human:
+    needs: prepare
+    if: needs.prepare.outputs.stop_reason == 'max_attempts'
+    name: Flag for human follow-up
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    steps:
+      - name: Add needs-human label and comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ needs.prepare.outputs.pr_number }}');
+            if (!prNumber) {
+              core.info('No PR number available; skipping comment/label.');
+              return;
+            }
+
+            const appendix = `${{ toJSON(needs.prepare.outputs.appendix) }}`.replace(/^"|"$/g, '');
+            const attempts = ${{ needs.prepare.outputs.attempts || 0 }};
+            const maxAttempts = ${{ needs.prepare.outputs.max_attempts || 0 }};
+
+            const { owner, repo } = context.repo;
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: ['needs-human'],
+            }).catch((error) => {
+              core.warning(`Failed to add label: ${error.message}`);
+            });
+
+            const body = [
+              'Autofix attempts exhausted for this head.',
+              `Attempts: ${attempts} / ${maxAttempts}`,
+              '',
+              'Latest Gate summary:',
+              '```',
+              appendix || 'No run context available.',
+              '```',
+              '',
+              'Please investigate manually.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  metrics:
+    name: Record autofix metrics
+    needs:
+      - prepare
+      - autofix
+    if: always()
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    steps:
+      - name: Collect metrics
+        id: collect
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = Number('${{ needs.prepare.outputs.pr_number || 0 }}') || 0;
+            const attemptNumber = Number('${{ needs.prepare.outputs.attempts || 0 }}') || 0;
+            const attemptLimit = Number('${{ needs.prepare.outputs.max_attempts || 0 }}') || 0;
+            const headShaBefore = '${{ needs.prepare.outputs.head_sha }}';
+            const gateConclusionBefore = '${{ needs.prepare.outputs.gate_conclusion }}' || (context.payload.workflow_run?.conclusion || '');
+            const gateRunId = '${{ needs.prepare.outputs.gate_run_id }}' || String(context.payload.workflow_run?.id || '');
+            const triggerReason = '${{ needs.prepare.outputs.trigger_reason || 'unknown' }}';
+            const triggerJob = '${{ needs.prepare.outputs.trigger_job }}';
+            const triggerStep = '${{ needs.prepare.outputs.trigger_step }}';
+            const stopReason = '${{ needs.prepare.outputs.stop_reason }}';
+            const autofixResult = '${{ needs.autofix.result }}';
+
+            const { owner, repo } = context.repo;
+            let fixApplied = false;
+            let headShaAfter = headShaBefore;
+            let gateResultAfter = gateConclusionBefore || 'unknown';
+
+            if (prNumber) {
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                });
+                headShaAfter = pr.head?.sha || headShaAfter;
+                fixApplied = Boolean(headShaBefore && headShaAfter && headShaBefore !== headShaAfter);
+
+                const gateWorkflow = 'pr-00-gate.yml';
+                const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                  owner,
+                  repo,
+                  workflow_id: gateWorkflow,
+                  head_sha: headShaAfter,
+                  per_page: 20,
+                });
+                const latestGateRun = runs[0];
+                if (latestGateRun) {
+                  gateResultAfter = latestGateRun.conclusion || latestGateRun.status || 'unknown';
+                } else {
+                  gateResultAfter = 'not-found';
+                }
+              } catch (error) {
+                core.warning(`Failed to resolve PR or gate status: ${error.message}`);
+              }
+            }
+
+            const metrics = {
+              workflow_run_id: gateRunId,
+              pr_number: prNumber,
+              attempt_number: attemptNumber,
+              attempt_limit: attemptLimit,
+              trigger_reason: triggerReason || 'unknown',
+              trigger_job: triggerJob,
+              trigger_step: triggerStep,
+              fix_applied: fixApplied,
+              gate_result_after: gateResultAfter || 'unknown',
+              gate_conclusion_before: gateConclusionBefore || 'unknown',
+              stop_reason: stopReason || '',
+              autofix_result: autofixResult || 'unknown',
+              head_sha_before: headShaBefore,
+              head_sha_after: headShaAfter,
+              recorded_at: new Date().toISOString(),
+            };
+
+            core.setOutput('metrics_json', JSON.stringify(metrics));
+
+      - name: Write summary and artifact
+        env:
+          METRICS_JSON: ${{ steps.collect.outputs.metrics_json }}
+        run: |
+          set -euo pipefail
+          if [ -z "${METRICS_JSON:-}" ]; then
+            echo "No metrics JSON captured; skipping summary."
+            exit 0
+          fi
+
+          python - <<'PY'
+          import json
+          import os
+
+          metrics = json.loads(os.environ["METRICS_JSON"])
+          order = [
+              "pr_number",
+              "attempt_number",
+              "attempt_limit",
+              "trigger_reason",
+              "trigger_job",
+              "trigger_step",
+              "fix_applied",
+              "gate_conclusion_before",
+              "gate_result_after",
+              "autofix_result",
+              "stop_reason",
+              "workflow_run_id",
+              "head_sha_before",
+              "head_sha_after",
+              "recorded_at",
+          ]
+
+          lines = ["## Autofix loop metrics", ""] + ["| Field | Value |", "| --- | --- |"]
+          for key in order:
+              value = metrics.get(key, "")
+              lines.append(f"| {key} | `{value}` |")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fp:
+                  fp.write("\n".join(lines) + "\n")
+
+          out_path = "autofix-metrics.ndjson"
+          with open(out_path, "a", encoding="utf-8") as fp:
+              fp.write(json.dumps(metrics) + "\n")
+          print(f"Wrote metrics to {out_path}")
+          PY
+
+      - name: Upload metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agents-autofix-metrics
+          path: autofix-metrics.ndjson
+          retention-days: 30

--- a/.github/workflows/agents-bot-comment-handler.yml
+++ b/.github/workflows/agents-bot-comment-handler.yml
@@ -1,0 +1,178 @@
+# Bot Comment Handler - Thin caller for consumer repos
+#
+# Addresses unresolved review comments from bots (Copilot, CodeRabbit, etc.)
+# by dispatching the configured agent to fix them.
+#
+# Triggers:
+# - PR labeled with 'autofix:bot-comments' (manual trigger)
+# - Gate workflow completion (automatic for agent PRs)
+# - Manual dispatch for testing
+#
+# Agent selection:
+# - Uses PR's agent:* label (agent:codex, agent:claude, etc.)
+# - Falls back to Codex if no agent label
+#
+# Workflow file: .github/workflows/agents-bot-comment-handler.yml
+
+name: Agents Bot Comment Handler
+
+on:
+  # Manual trigger via label
+  pull_request:
+    types: [labeled]
+  
+  # Automatic trigger after Gate completes (for agent PRs)
+  # Note: branches-ignore is not supported for workflow_run, filtering is done in job logic
+  workflow_run:
+    workflows: ["Gate"]
+    types: [completed]
+  
+  # Manual dispatch for testing
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to process'
+        required: true
+        type: string
+      dry_run:
+        description: 'Preview without making changes'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: bot-comments-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  # Resolve PR number from different trigger types
+  resolve:
+    name: Resolve PR
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
+    steps:
+      - name: Resolve PR number and check conditions
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            let prNumber = null;
+            let shouldRun = false;
+            
+            if (eventName === 'workflow_dispatch') {
+              prNumber = '${{ inputs.pr_number }}';
+              shouldRun = true;
+              console.log(`Manual dispatch for PR #${prNumber}`);
+            }
+            else if (eventName === 'pull_request') {
+              // Only run if labeled with autofix:bot-comments
+              const label = context.payload.label?.name;
+              if (label === 'autofix:bot-comments') {
+                prNumber = context.payload.pull_request.number;
+                shouldRun = true;
+                console.log(`Label trigger for PR #${prNumber}`);
+              } else {
+                console.log(`Ignoring label: ${label}`);
+              }
+            }
+            else if (eventName === 'workflow_run') {
+              // Only run if Gate succeeded and PR has agent:* label
+              const workflowRun = context.payload.workflow_run;
+              
+              // Skip main branch
+              if (workflowRun.head_branch === 'main') {
+                console.log('Skipping main branch');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              if (workflowRun.conclusion !== 'success') {
+                console.log(`Gate did not succeed (${workflowRun.conclusion}), skipping`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              // Get PR from workflow run
+              const prs = workflowRun.pull_requests;
+              if (!prs || prs.length === 0) {
+                console.log('No PR associated with workflow run');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              prNumber = prs[0].number;
+              
+              // Check if PR has agent label
+              let pr;
+              try {
+                const response = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber
+                });
+                pr = response.data;
+              } catch (error) {
+                console.log(`Failed to fetch PR #${prNumber} details, skipping. Error: ${error.message || error}`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              const hasAgentLabel = pr.labels.some(l => /^agent:/.test(l.name));
+              if (!hasAgentLabel) {
+                console.log(`PR #${prNumber} has no agent label, skipping`);
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              
+              shouldRun = true;
+              console.log(`Gate completion trigger for agent PR #${prNumber}`);
+            }
+            
+            core.setOutput('pr_number', prNumber || '');
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+
+  # Call the reusable workflow
+  handle:
+    name: Handle bot comments
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
+    uses: stranske/Workflows/.github/workflows/reusable-bot-comment-handler.yml@main
+    with:
+      pr_number: ${{ needs.resolve.outputs.pr_number }}
+      dry_run: ${{ inputs.dry_run == true }}
+    secrets:
+      service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      gh_app_id: ${{ secrets.GH_APP_ID }}
+      gh_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+  # Remove the trigger label after processing
+  cleanup:
+    name: Cleanup
+    needs: [resolve, handle]
+    if: always() && github.event_name == 'pull_request' && github.event.label.name == 'autofix:bot-comments'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove trigger label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'autofix:bot-comments'
+              });
+              console.log('Removed autofix:bot-comments label');
+            } catch (error) {
+              console.log(`Could not remove label: ${error.message}`);
+            }

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -1,0 +1,492 @@
+# CLI Codex Keepalive Loop - triggers Codex after Gate passes
+# This workflow is CRITICAL for the keepalive pipeline to function with CLI Codex.
+#
+# How it works:
+# 1. Gate workflow completes on a PR
+# 2. This workflow evaluates if keepalive should continue
+# 3. If yes, calls reusable-codex-run.yml to run Codex CLI
+# 4. Codex makes changes, pushes commits
+# 5. Gate runs again, loop continues until tasks complete
+#
+# Copy this file to: .github/workflows/agents-keepalive-loop.yml
+#
+# Required secrets:
+# - CODEX_AUTH_JSON: JSON auth for Codex CLI (ChatGPT subscription)
+# - WORKFLOWS_APP_ID: GitHub App ID (alternative to CODEX_AUTH_JSON)
+# - WORKFLOWS_APP_PRIVATE_KEY: GitHub App private key
+#
+# Required files:
+# - .github/codex/prompts/keepalive_next_task.md
+# - .github/codex/AGENT_INSTRUCTIONS.md
+name: Agents Keepalive Loop
+
+on:
+  workflow_run:
+    workflows: ["Gate"]
+    types: [completed]
+  pull_request:
+    types:
+      - labeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to run keepalive on'
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: keepalive-${{ github.event.workflow_run.pull_requests[0].number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    name: Evaluate keepalive loop
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    outputs:
+      pr_number: ${{ steps.evaluate.outputs.pr_number }}
+      pr_ref: ${{ steps.evaluate.outputs.pr_ref }}
+      head_sha: ${{ steps.evaluate.outputs.head_sha }}
+      action: ${{ steps.evaluate.outputs.action }}
+      reason: ${{ steps.evaluate.outputs.reason }}
+      gate_conclusion: ${{ steps.evaluate.outputs.gate_conclusion }}
+      iteration: ${{ steps.evaluate.outputs.iteration }}
+      max_iterations: ${{ steps.evaluate.outputs.max_iterations }}
+      failure_threshold: ${{ steps.evaluate.outputs.failure_threshold }}
+      tasks_total: ${{ steps.evaluate.outputs.tasks_total }}
+      tasks_unchecked: ${{ steps.evaluate.outputs.tasks_unchecked }}
+      keepalive_enabled: ${{ steps.evaluate.outputs.keepalive_enabled }}
+      autofix_enabled: ${{ steps.evaluate.outputs.autofix_enabled }}
+      has_agent_label: ${{ steps.evaluate.outputs.has_agent_label }}
+      agent_type: ${{ steps.evaluate.outputs.agent_type }}
+      task_appendix: ${{ steps.evaluate.outputs.task_appendix }}
+      trace: ${{ steps.evaluate.outputs.trace }}
+      start_ts: ${{ steps.timestamps.outputs.start_ts }}
+      security_blocked: ${{ steps.security_gate.outputs.blocked }}
+      security_reason: ${{ steps.security_gate.outputs.reason }}
+    steps:
+      # Dual checkout pattern: consumer repo for context, Workflows repo for scripts
+      - name: Checkout consumer repository
+        uses: actions/checkout@v4
+        with:
+          path: consumer
+
+      - name: Checkout Workflows scripts
+        uses: actions/checkout@v4
+        with:
+          repository: stranske/Workflows
+          ref: main
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          path: workflows-lib
+          fetch-depth: 1
+
+      - name: Set scripts path
+        run: |
+          echo "WORKFLOWS_SCRIPTS_PATH=${GITHUB_WORKSPACE}/workflows-lib/.github/scripts" >> "$GITHUB_ENV"
+
+      - name: Capture timestamps
+        id: timestamps
+        run: echo "start_ts=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Security gate - prompt injection guard
+        id: security_gate
+        uses: actions/github-script@v7
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH;
+            const { evaluatePromptInjectionGuard } = require(`${scriptsPath}/prompt_injection_guard.js`);
+
+            // Resolve PR from event context
+            const payload = context.payload || {};
+            let prNumber = 0;
+            let pr = null;
+
+            if (context.eventName === 'pull_request' && payload.pull_request) {
+              prNumber = payload.pull_request.number;
+              pr = payload.pull_request;
+            } else if (context.eventName === 'workflow_run' && payload.workflow_run) {
+              const prs = payload.workflow_run.pull_requests || [];
+              if (prs[0]?.number) {
+                prNumber = prs[0].number;
+              } else {
+                // Fallback: query PRs by head SHA when pull_requests array is empty
+                // This happens due to GitHub's workflow_run event limitations
+                const headSha = payload.workflow_run.head_sha;
+                if (headSha) {
+                  console.log(`pull_requests array empty, querying by head SHA: ${headSha}`);
+                  const { data: commits } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    commit_sha: headSha,
+                  });
+                  if (commits[0]?.number) {
+                    prNumber = commits[0].number;
+                    console.log(`Found PR #${prNumber} via commit SHA lookup`);
+                  }
+                }
+              }
+              if (prNumber > 0) {
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                pr = data;
+              }
+            } else if (context.eventName === 'workflow_dispatch' && process.env.INPUT_PR_NUMBER) {
+              prNumber = Number(process.env.INPUT_PR_NUMBER);
+              if (prNumber > 0) {
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                pr = data;
+              }
+            }
+
+            if (!pr) {
+              core.setOutput('blocked', 'false');
+              core.setOutput('reason', 'no-pr-context');
+              return;
+            }
+
+            const result = await evaluatePromptInjectionGuard({
+              github,
+              context,
+              pr,
+              actor: context.actor,
+              promptContent: pr.body || '',
+              core,
+            });
+
+            core.setOutput('blocked', String(result.blocked));
+            core.setOutput('reason', result.reason);
+
+            if (result.blocked) {
+              core.warning(`Security gate blocked: ${result.reason}`);
+            }
+
+      - name: Evaluate keepalive conditions
+        id: evaluate
+        if: steps.security_gate.outputs.blocked != 'true'
+        uses: actions/github-script@v7
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH;
+            const { evaluateKeepaliveLoop } = require(`${scriptsPath}/keepalive_loop.js`);
+
+            // For workflow_dispatch, inject PR number into payload structure
+            let payload = context.payload;
+            if (context.eventName === 'workflow_dispatch' && process.env.INPUT_PR_NUMBER) {
+              const prNumber = Number(process.env.INPUT_PR_NUMBER);
+              if (prNumber > 0) {
+                // Fetch PR data and inject into a mock workflow_run structure
+                const { data: pr } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                payload = {
+                  ...payload,
+                  workflow_run: {
+                    pull_requests: [{ number: prNumber }],
+                    head_sha: pr.head.sha,
+                    head_branch: pr.head.ref,
+                    conclusion: 'success',  // Assume success for manual trigger
+                  },
+                };
+              }
+            }
+
+            const result = await evaluateKeepaliveLoop({
+              github,
+              context,
+              core,
+              payload,
+            });
+
+            // Map flat result properties to outputs (evaluateKeepaliveLoop returns
+            // properties directly on result object, not nested in result.outputs)
+            const output = {
+              pr_number: String(result.prNumber || ''),
+              pr_ref: String(result.prRef || ''),
+              head_sha: String(result.headSha || ''),
+              action: result.action || '',
+              reason: result.reason || '',
+              gate_conclusion: result.gateConclusion || '',
+              iteration: String(result.iteration ?? ''),
+              max_iterations: String(result.maxIterations ?? ''),
+              failure_threshold: String(result.failureThreshold ?? ''),
+              tasks_total: String(result.checkboxCounts?.total ?? ''),
+              tasks_unchecked: String(result.checkboxCounts?.unchecked ?? ''),
+              keepalive_enabled: String(result.keepaliveEnabled || false),
+              autofix_enabled: String(result.config?.autofix_enabled || false),
+              has_agent_label: String(result.hasAgentLabel || false),
+              agent_type: String(result.agentType || ''),
+              trace: String(result.config?.trace || ''),
+            };
+            for (const [key, value] of Object.entries(output)) {
+              core.setOutput(key, value);
+            }
+            // Task appendix needs special handling due to multiline content
+            core.setOutput('task_appendix', result.taskAppendix || '');
+
+  preflight:
+    name: Verify secrets available
+    needs: evaluate
+    if: needs.evaluate.outputs.action == 'run'
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    outputs:
+      secrets_ok: ${{ steps.check.outputs.secrets_ok }}
+    steps:
+      - name: Check secrets
+        id: check
+        env:
+          HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID != '' }}
+          HAS_APP_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY != '' }}
+        run: |
+          echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
+          echo "WORKFLOWS_APP_ID present: $HAS_APP_ID"
+          echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
+          if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+            echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Neither CODEX_AUTH_JSON nor WORKFLOWS_APP_ID is set. Cannot run Codex."
+            echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+  # Mark agent as running before starting the actual work
+  mark-running:
+    name: Mark agent running
+    needs:
+      - evaluate
+      - preflight
+    if: needs.evaluate.outputs.action == 'run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Workflows scripts
+        uses: actions/checkout@v4
+        with:
+          repository: stranske/Workflows
+          ref: main
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Update summary with running status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { markAgentRunning } = require('./.github/scripts/keepalive_loop.js');
+            const inputs = {
+              pr_number: '${{ needs.evaluate.outputs.pr_number }}',
+              agent_type: '${{ needs.evaluate.outputs.agent_type }}',
+              iteration: '${{ needs.evaluate.outputs.iteration }}',
+              max_iterations: '${{ needs.evaluate.outputs.max_iterations }}',
+              tasks_total: '${{ needs.evaluate.outputs.tasks_total }}',
+              tasks_unchecked: '${{ needs.evaluate.outputs.tasks_unchecked }}',
+              trace: '${{ needs.evaluate.outputs.trace }}',
+              run_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+            };
+            await markAgentRunning({ github, context, core, inputs });
+
+  # Run Codex CLI for agent:codex PRs
+  run-codex:
+    name: Keepalive next task (Codex)
+    needs:
+      - evaluate
+      - preflight
+      - mark-running
+    if: needs.evaluate.outputs.agent_type == 'codex'
+    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+    with:
+      skip: ${{ needs.evaluate.outputs.action != 'run' }}
+      prompt_file: .github/codex/prompts/keepalive_next_task.md
+      mode: keepalive
+      pr_number: ${{ needs.evaluate.outputs.pr_number }}
+      pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
+      appendix: ${{ needs.evaluate.outputs.task_appendix }}
+      iteration: ${{ needs.evaluate.outputs.iteration }}
+
+  summary:
+    name: Update keepalive summary
+    needs:
+      - evaluate
+      - preflight
+      - run-codex
+    if: always() && needs.evaluate.outputs.pr_number != '' && needs.evaluate.outputs.pr_number != '0'
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    steps:
+      - name: Checkout Workflows scripts
+        uses: actions/checkout@v4
+        with:
+          repository: stranske/Workflows
+          ref: main
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Emit keepalive metrics
+        id: keepalive-metrics
+        env:
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          ACTION: ${{ needs.evaluate.outputs.action }}
+          REASON: ${{ needs.evaluate.outputs.reason }}
+          GATE_CONCLUSION: ${{ needs.evaluate.outputs.gate_conclusion }}
+          ITERATION: ${{ needs.evaluate.outputs.iteration }}
+          MAX_ITERATIONS: ${{ needs.evaluate.outputs.max_iterations }}
+          TASKS_TOTAL: ${{ needs.evaluate.outputs.tasks_total }}
+          TASKS_UNCHECKED: ${{ needs.evaluate.outputs.tasks_unchecked }}
+          START_TS: ${{ needs.evaluate.outputs.start_ts }}
+        run: |
+          set -euo pipefail
+
+          now=$(date -u +%s)
+          if [[ "${START_TS:-}" =~ ^[0-9]+$ ]]; then
+            duration=$(( now - START_TS ))
+            if [ "$duration" -lt 0 ]; then duration=0; fi
+          else
+            duration=0
+          fi
+
+          tasks_total=${TASKS_TOTAL:-0}
+          tasks_unchecked=${TASKS_UNCHECKED:-0}
+          if ! [[ "$tasks_total" =~ ^-?[0-9]+$ ]]; then tasks_total=0; fi
+          if ! [[ "$tasks_unchecked" =~ ^-?[0-9]+$ ]]; then tasks_unchecked=0; fi
+          tasks_completed=$(( tasks_total - tasks_unchecked ))
+          if [ "$tasks_completed" -lt 0 ]; then tasks_completed=0; fi
+
+          metrics_json=$(jq -n \
+            --arg pr "${PR_NUMBER:-0}" \
+            --arg iteration "${ITERATION:-0}" \
+            --arg action "${ACTION:-}" \
+            --arg stop_reason "${REASON:-}" \
+            --arg gate_conclusion "${GATE_CONCLUSION:-}" \
+            --arg tasks_total "$tasks_total" \
+            --arg tasks_completed "$tasks_completed" \
+            --arg duration "$duration" \
+            '{
+              pr_number: ($pr | tonumber? // 0),
+              iteration_count: ($iteration | tonumber? // 0),
+              action: $action,
+              stop_reason: $stop_reason,
+              gate_conclusion: $gate_conclusion,
+              tasks_total: ($tasks_total | tonumber? // 0),
+              tasks_completed: ($tasks_completed | tonumber? // 0),
+              duration_seconds: ($duration | tonumber? // 0)
+            }')
+
+          {
+            echo '### Keepalive metrics'
+            echo ''
+            echo '| Field | Value |'
+            echo '| --- | --- |'
+            echo "| pr_number | $(echo "$metrics_json" | jq -r '.pr_number') |"
+            echo "| iteration_count | $(echo "$metrics_json" | jq -r '.iteration_count') |"
+            echo "| action | $(echo "$metrics_json" | jq -r '.action') |"
+            echo "| stop_reason | $(echo "$metrics_json" | jq -r '.stop_reason') |"
+            echo "| gate_conclusion | $(echo "$metrics_json" | jq -r '.gate_conclusion') |"
+            echo "| tasks_total | $(echo "$metrics_json" | jq -r '.tasks_total') |"
+            echo "| tasks_completed | $(echo "$metrics_json" | jq -r '.tasks_completed') |"
+            echo "| duration_seconds | $(echo "$metrics_json" | jq -r '.duration_seconds') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "$metrics_json" >> keepalive-metrics.ndjson
+
+      - name: Upload keepalive metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keepalive-metrics
+          path: keepalive-metrics.ndjson
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Auto-reconcile task checkboxes
+        if: needs.run-codex.outputs.changes-made == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { autoReconcileTasks } = require('./.github/scripts/keepalive_loop.js');
+
+            const prNumber = Number('${{ needs.evaluate.outputs.pr_number }}') || 0;
+            const beforeSha = '${{ needs.evaluate.outputs.head_sha }}';
+            const headSha = '${{ needs.run-codex.outputs.commit-sha }}';
+
+            if (!prNumber || !beforeSha || !headSha) {
+              core.info('Missing required inputs for task reconciliation');
+              return;
+            }
+
+            core.info(`Auto-reconciling tasks for PR #${prNumber}`);
+            core.info(`Comparing ${beforeSha.slice(0, 7)} → ${headSha.slice(0, 7)}`);
+
+            const result = await autoReconcileTasks({
+              github, context, prNumber, baseSha: beforeSha, headSha, core
+            });
+
+            if (result.updated) {
+              core.info(`✅ ${result.details}`);
+              core.notice(`Auto-checked ${result.tasksChecked} task(s) based on commit analysis`);
+            } else {
+              core.info(`ℹ️ ${result.details}`);
+            }
+
+            core.setOutput('tasks_checked', result.tasksChecked);
+            core.setOutput('reconciliation_details', result.details);
+
+      - name: Update summary comment
+        uses: actions/github-script@v7
+        env:
+          CODEX_SUMMARY: ${{ needs.run-codex.outputs.final-message-summary || '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { updateKeepaliveLoopSummary } = require('./.github/scripts/keepalive_loop.js');
+            const inputs = {
+              pr_number: Number('${{ needs.evaluate.outputs.pr_number }}') || 0,
+              action: '${{ needs.evaluate.outputs.action }}',
+              reason: '${{ needs.evaluate.outputs.reason }}',
+              gate_conclusion: '${{ needs.evaluate.outputs.gate_conclusion }}',
+              iteration: Number('${{ needs.evaluate.outputs.iteration }}') || 0,
+              max_iterations: Number('${{ needs.evaluate.outputs.max_iterations }}') || 0,
+              failure_threshold: Number('${{ needs.evaluate.outputs.failure_threshold }}') || 3,
+              tasks_total: Number('${{ needs.evaluate.outputs.tasks_total }}') || 0,
+              tasks_unchecked: Number('${{ needs.evaluate.outputs.tasks_unchecked }}') || 0,
+              keepalive_enabled: '${{ needs.evaluate.outputs.keepalive_enabled }}',
+              autofix_enabled: '${{ needs.evaluate.outputs.autofix_enabled }}',
+              agent_type: '${{ needs.evaluate.outputs.agent_type }}',
+              trace: '${{ needs.evaluate.outputs.trace }}',
+              run_result: '${{ needs.run-codex.result }}',
+              agent_exit_code: '${{ needs.run-codex.outputs.exit-code }}',
+              agent_changes_made: '${{ needs.run-codex.outputs.changes-made }}',
+              agent_commit_sha: '${{ needs.run-codex.outputs.commit-sha }}',
+              agent_files_changed: '${{ needs.run-codex.outputs.files-changed }}',
+              agent_summary: process.env.CODEX_SUMMARY || '',
+            };
+            await updateKeepaliveLoopSummary({ github, context, core, inputs });

--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -19,7 +19,7 @@ PYTEST_VERSION=9.0.2
 PYTEST_COV_VERSION=7.0.0
 
 # Coverage (required by pytest-cov>=7.0.0)
-COVERAGE_VERSION=7.13.0
+COVERAGE_VERSION=7.13.1
 
 # Pydantic (if your project uses it)
 # Uncomment and set these if you encounter pydantic-core version conflicts


### PR DESCRIPTION
## Summary
Adds the critical missing thin caller workflows from `stranske/Workflows/templates/consumer-repo`.

## Root Cause
Keepalive was not working because `agents-keepalive-loop.yml` was missing. This workflow is triggered when Gate completes and is responsible for:
1. Evaluating if keepalive should continue
2. Calling `reusable-codex-run.yml` to execute Codex CLI
3. Updating PR status summaries

## Changes
| File | Purpose |
|------|---------|
| `agents-keepalive-loop.yml` | **CRITICAL** - Triggers Codex after Gate passes |
| `agents-autofix-loop.yml` | Runs autofix when Gate fails |
| `agents-bot-comment-handler.yml` | Handles bot comment triggers |
| `autofix-versions.env` | Version pins for autofix tools |

## Dual Checkout Pattern
All workflows use the consumer repo pattern:
```yaml
# Checkout consumer repo for context
- uses: actions/checkout@v4
  with:
    path: consumer

# Checkout Workflows scripts  
- uses: actions/checkout@v4
  with:
    repository: stranske/Workflows
    sparse-checkout: .github/scripts
    path: workflows-lib
```

## Reference
- Transition doc: `docs/development/WORKFLOWS_TRANSITION.md` section 3.1
- Working examples: `stranske/Travel-Plan-Permission`, `stranske/Manager-Database`

## Testing
After merge:
1. Create issue with `agent:codex` label
2. Issue intake creates bootstrap PR
3. Gate runs on PR
4. **agents-keepalive-loop.yml should now trigger** when Gate completes
5. Codex continues work on PR