### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -101,10 +101,6 @@ runs:
         # Check if already installed
         if [ -d "node_modules/@octokit/rest" ]; then
           echo "✅ @octokit/rest already installed"
-          # Clean up if we created package.json (already installed case)
-          if [ "$CREATED_PACKAGE_JSON" = "true" ]; then
-            rm -f package.json package-lock.json
-          fi
         else
           # Install with pinned versions for consistency
           # Capture stderr for debugging if the command fails
@@ -127,12 +123,6 @@ runs:
               @octokit/auth-app@6.0.3
           fi
           echo "✅ @octokit dependencies installed"
-
-          # Clean up package*.json if we created them to avoid polluting working tree
-          if [ "$CREATED_PACKAGE_JSON" = "true" ]; then
-            rm -f package.json package-lock.json
-            echo "🧹 Cleaned up temporary package*.json files"
-          fi
         fi
 
     - name: Export NODE_PATH for shared deps

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-
 from scripts.langchain.structured_output import (
     DEFAULT_REPAIR_PROMPT,
     build_repair_callback,

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -18,9 +18,9 @@ from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, Field
+from scripts.langchain.structured_output import build_repair_callback, parse_structured_output
 
 from scripts import api_client
-from scripts.langchain.structured_output import build_repair_callback, parse_structured_output
 
 PR_EVALUATION_PROMPT = """
 You are reviewing a **merged** pull request to evaluate whether the code

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -12,9 +12,10 @@ import argparse
 import ast
 import re
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any, cast
+
+import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = REPO_ROOT / "src"


### PR DESCRIPTION
## Sync Summary

### Files Updated
- setup-api-client/ (1 files): Unified API client setup - installs @octokit deps and exports all load balancer tokens

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)