### PR TITLE
Fix: Update sync job permissions for nested reusable workflow

### DIFF
--- a/.github/workflows/agents-issue-intake.yml
+++ b/.github/workflows/agents-issue-intake.yml
@@ -176,10 +176,11 @@ jobs:
     needs: route
     if: needs.route.outputs.should_run_sync == 'true'
     permissions:
-      contents: read
+      contents: write
       issues: write
       id-token: write
       models: read
+      pull-requests: write
     uses: stranske/Workflows/.github/workflows/agents-63-issue-intake.yml@main
     with:
       intake_mode: "chatgpt_sync"


### PR DESCRIPTION
The agent_bridge job in the reusable workflow requires contents:write and pull-requests:write permissions. When calling reusable workflows with explicit permissions, those become the maximum permissions available to nested jobs.

This fixes startup_failure errors.