### PR TITLE
fix: add repository: stranske/Workflows to belt-tools checkout

### DIFF
--- a/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/.github/workflows/agents-72-codex-belt-worker.yml
@@ -497,6 +497,7 @@ jobs:
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') }}
         uses: actions/checkout@v6
         with:
+          repository: stranske/Workflows
           ref: ${{ github.ref }}
           token: ${{ env.GH_BELT_TOKEN }}
           fetch-depth: 1


### PR DESCRIPTION
The belt-tools checkout was missing the repository specification, causing it to checkout the consumer repo instead of Workflows repo. This meant scripts/*.py files weren't available in .belt-tools/.

Fixes #1175

<!-- pr-preamble:start -->
> **Source:** Issue #1175

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Users can configure portfolios that violate constraints (negative weights, exceeding leverage limits, etc.) without clear feedback. Proactive validation would:
Catch configuration errors early
Suggest corrections for common mistakes
Improve user experience

#### Tasks
- [ ] Define common constraints for weight bounds
- [ ] Define common constraints for leverage
- [ ] Define common constraints for concentration
- [ ] Add validation hooks in portfolio construction
- [ ] Generate suggestions for constraint violations
- [ ] Add `--validate-only` CLI flag
- [ ] Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages
- [ ] Define approach for: Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages (verify: tests pass)
- [ ] Define scope for: Implement: Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages (verify: tests pass)
- [ ] Implement focused slice for: Implement: Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages (verify: tests pass)
- [ ] Validate focused slice for: Implement: Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages (verify: tests pass)
- [ ] Define scope for: Validate: Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages (verify: tests pass)
- [ ] Implement focused slice for: Validate: Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages (verify: tests pass)
- [ ] Validate focused slice for: Validate: Implement `ConstraintValidator` class to validate portfolio constraints with unit tests ensuring correct error messages (verify: tests pass)
- [ ] Document supported constraints in `docs/constraints.md` with examples and usage guidelines
- [ ] Document supported constraints in `docs/constraints.md` with examples (verify: docs updated)
- [ ] Define scope for: Document supported constraints in `docs/constraints.md` with usage guidelines (verify: docs updated)
- [ ] Implement focused slice for: Document supported constraints in `docs/constraints.md` with usage guidelines (verify: docs updated)
- [ ] Validate focused slice for: Document supported constraints in `docs/constraints.md` with usage guidelines (verify: docs updated)

#### Acceptance criteria
- [ ] Invalid portfolios produce clear error messages
- [ ] Error messages suggest how to fix the violation
- [ ] Validation can run without executing full simulation
- [ ] Common constraints are pre-defined and documented

**Head SHA:** e518cc3f839fded3558c84f494a0d23344aeaf48
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/21155044946) |
| Autofix | ⏳ queued | [View run](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/21155044936) |
| Copilot code review | ⏳ queued | [View run](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/21155046325) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/21155044875) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/21155044945) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/21155044867) |
<!-- auto-status-summary:end -->