### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/setup-api-client/action.yml
+++ b/.github/actions/setup-api-client/action.yml
@@ -101,10 +101,6 @@ runs:
         # Check if already installed
         if [ -d "node_modules/@octokit/rest" ]; then
           echo "✅ @octokit/rest already installed"
-          # Clean up if we created package.json (already installed case)
-          if [ "$CREATED_PACKAGE_JSON" = "true" ]; then
-            rm -f package.json package-lock.json
-          fi
         else
           # Install with pinned versions for consistency
           # Capture stderr for debugging if the command fails
@@ -127,12 +123,6 @@ runs:
               @octokit/auth-app@6.0.3
           fi
           echo "✅ @octokit dependencies installed"
-
-          # Clean up package*.json if we created them to avoid polluting working tree
-          if [ "$CREATED_PACKAGE_JSON" = "true" ]; then
-            rm -f package.json package-lock.json
-            echo "🧹 Cleaned up temporary package*.json files"
-          fi
         fi
 
     - name: Export NODE_PATH for shared deps

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -311,8 +311,48 @@ jobs:
             for (const [key, value] of Object.entries(output)) {
               core.setOutput(key, value);
             }
-            // Task appendix needs special handling due to multiline content
+            
+            // Task appendix: Write directly to file to avoid GitHub's secret scanner
+            // blocking job outputs (which happens with long/repetitive content).
+            // Writing here (before setting the task_appendix output) ensures the content
+            // reaches the artifact even if that output gets censored.
+            const fs = require('fs');
+            const path = require('path');
+            const artifactsDir = '/tmp/keepalive-artifacts';
+            const appendixPath = path.join(artifactsDir, 'task-appendix.txt');
+
+            // Ensure artifacts directory exists
+            fs.mkdirSync(artifactsDir, { recursive: true });
+
+            // Write the full task appendix directly to the artifact file
+            if (result.taskAppendix && result.taskAppendix.length > 0) {
+              fs.writeFileSync(appendixPath, result.taskAppendix + '\n', { encoding: 'utf8' });
+              core.info(`Task appendix written directly to file (${result.taskAppendix.length} chars)`);
+            } else {
+              // Create an empty file if there is no appendix content
+              fs.closeSync(fs.openSync(appendixPath, 'w'));
+              core.info('Empty task appendix file created');
+            }
+
+            // Keep output for backward compatibility (may be censored, but that's OK now)
             core.setOutput('task_appendix', result.taskAppendix || '');
+
+      - name: Verify task appendix artifact
+        if: steps.evaluate.outputs.action == 'run' || steps.evaluate.outputs.action == 'fix' || steps.evaluate.outputs.action == 'conflict'
+        run: |
+          if [ ! -f /tmp/keepalive-artifacts/task-appendix.txt ]; then
+            echo "ERROR: Task appendix file not created by evaluate step"
+            exit 1
+          fi
+          echo "Task appendix ready ($(wc -c < /tmp/keepalive-artifacts/task-appendix.txt) bytes)"
+
+      - name: Upload task appendix artifact
+        if: steps.evaluate.outputs.action == 'run' || steps.evaluate.outputs.action == 'fix' || steps.evaluate.outputs.action == 'conflict'
+        uses: actions/upload-artifact@v7
+        with:
+          name: keepalive-task-appendix-${{ steps.evaluate.outputs.pr_number }}
+          path: /tmp/keepalive-artifacts/task-appendix.txt
+          retention-days: 1
 
   preflight:
     name: Verify secrets available

--- a/.github/workflows/agents-verify-to-new-pr.yml
+++ b/.github/workflows/agents-verify-to-new-pr.yml
@@ -206,6 +206,7 @@ jobs:
         if: steps.check-merged.outputs.merged == 'true'
         continue-on-error: true
         env:
+          PYTHONPATH: ${{ github.workspace }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_STRANSKE: ${{ secrets.CLAUDE_API_STRANSKE }}
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-keepalive-loop.yml: Keepalive loop - continues agent work until tasks complete (deprecated; replaced by agents-81-gate-followups.yml, removal no earlier than 2026-02-15)
- agents-verify-to-new-pr.yml: Verify to new PR - creates follow-up issue and triggers auto-pilot to prepare a new PR
- setup-api-client/ (1 files): Unified API client setup - installs @octokit deps and exports all load balancer tokens

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)