### PR TITLE
Fix: Remove concurrency deadlock and add models:read permission

### DIFF
--- a/.github/workflows/agents-issue-intake.yml
+++ b/.github/workflows/agents-issue-intake.yml
@@ -69,10 +69,6 @@ permissions:
   issues: write
   pull-requests: write
 
-concurrency:
-  group: issue-intake-${{ github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   # Determine which mode to run
   route:
@@ -85,13 +81,15 @@ jobs:
       - name: Determine mode
         id: determine
         run: |
+          echo "DEBUG: event_name=${{ github.event_name }}"
+          echo "DEBUG: inputs.mode=${{ inputs.mode }}"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             mode="${{ inputs.mode || 'agent_bridge' }}"
           else
             # Issue events always use agent_bridge mode
             mode="agent_bridge"
           fi
-
+          echo "DEBUG: final mode=${mode}"
           echo "mode=${mode}" >> $GITHUB_OUTPUT
 
           if [[ "${mode}" == "agent_bridge" ]]; then


### PR DESCRIPTION
- Removed concurrency block from caller to prevent deadlock with reusable workflow
- Added models:read permission required by format_created_issues nested job
- Added debug logging to mode determination

This fixes startup_failure and concurrency deadlock errors.