### PR TITLE
perf(workflows): optimize CI execution - remove duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@
 #
 # NOTE: PAEM uses single Python version (3.12) on Linux only
 # Multi-platform matrix dropped per transition decision 2025-12-29
+#
+# IMPORTANT: This workflow runs on push to main ONLY.
+# PR validation is handled by pr-00-gate.yml to avoid duplicate CI runs.
 name: CI
 
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   workflow_dispatch:
 

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -41,6 +41,7 @@ jobs:
 
   # ───────────────────────────────────────────────────────────────────────────
   # PAEM-specific: Codespace Configuration Validation
+  # Runs in PARALLEL with python-ci (no dependency)
   # ───────────────────────────────────────────────────────────────────────────
   codespace-validation:
     name: Codespace Config
@@ -59,11 +60,14 @@ jobs:
 
   # ───────────────────────────────────────────────────────────────────────────
   # PAEM-specific: Integration Tests (CLI + Golden Tutorials)
+  # Runs in PARALLEL with python-ci for faster feedback
   # ───────────────────────────────────────────────────────────────────────────
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [python-ci]
+    # OPTIMIZATION: Removed 'needs: [python-ci]' - integration tests don't
+    # depend on Python CI passing and can run in parallel for faster feedback.
+    # If integration tests fail, the summary job will still catch it.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Why
Workflow execution is slower in PAEM compared to other consumer repos due to redundant checks.

## Scope
Optimize workflow execution by:
1. Eliminating duplicate CI runs on PRs
2. Running jobs in parallel where possible

## Changes

### 1. Remove duplicate CI runs (ci.yml)
- **Before**: Both `ci.yml` AND `pr-00-gate.yml` triggered on `pull_request`, running the same Python CI workflow twice
- **After**: `ci.yml` runs only on `push` to main; PRs are validated solely by Gate

### 2. Parallelize integration tests (pr-00-gate.yml)  
- **Before**: `integration-tests` waited for `python-ci` to complete (~70s)
- **After**: Runs in parallel - both jobs start immediately

## Expected Improvements
| Metric | Before | After |
|--------|--------|-------|
| Workflow runs per PR push | 2 (CI + Gate) | 1 (Gate only) |
| Gate total time | ~3.5 min | ~2.5 min (parallel) |
| GitHub Actions minutes | 2x | 1x |

## Testing
This PR will validate itself - watch for:
- Only Gate workflow runs (not CI)
- Integration tests start immediately (not after Python CI)