### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=25.12.0
-RUFF_VERSION=0.14.13
+RUFF_VERSION=0.14.11
 ISORT_VERSION=7.0.0
 DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.19.1
@@ -13,3 +13,4 @@ PYTEST_VERSION=9.0.2
 PYTEST_COV_VERSION=7.0.0
 PYTEST_XDIST_VERSION=3.8.0
 COVERAGE_VERSION=7.13.1
+

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -670,9 +670,9 @@ def _generate_with_llm(
     pr_number: int,
     codex_log: str | None,
     reasoning_client: Any,
-    reasoning_model: str,
+    reasoning_model: str,  # noqa: ARG001 - kept for API compatibility
     standard_client: Any,
-    standard_model: str,
+    standard_model: str,  # noqa: ARG001 - kept for API compatibility
 ) -> FollowupIssue:
     """Generate follow-up issue using multi-round LLM interaction.
 

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -12,10 +12,9 @@ import argparse
 import ast
 import re
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any, cast
-
-import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = REPO_ROOT / "src"


### PR DESCRIPTION
## Sync Summary

### Files Updated
- autofix-versions.env: Autofix tool version pins - shared dev tool versions (synced)
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow
- followup_issue_generator.py: Follow-up issue generator - creates issues from verification feedback

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)