### PR TITLE
fix: use owner/name format for reference pack repo field

### DIFF
--- a/.github/reference_packs.json
+++ b/.github/reference_packs.json
@@ -2,7 +2,7 @@
   "packs": [
     {
       "name": "trend_streamlit_llm",
-      "repo": "Trend_Model_Project",
+      "repo": "stranske/Trend_Model_Project",
       "ref": "8356d93c951ba39074d834875edbb7faa187da32",
       "paths": [
         "streamlit_app/components/llm_settings.py",


### PR DESCRIPTION
## Problem

The `repo` field in `.github/reference_packs.json` is `"Trend_Model_Project"` but the Workflows validation script requires `owner/name` format.

This causes the "Validate and materialize reference packs" step to fail in keepalive Codex runs:
```
Reference packs config error: repo must use owner/name format
```

Evidence: [Run 21909862693](https://github.com/stranske/Portable-Alpha-Extension-Model/actions/runs/21909862693), step #16 failed.

## Fix

`"repo": "Trend_Model_Project"` → `"repo": "stranske/Trend_Model_Project"`

Closes #1389
Unblocks the final acceptance criterion of #1375 / PR #1386.