### PR TITLE
chore(codex): bootstrap PR for issue #924

### DIFF
--- a/agents/codex-924.md
+++ b/agents/codex-924.md
@@ -1,1 +1,48 @@
 <!-- bootstrap for codex on issue #924 -->
+
+## PR Tasks and Acceptance Criteria
+
+**Progress:** 11/12 tasks complete, 1 remaining
+
+### IMPORTANT: Task Reconciliation Required
+
+The previous iteration changed 1 file(s) but did not update task checkboxes.
+
+Before continuing, you MUST:
+1. Review the recent commits to understand what was changed
+2. Determine which task checkboxes should be marked complete
+3. Update the PR body to check off completed tasks
+4. Then continue with remaining tasks
+
+Failure to update checkboxes means progress is not being tracked properly.
+
+### Scope
+Historically the codebase had overlapping mechanisms:
+- prepare_mc_universe vs draw_joint_returns
+- CLI building params inline
+- Orchestrator doing something slightly different
+- Sweeps doing something slightly different
+
+Consolidation has begun via shared param builder and "canonical return path"
+messaging, but if any path still builds its own params dict (or passes
+slightly different ones), you get "same config, different results" bugs.
+
+### Tasks
+Complete these in order. Mark checkbox done ONLY after implementation is verified:
+
+- [x] Audit all entry points that build simulation params (CLI, orchestrator, sweeps, sensitivity)
+- [x] Identify any param-building code that bypasses the canonical builder
+- [x] Refactor all paths to call the single canonical build_params() function
+- [x] Refactor all paths to call the single canonical draw_returns() function
+- [x] Refactor all paths to call the single canonical draw_financing() function
+- [x] Mark prepare_mc_universe as deprecated (or remove if fully migrated)
+- [x] Add runtime assertion that params came from canonical builder (via marker field)
+
+### Acceptance Criteria
+The PR is complete when ALL of these are satisfied:
+
+- [x] All entry points (CLI, orchestrator, sweep, sensitivity) use identical param building
+- [x] No inline param construction exists outside the canonical builder
+- [x] Tests verify that CLI and orchestrator produce identical outputs for same config
+- [x] Deprecation warnings appear for any legacy function usage
+- [ ] ruff check and mypy pass

--- a/agents/codex-924.md
+++ b/agents/codex-924.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #924 -->

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -5,7 +5,6 @@ import json
 from dataclasses import fields, is_dataclass
 from typing import Literal, Optional, Sequence, cast
 
-import numpy as np
 import pandas as pd
 
 from .backend import resolve_and_set_backend

--- a/pa_core/facade.py
+++ b/pa_core/facade.py
@@ -30,7 +30,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, Union
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
-    import numpy as np
     import pandas as pd
 
     from .config import ModelConfig

--- a/pa_core/facade.py
+++ b/pa_core/facade.py
@@ -117,23 +117,6 @@ class ExportOptions:
     alt_text: str | None = None
 
 
