### PR TITLE
chore: add codex working files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,14 @@ archive/generated-outputs/*
 # Plots output folder (generated, don't commit)
 plots/*
 !plots/.gitkeep
+
+# Codex working files (preserved via workflow artifacts, not git)
+# CRITICAL: These must be gitignored to prevent merge conflicts when
+# multiple PRs run keepalive simultaneously. Each run rebuilds these files.
+# Generic names (legacy)
+codex-prompt.md
+codex-output.md
+# PR-specific names (used by reusable-codex-run.yml to avoid conflicts)
+codex-prompt-*.md
+codex-output-*.md
+verifier-context.md


### PR DESCRIPTION
Prevents merge conflicts when multiple PRs run keepalive concurrently.

The workflow now uses PR-specific filenames and excludes them from commits, but the .gitignore provides defense-in-depth.

This should be merged quickly to prevent future conflicts.