### PR TITLE
fix: add CLAUDE_CODE_OAUTH_TOKEN support

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -25,7 +25,9 @@ agents:
   claude:
     runner_workflow: .github/workflows/reusable-claude-run.yml
     required_secrets:
-      - CLAUDE_AUTH_JSON
+      - CLAUDE_CODE_OAUTH_TOKEN  # preferred: long-lived token from `claude setup-token`
+      - CLAUDE_AUTH_JSON          # fallback: credentials.json (short-lived OAuth)
+    required_secrets_mode: any    # at least one must be present
     branch_prefix: claude/issue-
     ui_mentions_allowed: false
     automation_logins:

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -211,6 +211,7 @@ jobs:
         env:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
+          HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
           HAS_APP_ID: >-
             ${{ secrets.KEEPALIVE_APP_ID != '' ||
                 secrets.WORKFLOWS_APP_ID != '' }}
@@ -220,6 +221,7 @@ jobs:
         run: |
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
           echo "CLAUDE_AUTH_JSON present: $HAS_CLAUDE_AUTH"
+          echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
           echo "KEEPALIVE_APP or WORKFLOWS_APP present: $HAS_APP_ID"
           echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
           HAS_ANY="false"

--- a/.github/workflows/agents-autofix-loop.yml
+++ b/.github/workflows/agents-autofix-loop.yml
@@ -534,6 +534,7 @@ jobs:
       appendix: ${{ needs.prepare.outputs.appendix }}
     secrets:
       CLAUDE_AUTH_JSON: ${{ secrets.CLAUDE_AUTH_JSON }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
       WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
 

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -228,6 +228,7 @@ jobs:
           INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
+          HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
           INPUT_FORCE_RETRY: >-
             ${{ steps.retry_label.outputs.force_retry ||
                 (github.event_name == 'pull_request' &&
@@ -404,6 +405,7 @@ jobs:
         env:
           HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
           HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_AUTH_JSON != '' }}
+          HAS_CLAUDE_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
           AGENT_TYPE: ${{ needs.evaluate.outputs.agent_type || 'codex' }}
           HAS_APP_ID: >-
             ${{ secrets.KEEPALIVE_APP_ID != '' ||
@@ -415,6 +417,7 @@ jobs:
           echo "Requested agent: $AGENT_TYPE"
           echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
           echo "CLAUDE_AUTH_JSON present: $HAS_CLAUDE_AUTH"
+          echo "CLAUDE_CODE_OAUTH_TOKEN present: $HAS_CLAUDE_OAUTH"
           echo "KEEPALIVE_APP or WORKFLOWS_APP present: $HAS_APP_ID"
           echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
           agent_auth_ok=false


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_OAUTH_TOKEN` as preferred auth method in registry (with `required_secrets_mode: any`)
- Pass `CLAUDE_CODE_OAUTH_TOKEN` through autofix, keepalive, and gate-followups workflows
- Add `HAS_CLAUDE_OAUTH` env var checks alongside `HAS_CLAUDE_AUTH`

The short-lived OAuth tokens in `CLAUDE_AUTH_JSON` expire in 8-12 hours, causing Claude keepalive failures. `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) is valid ~1 year.

## Test plan
- [ ] Verify Claude keepalive runs authenticate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)