### PR TITLE
chore(codex): bootstrap PR for issue #858

### DIFF
--- a/agents/codex-858.md
+++ b/agents/codex-858.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #858 -->


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #858

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The `build/lib/**` directory contains a full built/distribution copy of the package (including `build/lib/pa_core/cli.py`, `build/lib/dashboard/pages/...`, etc.). This creates several high-risk failure modes:

- **Import shadowing**: If someone's PYTHONPATH or tooling ever includes `build/lib`, stale code gets imported without realizing it
- **Split-brain maintenance**: Changes can land in `pa_core/...` and not in `build/lib/...`, or vice versa
- **Testing ambiguity**: Tests may pass in one environment and fail in another depending on path precedence

#### Tasks
- [ ] Add `build/` to `.gitignore` if not already present
- [ ] Remove `build/lib/` and all contents from git tracking with `git rm -r --cached build/`
- [ ] Verify no imports reference `build/lib` paths
- [ ] Update any documentation that references the `build/` directory structure
- [ ] Create a commit that removes the tracked `build/` files

#### Acceptance criteria
- [ ] `build/` directory is listed in `.gitignore`
- [ ] `git ls-files build/` returns empty (no tracked files)
- [ ] All tests pass after removal
- [ ] No import statements reference `build/lib` paths

<!-- auto-status-summary:end -->