### PR TITLE
chore: configure Dependabot to ignore synced dev tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
     open-pull-requests-limit: 10
     reviewers:
       - "stranske"
@@ -15,9 +17,21 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Track both pyproject.toml and requirements files
-    allow:
-      - dependency-type: "all"
+    # Ignore dev tools - these are synced from stranske/Workflows via maint-52
+    # Updates flow: Workflows (Dependabot) -> autofix-versions.env -> consumer repos
+    ignore:
+      - dependency-name: "ruff"
+      - dependency-name: "black"
+      - dependency-name: "mypy"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-cov"
+      - dependency-name: "pytest-xdist"
+      - dependency-name: "isort"
+      - dependency-name: "docformatter"
+      - dependency-name: "coverage"
+      - dependency-name: "hypothesis"
+    # Group all non-ignored dependencies together for minor/patch updates
+    # NOTE: No overlapping groups - using single pattern to avoid Dependabot errors
     groups:
       python-minor:
         patterns:


### PR DESCRIPTION
## Summary

Updates Dependabot config to ignore dev tools that are now synced from `stranske/Workflows` via the `maint-52-sync-dev-versions` workflow.

## Why

Dev tools are now managed centrally:
1. Dependabot updates `stranske/Workflows` on **Sundays**
2. Updates are tested in CI
3. `maint-52-sync-dev-versions` syncs to consumer repos
4. Consumer repos get consistent, tested versions

## Changes

**Ignored packages** (synced from Workflows):
- ruff, black, mypy, isort, docformatter
- pytest, pytest-cov, pytest-xdist, coverage
- hypothesis

**Still updated by Dependabot**:
- Runtime deps: pandas, numpy, pydantic, PyYAML, requests, jsonschema
- GitHub Actions

## Benefits

- No duplicate PRs for dev tools
- No version conflicts
- Consistent dev tool versions across all repos