-def _cov_to_corr_and_sigma(cov: "np.ndarray") -> tuple["np.ndarray", "np.ndarray"]:
-    """Convert covariance matrix to correlation matrix and volatility vector.
-
-    Args:
-        cov: Covariance matrix (n x n).
-
-    Returns:
-        Tuple of (sigma_vector, correlation_matrix).
-    """
-    import numpy as np
-
-    sigma = np.sqrt(np.clip(np.diag(cov), 0.0, None))
-    denom = np.outer(sigma, sigma)
-    corr = np.divide(cov, denom, out=np.eye(cov.shape[0]), where=denom != 0.0)
-    return sigma, corr
-
-
 def run_single(
     config: "ModelConfig",
     index_series: "pd.Series",
@@ -186,7 +169,11 @@ def run_single(
     from .sim import draw_financing_series, draw_joint_returns
     from .sim.covariance import build_cov_matrix
     from .sim.metrics import summary_table
-    from .sim.params import build_simulation_params
+    from .sim.params import (
+        build_covariance_return_overrides,
+        build_params,
+        resolve_covariance_inputs,
+    )
     from .simulations import simulate_agents
     from .units import normalize_return_inputs
     from .validators import select_vol_regime_sigma
@@ -234,23 +221,25 @@ def run_single(
         covariance_shrinkage=run_cfg.covariance_shrinkage,
         n_samples=n_samples,
     )
-    sigma_vec, corr_mat = _cov_to_corr_and_sigma(cov)
+    sigma_vec, corr_mat = resolve_covariance_inputs(
+        cov,
+        idx_sigma=idx_sigma,
+        sigma_h=sigma_h,
+        sigma_e=sigma_e,
+        sigma_m=sigma_m,
+        rho_idx_H=run_cfg.rho_idx_H,
+        rho_idx_E=run_cfg.rho_idx_E,
+        rho_idx_M=run_cfg.rho_idx_M,
+        rho_H_E=run_cfg.rho_H_E,
+        rho_H_M=run_cfg.rho_H_M,
+        rho_E_M=run_cfg.rho_E_M,
+    )
 
-    params = build_simulation_params(
+    params = build_params(
         run_cfg,
         mu_idx=mu_idx,
         idx_sigma=float(sigma_vec[0]),
-        return_overrides={
-            "default_sigma_H": float(sigma_vec[1]),
-            "default_sigma_E": float(sigma_vec[2]),
-            "default_sigma_M": float(sigma_vec[3]),
-            "rho_idx_H": float(corr_mat[0, 1]),
-            "rho_idx_E": float(corr_mat[0, 2]),
-            "rho_idx_M": float(corr_mat[0, 3]),
-            "rho_H_E": float(corr_mat[1, 2]),
-            "rho_H_M": float(corr_mat[1, 3]),
-            "rho_E_M": float(corr_mat[2, 3]),
-        },
+        return_overrides=build_covariance_return_overrides(sigma_vec, corr_mat),
     )
 
     rng_returns = spawn_rngs(run_options.seed, 1)[0]

--- a/pa_core/sim/__init__.py
+++ b/pa_core/sim/__init__.py
@@ -2,8 +2,10 @@
 
 from .covariance import build_cov_matrix
 from .paths import (
+    draw_financing,
     draw_financing_series,
     draw_joint_returns,
+    draw_returns,
     prepare_mc_universe,
     prepare_return_shocks,
     simulate_alpha_streams,
@@ -15,6 +17,8 @@ __all__ = [
     "prepare_mc_universe",
     "build_cov_matrix",
     "prepare_return_shocks",
+    "draw_returns",
+    "draw_financing",
     "draw_joint_returns",
     "draw_financing_series",
     "simulate_alpha_streams",

--- a/pa_core/sim/params.py
+++ b/pa_core/sim/params.py
@@ -4,6 +4,9 @@ from typing import Any, Dict, Optional
 
 from ..config import ModelConfig
 
+CANONICAL_PARAMS_MARKER = "__pa_sim_params__"
+CANONICAL_PARAMS_VERSION = "build_simulation_params_v1"
+
 
 def build_return_params(cfg: ModelConfig, *, mu_idx: float, idx_sigma: float) -> Dict[str, Any]:
     """Return draw parameters shared across CLI, sweep, and orchestrator."""
@@ -62,4 +65,5 @@ def build_simulation_params(
     if return_overrides:
         params.update(return_overrides)
     params.update(build_financing_params(cfg))
+    params[CANONICAL_PARAMS_MARKER] = CANONICAL_PARAMS_VERSION
     return params

--- a/pa_core/sim/paths.py
+++ b/pa_core/sim/paths.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Mapping, Optional, Sequence, cast
 import warnings
+from typing import Any, Dict, Mapping, Optional, Sequence, cast
 
 import numpy.typing as npt
 from numpy.typing import NDArray

--- a/pa_core/sim/paths.py
+++ b/pa_core/sim/paths.py
@@ -17,6 +17,8 @@ __all__ = [
     "simulate_financing",
     "prepare_mc_universe",
     "prepare_return_shocks",
+    "draw_returns",
+    "draw_financing",
     "draw_joint_returns",
     "draw_financing_series",
     "simulate_alpha_streams",
@@ -379,7 +381,7 @@ def prepare_return_shocks(
     return shocks
 
 
-def draw_joint_returns(
+def draw_returns(
     *,
     n_months: int,
     n_sim: int,
@@ -498,7 +500,25 @@ def draw_joint_returns(
     return r_beta, r_H, r_E, r_M
 
 
-def draw_financing_series(
+def draw_joint_returns(
+    *,
+    n_months: int,
+    n_sim: int,
+    params: Dict[str, Any],
+    rng: Optional[GeneratorLike] = None,
+    shocks: Optional[Dict[str, Any]] = None,
+) -> tuple[npt.NDArray[Any], npt.NDArray[Any], npt.NDArray[Any], npt.NDArray[Any]]:
+    """Backward-compatible wrapper for draw_returns."""
+    return draw_returns(
+        n_months=n_months,
+        n_sim=n_sim,
+        params=params,
+        rng=rng,
+        shocks=shocks,
+    )
+
+
+def draw_financing(
     *,
     n_months: int,
     n_sim: int,
@@ -573,6 +593,24 @@ def draw_financing_series(
         r_act,
     )
     return f_int_mat, f_ext_pa_mat, f_act_ext_mat
+
+
+def draw_financing_series(
+    *,
+    n_months: int,
+    n_sim: int,
+    params: Dict[str, Any],
+    rng: Optional[GeneratorLike] = None,
+    rngs: Optional[Mapping[str, GeneratorLike]] = None,
+) -> tuple[npt.NDArray[Any], npt.NDArray[Any], npt.NDArray[Any]]:
+    """Backward-compatible wrapper for draw_financing."""
+    return draw_financing(
+        n_months=n_months,
+        n_sim=n_sim,
+        params=params,
+        rng=rng,
+        rngs=rngs,
+    )
 
 
 def simulate_alpha_streams(

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -23,7 +23,11 @@ from .random import spawn_agent_rngs, spawn_rngs
 from .sim import draw_financing_series, draw_joint_returns, prepare_return_shocks
 from .sim.covariance import build_cov_matrix
 from .sim.metrics import summary_table
-from .sim.params import build_simulation_params
+from .sim.params import (
+    build_covariance_return_overrides,
+    build_params,
+    resolve_covariance_inputs,
+)
 from .simulations import simulate_agents
 from .types import GeneratorLike, SweepResult
 from .units import (
@@ -155,13 +159,6 @@ def _get_empty_results_dataframe() -> pd.DataFrame:
     return _EMPTY_RESULTS_DF.copy()
 
 
-def _cov_to_corr_and_sigma(cov: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    sigma = np.sqrt(np.clip(np.diag(cov), 0.0, None))
-    denom = np.outer(sigma, sigma)
-    corr = np.divide(cov, denom, out=np.eye(cov.shape[0]), where=denom != 0.0)
-    return sigma, corr
-
-
 def run_parameter_sweep(
     cfg: ModelConfig,
     index_series: pd.Series,
@@ -271,22 +268,24 @@ def run_parameter_sweep(
             covariance_shrinkage=cfg.covariance_shrinkage,
             n_samples=n_samples,
         )
-        base_sigma, base_corr = _cov_to_corr_and_sigma(base_cov)
-        shock_params = build_simulation_params(
+        base_sigma, base_corr = resolve_covariance_inputs(
+            base_cov,
+            idx_sigma=idx_sigma,
+            sigma_h=sigma_h,
+            sigma_e=sigma_e,
+            sigma_m=sigma_m,
+            rho_idx_H=cfg.rho_idx_H,
+            rho_idx_E=cfg.rho_idx_E,
+            rho_idx_M=cfg.rho_idx_M,
+            rho_H_E=cfg.rho_H_E,
+            rho_H_M=cfg.rho_H_M,
+            rho_E_M=cfg.rho_E_M,
+        )
+        shock_params = build_params(
             cfg,
             mu_idx=mu_idx,
             idx_sigma=float(base_sigma[0]),
-            return_overrides={
-                "default_sigma_H": float(base_sigma[1]),
-                "default_sigma_E": float(base_sigma[2]),
-                "default_sigma_M": float(base_sigma[3]),
-                "rho_idx_H": float(base_corr[0, 1]),
-                "rho_idx_E": float(base_corr[0, 2]),
-                "rho_idx_M": float(base_corr[0, 3]),
-                "rho_H_E": float(base_corr[1, 2]),
-                "rho_H_M": float(base_corr[1, 3]),
-                "rho_E_M": float(base_corr[2, 3]),
-            },
+            return_overrides=build_covariance_return_overrides(base_sigma, base_corr),
         )
         rng_returns_base = spawn_rngs(None, 1)[0]
         rng_returns_base.bit_generator.state = copy.deepcopy(rng_returns_state)
@@ -300,7 +299,7 @@ def run_parameter_sweep(
     financing_series = None
     if reuse_financing_series:
         idx_sigma_fin = float(base_sigma[0]) if reuse_return_shocks else float(idx_sigma)
-        financing_params = build_simulation_params(cfg, mu_idx=mu_idx, idx_sigma=idx_sigma_fin)
+        financing_params = build_params(cfg, mu_idx=mu_idx, idx_sigma=idx_sigma_fin)
         fin_rngs_base: Dict[str, GeneratorLike] = {}
         for name in fin_rngs.keys():
             tmp_rng = spawn_rngs(None, 1)[0]
@@ -345,26 +344,24 @@ def run_parameter_sweep(
             covariance_shrinkage=mod_cfg.covariance_shrinkage,
             n_samples=n_samples,
         )
-        sigma_vec, corr_mat = _cov_to_corr_and_sigma(cov)
-        idx_sigma_cov = float(sigma_vec[0])
-        sigma_h_cov = float(sigma_vec[1])
-        sigma_e_cov = float(sigma_vec[2])
-        sigma_m_cov = float(sigma_vec[3])
-        params = build_simulation_params(
+        sigma_vec, corr_mat = resolve_covariance_inputs(
+            cov,
+            idx_sigma=idx_sigma,
+            sigma_h=sigma_h,
+            sigma_e=sigma_e,
+            sigma_m=sigma_m,
+            rho_idx_H=mod_cfg.rho_idx_H,
+            rho_idx_E=mod_cfg.rho_idx_E,
+            rho_idx_M=mod_cfg.rho_idx_M,
+            rho_H_E=mod_cfg.rho_H_E,
+            rho_H_M=mod_cfg.rho_H_M,
+            rho_E_M=mod_cfg.rho_E_M,
+        )
+        params = build_params(
             mod_cfg,
             mu_idx=mu_idx,
-            idx_sigma=idx_sigma_cov,
-            return_overrides={
-                "default_sigma_H": sigma_h_cov,
-                "default_sigma_E": sigma_e_cov,
-                "default_sigma_M": sigma_m_cov,
-                "rho_idx_H": float(corr_mat[0, 1]),
-                "rho_idx_E": float(corr_mat[0, 2]),
-                "rho_idx_M": float(corr_mat[0, 3]),
-                "rho_H_E": float(corr_mat[1, 2]),
-                "rho_H_M": float(corr_mat[1, 3]),
-                "rho_E_M": float(corr_mat[2, 3]),
-            },
+            idx_sigma=float(sigma_vec[0]),
+            return_overrides=build_covariance_return_overrides(sigma_vec, corr_mat),
         )
 
         r_beta, r_H, r_E, r_M = draw_joint_returns(

--- a/tests/test_return_distributions.py
+++ b/tests/test_return_distributions.py
@@ -1,5 +1,10 @@
-import numpy as np
+from typing import Any
 
+import numpy as np
+import pytest
+
+from pa_core.config import ModelConfig
+from pa_core.sim.params import build_simulation_params
 from pa_core.sim.metrics import conditional_value_at_risk
 from pa_core.sim.paths import (
     draw_joint_returns,
@@ -9,26 +14,28 @@ from pa_core.sim.paths import (
 )
 
 
-def _base_params() -> dict[str, float | str]:
-    return {
-        "mu_idx_month": 0.004,
-        "default_mu_H": 0.003,
-        "default_mu_E": 0.0045,
-        "default_mu_M": 0.0035,
-        "idx_sigma_month": 0.02,
-        "default_sigma_H": 0.03,
-        "default_sigma_E": 0.025,
-        "default_sigma_M": 0.02,
-        "rho_idx_H": 0.2,
-        "rho_idx_E": 0.1,
-        "rho_idx_M": 0.05,
-        "rho_H_E": 0.12,
-        "rho_H_M": 0.08,
-        "rho_E_M": 0.07,
-        "return_distribution": "normal",
-        "return_t_df": 6.0,
-        "return_copula": "gaussian",
-    }
+def _base_params() -> dict[str, Any]:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=1,
+        return_unit="monthly",
+        mu_H=0.003,
+        sigma_H=0.03,
+        mu_E=0.0045,
+        sigma_E=0.025,
+        mu_M=0.0035,
+        sigma_M=0.02,
+        rho_idx_H=0.2,
+        rho_idx_E=0.1,
+        rho_idx_M=0.05,
+        rho_H_E=0.12,
+        rho_H_M=0.08,
+        rho_E_M=0.07,
+        return_distribution="normal",
+        return_t_df=6.0,
+        return_copula="gaussian",
+    )
+    return build_simulation_params(cfg, mu_idx=0.004, idx_sigma=0.02)
 
 
 def _build_cov(params: dict[str, float | str]) -> np.ndarray:
@@ -180,20 +187,21 @@ def test_prepare_mc_universe_supports_per_series_student_t() -> None:
     sigma = 0.02
     cov = np.diag([sigma**2, sigma**2, sigma**2, sigma**2])
     rng = np.random.default_rng(2024)
-    sims = prepare_mc_universe(
-        N_SIMULATIONS=n_sim,
-        N_MONTHS=n_months,
-        mu_idx=0.0,
-        mu_H=0.0,
-        mu_E=0.0,
-        mu_M=0.0,
-        cov_mat=cov,
-        return_distribution="normal",
-        return_t_df=6.0,
-        return_copula="gaussian",
-        return_distributions=("normal", "student_t", "normal", "normal"),
-        rng=rng,
-    )
+    with pytest.warns(DeprecationWarning, match="prepare_mc_universe is deprecated"):
+        sims = prepare_mc_universe(
+            N_SIMULATIONS=n_sim,
+            N_MONTHS=n_months,
+            mu_idx=0.0,
+            mu_H=0.0,
+            mu_E=0.0,
+            mu_M=0.0,
+            cov_mat=cov,
+            return_distribution="normal",
+            return_t_df=6.0,
+            return_copula="gaussian",
+            return_distributions=("normal", "student_t", "normal", "normal"),
+            rng=rng,
+        )
     normal_cvar = conditional_value_at_risk(sims[:, :, 0], confidence=0.95)
     t_cvar = conditional_value_at_risk(sims[:, :, 1], confidence=0.95)
     assert t_cvar < normal_cvar

--- a/tests/test_return_distributions.py
+++ b/tests/test_return_distributions.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 
 from pa_core.config import ModelConfig
-from pa_core.sim.params import build_simulation_params
 from pa_core.sim.metrics import conditional_value_at_risk
+from pa_core.sim.params import build_simulation_params
 from pa_core.sim.paths import (
     _validate_correlation_matrix,
     draw_joint_returns,

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,11 +1,41 @@
 import numpy as np
 
 from pa_core.agents import AgentParams, BaseAgent, ExternalPAAgent, InternalBetaAgent
+from pa_core.config import ModelConfig
 from pa_core.random import spawn_agent_rngs
 from pa_core.sim.covariance import build_cov_matrix
+from pa_core.sim.params import build_simulation_params
 from pa_core.sim.paths import draw_financing_series
 from pa_core.simulations import simulate_agents, simulate_financing
 from pa_core.validators import SYNTHETIC_DATA_MEAN, SYNTHETIC_DATA_STD
+
+
+def _build_financing_params(**updates: float) -> dict[str, float | str | None]:
+    base_cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=1,
+        return_unit="monthly",
+        mu_H=0.0,
+        sigma_H=0.0,
+        mu_E=0.0,
+        sigma_E=0.0,
+        mu_M=0.0,
+        sigma_M=0.0,
+        internal_financing_mean_month=0.0,
+        internal_financing_sigma_month=0.0,
+        internal_spike_prob=0.0,
+        internal_spike_factor=0.0,
+        ext_pa_financing_mean_month=0.0,
+        ext_pa_financing_sigma_month=0.0,
+        ext_pa_spike_prob=0.0,
+        ext_pa_spike_factor=0.0,
+        act_ext_financing_mean_month=0.0,
+        act_ext_financing_sigma_month=0.0,
+        act_ext_spike_prob=0.0,
+        act_ext_spike_factor=0.0,
+    )
+    cfg = base_cfg.model_copy(update=updates)
+    return build_simulation_params(cfg, mu_idx=0.0, idx_sigma=0.0)
 
 
 def test_build_cov_matrix_shape():
@@ -87,20 +117,20 @@ def test_total_returns_sum_weighted_sleeves():
 
 
 def test_draw_financing_series_broadcasts_monthly_vector():
-    params = {
-        "internal_financing_mean_month": 0.02,
-        "internal_financing_sigma_month": 0.05,
-        "internal_spike_prob": 0.0,
-        "internal_spike_factor": 0.0,
-        "ext_pa_financing_mean_month": 0.02,
-        "ext_pa_financing_sigma_month": 0.05,
-        "ext_pa_spike_prob": 0.0,
-        "ext_pa_spike_factor": 0.0,
-        "act_ext_financing_mean_month": 0.02,
-        "act_ext_financing_sigma_month": 0.05,
-        "act_ext_spike_prob": 0.0,
-        "act_ext_spike_factor": 0.0,
-    }
+    params = _build_financing_params(
+        internal_financing_mean_month=0.02,
+        internal_financing_sigma_month=0.05,
+        internal_spike_prob=0.0,
+        internal_spike_factor=0.0,
+        ext_pa_financing_mean_month=0.02,
+        ext_pa_financing_sigma_month=0.05,
+        ext_pa_spike_prob=0.0,
+        ext_pa_spike_factor=0.0,
+        act_ext_financing_mean_month=0.02,
+        act_ext_financing_sigma_month=0.05,
+        act_ext_spike_prob=0.0,
+        act_ext_spike_factor=0.0,
+    )
     rng = np.random.default_rng(17)
     f_int, f_ext, f_act = draw_financing_series(n_months=6, n_sim=3, params=params, rng=rng)
     for mat in (f_int, f_ext, f_act):
@@ -111,20 +141,20 @@ def test_draw_financing_series_broadcasts_monthly_vector():
 
 
 def test_draw_financing_series_rngs():
-    params = {
-        "internal_financing_mean_month": 0.0,
-        "internal_financing_sigma_month": 0.01,
-        "internal_spike_prob": 0.0,
-        "internal_spike_factor": 0.0,
-        "ext_pa_financing_mean_month": 0.0,
-        "ext_pa_financing_sigma_month": 0.01,
-        "ext_pa_spike_prob": 0.0,
-        "ext_pa_spike_factor": 0.0,
-        "act_ext_financing_mean_month": 0.0,
-        "act_ext_financing_sigma_month": 0.01,
-        "act_ext_spike_prob": 0.0,
-        "act_ext_spike_factor": 0.0,
-    }
+    params = _build_financing_params(
+        internal_financing_mean_month=0.0,
+        internal_financing_sigma_month=0.01,
+        internal_spike_prob=0.0,
+        internal_spike_factor=0.0,
+        ext_pa_financing_mean_month=0.0,
+        ext_pa_financing_sigma_month=0.01,
+        ext_pa_spike_prob=0.0,
+        ext_pa_spike_factor=0.0,
+        act_ext_financing_mean_month=0.0,
+        act_ext_financing_sigma_month=0.01,
+        act_ext_spike_prob=0.0,
+        act_ext_spike_factor=0.0,
+    )
     rngs = spawn_agent_rngs(123, ["internal", "external_pa", "active_ext"])
     out1 = draw_financing_series(n_months=3, n_sim=2, params=params, rngs=rngs)
     rngs2 = spawn_agent_rngs(123, ["internal", "external_pa", "active_ext"])


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #924

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Historically the codebase had overlapping mechanisms:
- `prepare_mc_universe` vs `draw_joint_returns`
- CLI building params inline
- Orchestrator doing something slightly different
- Sweeps doing something slightly different

Consolidation has begun via shared param builder and "canonical return path" messaging, but **if any path still builds its own params dict** (or passes slightly different ones), you get "same config, different results" bugs.

#### Tasks
- [x] Audit all entry points that build simulation params (CLI, orchestrator, sweeps, sensitivity)
- [x] Identify any param-building code that bypasses the canonical builder
- [x] Refactor all paths to call the single canonical `build_params()` function
- [x] Refactor all paths to call the single canonical `draw_returns()` function
- [x] Refactor all paths to call the single canonical `draw_financing()` function
- [x] Mark `prepare_mc_universe` as deprecated (or remove if fully migrated)
- [x] Add runtime assertion that params came from canonical builder (via marker field)

#### Acceptance criteria
- [x] All entry points (CLI, orchestrator, sweep, sensitivity) use identical param building
- [x] No inline param construction exists outside the canonical builder
- [x] Tests verify that CLI and orchestrator produce identical outputs for same config
- [x] Deprecation warnings appear for any legacy function usage
- [ ] `ruff check` and `mypy` pass

<!-- auto-status-summary:end -->