### PR TITLE
Issue #1681: Align Streamlit LLM foundation dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,11 +106,11 @@ app = []
 parquet = ["pyarrow"]
 llm = [
     "langchain==1.2.15",
-    "langchain-core==1.3.2",
+    "langchain-core==1.3.0",
     "langchain-community==0.4.1",
-    "langchain-openai==1.2.1",
-    "langchain-anthropic==1.4.2",
-    "langsmith==0.7.38",
+    "langchain-openai==1.1.14",
+    "langchain-anthropic==1.4.1",
+    "langsmith==0.7.32",
     "pydantic==2.13.3",
     "requests==2.33.1",
 ]

--- a/tests/test_validate_lockfile.py
+++ b/tests/test_validate_lockfile.py
@@ -1,0 +1,22 @@
+"""Tests for the LLM lockfile validation helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_validate_lockfile_module():
+    module_path = Path("scripts/validate_lockfile.py")
+    spec = importlib.util.spec_from_file_location("validate_lockfile", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_llm_requirements_match_lockfile() -> None:
+    validate_lockfile = _load_validate_lockfile_module()
+
+    assert validate_lockfile.main() == 0

--- a/tests/test_validate_lockfile.py
+++ b/tests/test_validate_lockfile.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 
 def _load_validate_lockfile_module():
-    module_path = Path("scripts/validate_lockfile.py")
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "validate_lockfile.py"
     spec = importlib.util.spec_from_file_location("validate_lockfile", module_path)
-    assert spec is not None
-    assert spec.loader is not None
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load validate_lockfile module from {module_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -1,15 +1,14 @@
 # LLM workflow dependency pins (used by agents-auto-pilot.yml)
 # Rationale:
-# - These are standalone runtime pins for workflow LLM steps, not app deps.
-# - These pins intentionally drift from pyproject.toml/requirements.lock so
-#   workflow automation can upgrade independently; no consumer dependency
-#   change is required when bumping this file.
+# - These are standalone runtime pins for workflow LLM steps.
+# - Keep these direct pins compatible with the app's llm extra and
+#   requirements.lock; scripts/validate_lockfile.py enforces that contract.
 # - Use strict X.Y.Z pins for direct workflow dependencies.
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
-langchain==1.2.17
+langchain==1.2.15
 langchain-community==0.4.1
-langchain-openai==1.2.1
-langchain-anthropic==1.4.3
+langchain-openai==1.1.14
+langchain-anthropic==1.4.1
 pydantic==2.13.3
 requests==2.33.1


### PR DESCRIPTION
Closes #1681

## Summary
- Align the `llm` optional dependency pins with the checked-in lockfile versions.
- Make `tools/requirements-llm.txt` explicitly follow the same lockfile contract enforced by `scripts/validate_lockfile.py`.
- Add pytest coverage for the LLM lockfile validation helper.

## Validation
- `python scripts/validate_lockfile.py`
- `python -m pytest tests/test_llm_import_and_no_network.py tests/test_llm_provider_missing_keys.py tests/test_llm_prompts.py tests/test_llm_tracing_noop.py tests/test_dependency_version_alignment.py tests/test_validate_lockfile.py -q`