### PR TITLE
Issue #1685: Harden LLM comparison prior-run loading

### DIFF
--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -31,7 +31,7 @@ from pa_core.contracts import (
     SUMMARY_TRACKING_ERROR_LEGACY_COLUMN,
     manifest_path_for_output,
 )
-from pa_core.llm.compare_runs import load_prior_manifest
+from pa_core.llm.compare_runs import load_prior_manifest, load_prior_summary
 
 
 @dataclass(frozen=True)
@@ -76,6 +76,29 @@ def _check_previous_run_availability(
         )
 
     if prior_manifest is not None and prior_manifest_path is not None:
+        try:
+            prior_summary, prior_summary_path = load_prior_summary(
+                prior_manifest, manifest_path=prior_manifest_path
+            )
+        except Exception as exc:
+            return _PreviousRunAvailability(
+                available=False,
+                prior_manifest_path=prior_manifest_path,
+                message=(
+                    "Comparison unavailable: unreadable prior Summary sheet referenced by "
+                    f"`manifest_data['previous_run']` at `{prior_manifest_path}` ({exc})."
+                ),
+            )
+        if prior_summary is None:
+            expected_summary = str(prior_summary_path) if prior_summary_path else "<unset>"
+            return _PreviousRunAvailability(
+                available=False,
+                prior_manifest_path=prior_manifest_path,
+                message=(
+                    "Comparison unavailable: missing prior Summary sheet referenced by "
+                    f"`manifest_data['previous_run']`; expected output file `{expected_summary}`."
+                ),
+            )
         return _PreviousRunAvailability(
             available=True,
             prior_manifest_path=prior_manifest_path,

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -41,6 +41,19 @@ class _PreviousRunAvailability:
     message: str | None
 
 
+def _prior_output_path(prior_manifest: dict | None, prior_manifest_path: Path) -> Path | None:
+    cli_args = prior_manifest.get("cli_args") if isinstance(prior_manifest, dict) else None
+    if not isinstance(cli_args, dict):
+        return None
+    output = cli_args.get("output")
+    if not isinstance(output, str) or not output.strip():
+        return None
+    output_path = Path(output).expanduser()
+    if not output_path.is_absolute():
+        output_path = prior_manifest_path.expanduser().parent / output_path
+    return output_path
+
+
 def _check_previous_run_availability(
     manifest_data: dict | None,
 ) -> _PreviousRunAvailability:
@@ -81,21 +94,29 @@ def _check_previous_run_availability(
                 prior_manifest, manifest_path=prior_manifest_path
             )
         except Exception as exc:
+            expected_summary = _prior_output_path(prior_manifest, prior_manifest_path)
+            expected_summary_text = str(expected_summary) if expected_summary else "<unset>"
             return _PreviousRunAvailability(
                 available=False,
                 prior_manifest_path=prior_manifest_path,
                 message=(
-                    "Comparison unavailable: unreadable prior Summary sheet referenced by "
-                    f"`manifest_data['previous_run']` at `{prior_manifest_path}` ({exc})."
+                    "Comparison unavailable: unreadable prior output workbook referenced by "
+                    f"`manifest_data['previous_run']`; expected output file "
+                    f"`{expected_summary_text}` ({exc})."
                 ),
             )
         if prior_summary is None:
             expected_summary = str(prior_summary_path) if prior_summary_path else "<unset>"
+            missing_target = (
+                "prior output workbook"
+                if prior_summary_path is not None
+                else "`cli_args.output` path in the prior manifest"
+            )
             return _PreviousRunAvailability(
                 available=False,
                 prior_manifest_path=prior_manifest_path,
                 message=(
-                    "Comparison unavailable: missing prior Summary sheet referenced by "
+                    f"Comparison unavailable: missing {missing_target} referenced by "
                     f"`manifest_data['previous_run']`; expected output file `{expected_summary}`."
                 ),
             )

--- a/pa_core/llm/compare_runs.py
+++ b/pa_core/llm/compare_runs.py
@@ -85,8 +85,15 @@ def load_prior_manifest(
 
 def load_prior_summary(
     prior_manifest: Mapping[str, Any] | None,
+    *,
+    manifest_path: Path | None = None,
 ) -> tuple[pd.DataFrame | None, Path | None]:
-    """Load prior Summary sheet referenced by prior manifest output path."""
+    """Load prior Summary sheet referenced by prior manifest output path.
+
+    Relative output paths are resolved from the prior manifest directory. Older
+    manifests often record ``cli_args.output`` as a run-local path, while the
+    dashboard process may be launched from a different working directory.
+    """
 
     if not isinstance(prior_manifest, Mapping):
         return None, None
@@ -98,6 +105,8 @@ def load_prior_summary(
         return None, None
 
     output_path = Path(output).expanduser()
+    if not output_path.is_absolute() and manifest_path is not None:
+        output_path = manifest_path.expanduser().parent / output_path
     if not output_path.exists() or not output_path.is_file():
         return None, output_path
 
@@ -287,7 +296,9 @@ def compare_runs(
     if prior_manifest is None:
         raise ValueError("No readable prior manifest found from manifest_data['previous_run'].")
 
-    prior_summary, prior_summary_path = load_prior_summary(prior_manifest)
+    prior_summary, prior_summary_path = load_prior_summary(
+        prior_manifest, manifest_path=prior_manifest_path
+    )
     if prior_summary is None:
         expected = str(prior_summary_path) if prior_summary_path else "<unset>"
         raise ValueError(f"No readable prior summary found at expected path: {expected}")

--- a/tests/test_dashboard_results_previous_run.py
+++ b/tests/test_dashboard_results_previous_run.py
@@ -50,13 +50,42 @@ def test_check_previous_run_availability_unreadable_json(tmp_path) -> None:
 def test_check_previous_run_availability_readable_manifest(tmp_path) -> None:
     module = _load_results_module()
     check = module["_check_previous_run_availability"]
+    prior_output = tmp_path / "prior.xlsx"
+    pd.DataFrame({"monthly_TE": [0.02]}).to_excel(prior_output, sheet_name="Summary", index=False)
     prior_manifest = tmp_path / "prior_manifest.json"
-    prior_manifest.write_text(json.dumps({"seed": 42}))
+    prior_manifest.write_text(json.dumps({"seed": 42, "cli_args": {"output": str(prior_output)}}))
     result = check({"previous_run": str(prior_manifest)})
 
     assert result.available is True
     assert result.prior_manifest_path == prior_manifest
     assert result.message is None
+
+
+def test_check_previous_run_availability_missing_prior_summary(tmp_path) -> None:
+    module = _load_results_module()
+    check = module["_check_previous_run_availability"]
+    prior_manifest = tmp_path / "prior_manifest.json"
+    prior_manifest.write_text(json.dumps({"seed": 42, "cli_args": {"output": "missing.xlsx"}}))
+    result = check({"previous_run": str(prior_manifest)})
+
+    assert result.available is False
+    assert result.prior_manifest_path == prior_manifest
+    assert "missing prior summary sheet" in str(result.message).lower()
+    assert str(tmp_path / "missing.xlsx") in str(result.message)
+
+
+def test_check_previous_run_availability_unreadable_prior_summary(tmp_path) -> None:
+    module = _load_results_module()
+    check = module["_check_previous_run_availability"]
+    prior_output = tmp_path / "prior.xlsx"
+    prior_output.write_text("not an excel workbook")
+    prior_manifest = tmp_path / "prior_manifest.json"
+    prior_manifest.write_text(json.dumps({"seed": 42, "cli_args": {"output": str(prior_output)}}))
+    result = check({"previous_run": str(prior_manifest)})
+
+    assert result.available is False
+    assert result.prior_manifest_path == prior_manifest
+    assert "unreadable prior summary sheet" in str(result.message).lower()
 
 
 class _FakeStreamlit:
@@ -79,8 +108,10 @@ def test_render_comparison_panel_calls_component_when_previous_run_readable(tmp_
 
     current_output = tmp_path / "current.xlsx"
     current_output.write_bytes(b"placeholder")
+    prior_output = tmp_path / "prior.xlsx"
+    pd.DataFrame({"monthly_TE": [0.02]}).to_excel(prior_output, sheet_name="Summary", index=False)
     prior_manifest = tmp_path / "prior_manifest.json"
-    prior_manifest.write_text(json.dumps({"seed": 42}))
+    prior_manifest.write_text(json.dumps({"seed": 42, "cli_args": {"output": str(prior_output)}}))
     manifest_data = {"previous_run": str(prior_manifest)}
     summary_df = pd.DataFrame({"monthly_TE": [0.02]})
     captured: dict[str, object] = {}

--- a/tests/test_dashboard_results_previous_run.py
+++ b/tests/test_dashboard_results_previous_run.py
@@ -70,7 +70,7 @@ def test_check_previous_run_availability_missing_prior_summary(tmp_path) -> None
 
     assert result.available is False
     assert result.prior_manifest_path == prior_manifest
-    assert "missing prior summary sheet" in str(result.message).lower()
+    assert "missing prior output workbook" in str(result.message).lower()
     assert str(tmp_path / "missing.xlsx") in str(result.message)
 
 
@@ -85,7 +85,20 @@ def test_check_previous_run_availability_unreadable_prior_summary(tmp_path) -> N
 
     assert result.available is False
     assert result.prior_manifest_path == prior_manifest
-    assert "unreadable prior summary sheet" in str(result.message).lower()
+    assert "unreadable prior output workbook" in str(result.message).lower()
+    assert str(prior_output) in str(result.message)
+
+
+def test_check_previous_run_availability_missing_prior_output_path(tmp_path) -> None:
+    module = _load_results_module()
+    check = module["_check_previous_run_availability"]
+    prior_manifest = tmp_path / "prior_manifest.json"
+    prior_manifest.write_text(json.dumps({"seed": 42, "cli_args": {}}))
+    result = check({"previous_run": str(prior_manifest)})
+
+    assert result.available is False
+    assert result.prior_manifest_path == prior_manifest
+    assert "missing `cli_args.output` path" in str(result.message)
 
 
 class _FakeStreamlit:

--- a/tests/test_llm_compare_runs.py
+++ b/tests/test_llm_compare_runs.py
@@ -57,6 +57,24 @@ def test_load_prior_summary_reads_previous_output(tmp_path):
     assert "monthly_TE" in loaded.columns
 
 
+def test_load_prior_summary_resolves_output_relative_to_manifest(tmp_path):
+    run_dir = tmp_path / "prior-run"
+    run_dir.mkdir()
+    prior_output = run_dir / "prior.xlsx"
+    pd.DataFrame({"monthly_TE": [0.02], "monthly_CVaR": [-0.03]}).to_excel(
+        prior_output, sheet_name="Summary", index=False
+    )
+    prior_manifest_path = run_dir / "manifest.json"
+    prior_manifest_path.write_text(json.dumps({"cli_args": {"output": "prior.xlsx"}}))
+    prior_manifest = {"cli_args": {"output": "prior.xlsx"}}
+
+    loaded, path = load_prior_summary(prior_manifest, manifest_path=prior_manifest_path)
+
+    assert isinstance(loaded, pd.DataFrame)
+    assert path == prior_output
+    assert loaded["monthly_TE"].iloc[0] == 0.02
+
+
 def test_format_config_diff_includes_seed_cli_and_wizard_changes():
     current_manifest = {
         "seed": 11,


### PR DESCRIPTION
Closes #1685

## Summary
- resolve relative prior-run output paths from the prior manifest directory so comparison summaries load when dashboards run elsewhere
- surface missing or unreadable prior Summary sheets before Compare Runs is clicked
- add regression coverage for relative prior outputs and Results-page missing/unreadable summary states

## Validation
- python -m pytest tests/test_llm_compare_runs.py tests/test_dashboard_comparison_llm.py tests/test_dashboard_results_previous_run.py --no-cov
- python -m ruff check pa_core/llm/compare_runs.py dashboard/pages/4_Results.py tests/test_llm_compare_runs.py tests/test_dashboard_results_previous_run.py
- python -m black --check pa_core/llm/compare_runs.py dashboard/pages/4_Results.py tests/test_llm_compare_runs.py tests/test_dashboard_results_previous_run.py
- python -m mypy pa_core/llm/compare_runs.py dashboard/pages/4_Results.py