### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,10 @@ llm = [
 
 # Development dependencies
 dev = [
-    "ruff==0.15.10",
-    "black>=26.1.0",
-    "isort>=7.0.0",
-    "mypy==1.20.1",
+    "ruff>=0.15.12",
+    "black>=26.3.1",
+    "isort>=8.0.1",
+    "mypy>=1.20.2",
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-xdist>=3.8.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -382,7 +382,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==1.20.1
+mypy==1.20.2
     # via portable-alpha-extension-model (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -653,7 +653,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.10
+ruff==0.15.12
     # via portable-alpha-extension-model (pyproject.toml)
 secretstorage==3.5.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via keyring


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 6 version updates:
  - ruff: ==0.15.10 -> >=0.15.12
  - black: >=26.1.0 -> >=26.3.1
  - isort: >=7.0.0 -> >=8.0.1
  - mypy: ==1.20.1 -> >=1.20.2
  - requirements.lock:mypy: 1.20.1 -> ==1.20.2
  - requirements.lock:ruff: 0.15.10 -> ==0.15.12

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`