### PR TITLE
Issue #1684: Append mandatory disclaimer to Explain Results output

### DIFF
--- a/pa_core/llm/result_explain.py
+++ b/pa_core/llm/result_explain.py
@@ -16,6 +16,21 @@ from pa_core.llm.tracing import langsmith_tracing_context, resolve_trace_url
 
 _REDACTION_TOKEN = "[REDACTED]"
 _MAX_ERROR_MESSAGE_LEN = 500
+EXPLAIN_RESULTS_DISCLAIMER = (
+    "Disclaimer: AI-generated explanation. Verify against the underlying simulation "
+    "data and manifest before relying on it for investment, risk, or compliance decisions."
+)
+
+
+def _with_disclaimer(text: str) -> str:
+    body = (text or "").rstrip()
+    if not body:
+        return EXPLAIN_RESULTS_DISCLAIMER
+    if EXPLAIN_RESULTS_DISCLAIMER in body:
+        return body
+    return f"{body}\n\n{EXPLAIN_RESULTS_DISCLAIMER}"
+
+
 _TAIL_ROW_LIMIT = 3
 _QUANTILE_LEVELS = [0.05, 0.5, 0.95]
 _METRIC_ALIAS_GROUPS: dict[str, tuple[str, ...]] = {
@@ -318,7 +333,7 @@ def explain_results_details(
             "LLM configuration is required to generate a result explanation. "
             f"Prepared payload for {analysis_output['rows']} rows."
         )
-        return text, None, payload
+        return _with_disclaimer(text), None, payload
 
     api_key = config.credentials.get("api_key", "")
     request_id = uuid4().hex
@@ -352,4 +367,4 @@ def explain_results_details(
         text = f"Failed to generate explanation: {safe_error}"
         payload["error"] = safe_error
         trace_url = None
-    return text, trace_url, payload
+    return _with_disclaimer(text), trace_url, payload

--- a/pa_core/llm/result_explain.py
+++ b/pa_core/llm/result_explain.py
@@ -26,7 +26,7 @@ def _with_disclaimer(text: str) -> str:
     body = (text or "").rstrip()
     if not body:
         return EXPLAIN_RESULTS_DISCLAIMER
-    if EXPLAIN_RESULTS_DISCLAIMER in body:
+    if body.endswith(EXPLAIN_RESULTS_DISCLAIMER):
         return body
     return f"{body}\n\n{EXPLAIN_RESULTS_DISCLAIMER}"
 

--- a/tests/test_reference_packs.py
+++ b/tests/test_reference_packs.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_TREND_PACK_PATHS = [
     "streamlit_app/components/llm_settings.py",

--- a/tests/test_result_explain.py
+++ b/tests/test_result_explain.py
@@ -624,6 +624,18 @@ def test_with_disclaimer_idempotent_does_not_double_append() -> None:
     assert result.count(result_explain.EXPLAIN_RESULTS_DISCLAIMER) == 1
 
 
+def test_with_disclaimer_appends_when_disclaimer_is_not_footer() -> None:
+    text = (
+        f"The model discussed this text: {result_explain.EXPLAIN_RESULTS_DISCLAIMER}\n"
+        "Then it continued with more analysis."
+    )
+
+    result = result_explain._with_disclaimer(text)
+
+    assert result.endswith(result_explain.EXPLAIN_RESULTS_DISCLAIMER)
+    assert result.count(result_explain.EXPLAIN_RESULTS_DISCLAIMER) == 2
+
+
 def test_with_disclaimer_strips_trailing_whitespace_before_appending() -> None:
     result = result_explain._with_disclaimer("Some text.   ")
     assert result.startswith("Some text.")

--- a/tests/test_result_explain.py
+++ b/tests/test_result_explain.py
@@ -102,10 +102,11 @@ def test_explain_results_details_nominal_baseline_fixture_returns_expected_value
     text, trace_url, payload = result_explain.explain_results_details(baseline_summary_df)
     metric_catalog = payload["metric_catalog"]
 
-    assert (
-        text
-        == "LLM configuration is required to generate a result explanation. Prepared payload for 3 rows."
+    assert text.startswith(
+        "LLM configuration is required to generate a result explanation. "
+        "Prepared payload for 3 rows."
     )
+    assert result_explain.EXPLAIN_RESULTS_DISCLAIMER in text
     assert trace_url is None
     assert metric_catalog["tracking_error"]["value"] == 0.03
     assert metric_catalog["tracking_error"]["value"] == pytest.approx(0.03)
@@ -168,7 +169,8 @@ def test_explain_results_calls_prompt_builder_and_llm_once(monkeypatch) -> None:
         tracing_enabled=False,
     )
 
-    assert text == "SENTINEL_LLM_RESPONSE"
+    assert text.startswith("SENTINEL_LLM_RESPONSE")
+    assert result_explain.EXPLAIN_RESULTS_DISCLAIMER in text
     assert trace_url is None
     assert len(prompt_calls) == 1
     assert len(create_calls) == 1
@@ -242,7 +244,8 @@ def test_create_llm_receives_dashboard_config_and_api_key_not_exposed(monkeypatc
         tracing_enabled=False,
     )
 
-    assert text == "ok"
+    assert text.startswith("ok")
+    assert result_explain.EXPLAIN_RESULTS_DISCLAIMER in text
     assert captured[0].provider_name == "openai"
     assert captured[0].model_name == "gpt-4o-mini"
     assert "api_key" in captured[0].credentials
@@ -318,7 +321,8 @@ def test_langsmith_tracing_wraps_llm_invoke(monkeypatch) -> None:
         _toy_df(), llm_config=_config(), tracing_enabled=True
     )
 
-    assert text == "TRACED_RESPONSE"
+    assert text.startswith("TRACED_RESPONSE")
+    assert result_explain.EXPLAIN_RESULTS_DISCLAIMER in text
     assert trace_url == "https://smith.langchain.com/r/context-verified"
     assert trace_state["inside"] is False
 
@@ -532,6 +536,44 @@ def test_error_messages_are_sanitized_and_bounded(monkeypatch) -> None:
     assert "SECRET456" not in text
     assert len(payload["error"]) <= result_explain._MAX_ERROR_MESSAGE_LEN
     assert "credentials" not in payload["error"].lower()
+
+
+def test_disclaimer_appended_to_no_llm_fallback_text() -> None:
+    text, _trace_url, _payload = result_explain.explain_results_details(_toy_df())
+    assert text.startswith("LLM configuration is required")
+    assert text.endswith(result_explain.EXPLAIN_RESULTS_DISCLAIMER)
+
+
+def test_disclaimer_appended_to_successful_llm_text(monkeypatch) -> None:
+    monkeypatch.setattr(
+        result_explain, "build_result_explanation_prompt", lambda *_a, **_k: "prompt"
+    )
+    monkeypatch.setattr(result_explain, "create_llm", lambda _cfg: _StaticLLM("model says hi"))
+
+    text, _trace_url, _payload = result_explain.explain_results_details(
+        _toy_df(), llm_config=_config(), tracing_enabled=False
+    )
+
+    assert text.startswith("model says hi")
+    assert text.endswith(result_explain.EXPLAIN_RESULTS_DISCLAIMER)
+
+
+def test_disclaimer_appended_once_to_error_path_text(monkeypatch) -> None:
+    monkeypatch.setattr(
+        result_explain, "build_result_explanation_prompt", lambda *_a, **_k: "prompt"
+    )
+
+    def _raise_create(_cfg: LLMProviderConfig) -> Any:
+        raise RuntimeError("upstream failure")
+
+    monkeypatch.setattr(result_explain, "create_llm", _raise_create)
+
+    text, _trace_url, _payload = result_explain.explain_results_details(
+        _toy_df(), llm_config=_config()
+    )
+
+    assert text.startswith("Failed to generate explanation")
+    assert text.count(result_explain.EXPLAIN_RESULTS_DISCLAIMER) == 1
 
 
 def test_error_messages_redact_lowercase_bearer_and_config_dump(monkeypatch) -> None:

--- a/tests/test_result_explain.py
+++ b/tests/test_result_explain.py
@@ -599,3 +599,183 @@ def test_error_messages_redact_lowercase_bearer_and_config_dump(monkeypatch) -> 
     assert "SECRET123" not in payload["error"]
     assert "config={" not in payload["error"]
     assert result_explain._REDACTION_TOKEN in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# _with_disclaimer edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_with_disclaimer_empty_string_returns_just_disclaimer() -> None:
+    result = result_explain._with_disclaimer("")
+    assert result == result_explain.EXPLAIN_RESULTS_DISCLAIMER
+
+
+def test_with_disclaimer_none_coerced_empty_returns_just_disclaimer() -> None:
+    # _with_disclaimer treats falsy text as empty via `(text or "")`.
+    result = result_explain._with_disclaimer("")
+    assert result == result_explain.EXPLAIN_RESULTS_DISCLAIMER
+
+
+def test_with_disclaimer_idempotent_does_not_double_append() -> None:
+    already = f"Some analysis.\n\n{result_explain.EXPLAIN_RESULTS_DISCLAIMER}"
+    result = result_explain._with_disclaimer(already)
+    assert result == already
+    assert result.count(result_explain.EXPLAIN_RESULTS_DISCLAIMER) == 1
+
+
+def test_with_disclaimer_strips_trailing_whitespace_before_appending() -> None:
+    result = result_explain._with_disclaimer("Some text.   ")
+    assert result.startswith("Some text.")
+    assert result.endswith(result_explain.EXPLAIN_RESULTS_DISCLAIMER)
+
+
+# ---------------------------------------------------------------------------
+# TypeError guard
+# ---------------------------------------------------------------------------
+
+
+def test_explain_results_raises_type_error_for_non_dataframe() -> None:
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        result_explain.explain_results_details({"not": "a dataframe"})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _extract_response_text list-content path
+# ---------------------------------------------------------------------------
+
+
+def test_extract_response_text_list_of_strings() -> None:
+    response = SimpleNamespace(content=["Hello ", "world"])
+    result = result_explain._extract_response_text(response)
+    assert result == "Hello world"
+
+
+def test_extract_response_text_list_of_dicts_with_text_key() -> None:
+    response = SimpleNamespace(content=[{"text": "part one"}, {"text": "part two"}])
+    result = result_explain._extract_response_text(response)
+    assert result == "part one part two"
+
+
+def test_extract_response_text_mixed_list_skips_non_text_dicts() -> None:
+    response = SimpleNamespace(content=["hello", {"type": "image"}, {"text": "world"}])
+    result = result_explain._extract_response_text(response)
+    assert result == "hello world"
+
+
+def test_extract_response_text_empty_list_falls_back_to_str() -> None:
+    response = SimpleNamespace(content=[])
+    result = result_explain._extract_response_text(response)
+    # Falls through to str(response).strip() which is non-empty.
+    assert isinstance(result, str) and result
+
+
+def test_extract_response_text_list_of_blank_strings_falls_back_to_str() -> None:
+    response = SimpleNamespace(content=["  ", ""])
+    result = result_explain._extract_response_text(response)
+    assert isinstance(result, str) and result
+
+
+# ---------------------------------------------------------------------------
+# _to_json_safe edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_to_json_safe_tuple_is_converted_to_list() -> None:
+    result = result_explain._to_json_safe((1, "a", None))
+    assert result == [1, "a", None]
+
+
+def test_to_json_safe_timestamp_is_isoformat_string() -> None:
+    ts = pd.Timestamp("2024-01-15 12:30:00")
+    result = result_explain._to_json_safe(ts)
+    assert isinstance(result, str)
+    assert "2024-01-15" in result
+
+
+def test_to_json_safe_pandas_na_becomes_none() -> None:
+    # pd.NA is not a float/str/int/bool/Timestamp, so it reaches the pd.isna branch.
+    result = result_explain._to_json_safe(pd.NA)
+    assert result is None
+
+
+def test_to_json_safe_unknown_object_returns_str() -> None:
+    class _Opaque:
+        def __str__(self) -> str:
+            return "opaque-value"
+
+    result = result_explain._to_json_safe(_Opaque())
+    assert result == "opaque-value"
+
+
+# ---------------------------------------------------------------------------
+# Helper function edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_build_basic_statistics_empty_numeric_df_returns_empty_dict() -> None:
+    df = pd.DataFrame({"label": ["a", "b"]})
+    result = result_explain._build_basic_statistics(df)
+    assert result == {}
+
+
+def test_build_quantiles_empty_numeric_df_returns_empty_dict() -> None:
+    df = pd.DataFrame({"label": ["a", "b"]})
+    result = result_explain._build_quantiles(df)
+    assert result == {}
+
+
+def test_build_tail_samples_empty_df_returns_empty_list() -> None:
+    df = pd.DataFrame()
+    result = result_explain._build_tail_samples(df)
+    assert result == []
+
+
+def test_build_stress_delta_summary_non_numeric_stress_cols_returns_empty_summary() -> None:
+    df = pd.DataFrame({"StressDelta_TE": ["high", "low"]})
+    result = result_explain._build_stress_delta_summary(df)
+    assert result is not None
+    assert result["summary"] == {}
+
+
+def test_build_stress_delta_summary_all_nan_stress_col_skips_col() -> None:
+    import numpy as np
+
+    df = pd.DataFrame({"StressDelta_TE": [np.nan, np.nan]})
+    result = result_explain._build_stress_delta_summary(df)
+    assert result is not None
+    assert "StressDelta_TE" not in result["summary"]
+
+
+def test_manifest_highlights_includes_seed_and_cli_args() -> None:
+    manifest = {
+        "run_name": "test_run",
+        "seed": 42,
+        "cli_args": {"n_sims": 1000, "horizon_months": 12, "output": "results/"},
+    }
+    result = result_explain._manifest_highlights(manifest)
+    assert result["seed"] == 42
+    assert result["cli_n_sims"] == 1000
+    assert result["cli_horizon_months"] == 12
+    assert result["cli_output"] == "results/"
+
+
+def test_sanitize_error_message_empty_exc_returns_unknown_error() -> None:
+    exc = RuntimeError("")
+    result = result_explain._sanitize_error_message(exc, secrets=[])
+    assert result == "unknown error"
+
+
+def test_sanitize_error_message_long_plain_message_is_truncated() -> None:
+    # A long message with no sensitive patterns so redaction leaves it intact.
+    long_msg = "Network timeout connecting to endpoint. " * 20
+    exc = RuntimeError(long_msg)
+    result = result_explain._sanitize_error_message(exc, secrets=[])
+    assert len(result) <= result_explain._MAX_ERROR_MESSAGE_LEN
+    assert result.endswith("...")
+
+
+def test_coerce_metric_value_column_not_in_df_returns_none() -> None:
+    df = _toy_df()
+    result = result_explain._coerce_metric_value(df, "nonexistent_column")
+    assert result is None


### PR DESCRIPTION
## Summary

Closes #1684.

Adds a mandatory disclaimer/footer to every text payload returned by
`pa_core.llm.result_explain.explain_results_details` so the dashboard
Explain Results panel always renders, downloads (TXT + JSON `text`
field), and caches an explicit AI-disclaimer notice. This satisfies
the open acceptance criterion in #1684 calling for "a mandatory
disclaimer/footer and structured export payload that excludes
secrets" — the structured export and secret-redaction behavior were
already in place; only the disclaimer was missing.

## Changes

- `pa_core/llm/result_explain.py`
  - New `EXPLAIN_RESULTS_DISCLAIMER` constant.
  - New `_with_disclaimer(text)` helper appends the disclaimer once,
    separated by a blank line, idempotent if the disclaimer is
    already present.
  - All three return paths (no `llm_config`, successful LLM call,
    sanitized error path) now route through `_with_disclaimer`.
- `tests/test_result_explain.py`
  - Updates the three existing exact-text equality assertions to
    `startswith(...)` + disclaimer membership.
  - Adds three explicit tests pinning the disclaimer to the no-LLM,
    success, and error paths and verifying it is appended exactly
    once.

## Validation

- `python -m pytest tests/test_result_explain.py tests/test_dashboard_explain_results.py tests/test_llm_result_explain_entrypoint.py --no-cov` — 33 passed.
- `python -m pytest tests/test_llm_prompts.py tests/test_llm_init_lazy_exports.py tests/test_llm_init_reexports.py tests/test_llm_import_and_no_network.py tests/test_dashboard_llm_settings.py tests/test_llm_provider_missing_keys.py --no-cov` — 85 passed.
- `python -m ruff check pa_core/llm/result_explain.py tests/test_result_explain.py` — clean.
- `python -m mypy pa_core/llm/result_explain.py` — no issues.
- `python -m black --check pa_core/llm/result_explain.py tests/test_result_explain.py` — formatted.

## Acceptance criteria coverage

- [x] Trace URL display when LangSmith tracing is enabled — already
      wired via `st.caption(f"Trace URL: ...")`.
- [x] `.[llm]` absent fallback message preserved — `_render_explain_results`
      in `dashboard/pages/4_Results.py` already handles `ModuleNotFoundError`.
- [x] Exports include prompt inputs summary, created timestamp,
      model/provider metadata, and trace URL when available — already
      in `dashboard/components/explain_results.py` JSON download.
- [x] No secrets appear in UI/downloads/exceptions/logs — preserved
      via existing `_redact_sensitive` and `_sanitize_error_message`;
      no new payload fields added.
- [x] Offline tests cover metric extraction and UI fallback without
      real LLM calls — preserved; this PR adds disclaimer-presence
      coverage.
