### PR TITLE
Issue #1686: Surface Config Chat trace URL

### DIFF
--- a/dashboard/components/config_chat.py
+++ b/dashboard/components/config_chat.py
@@ -184,6 +184,10 @@ def _render_preview(preview: Any) -> None:
     if isinstance(risk_flags, list) and risk_flags:
         st.warning(f"Risk flags: {', '.join(str(flag) for flag in risk_flags)}")
 
+    trace_url = preview.get("trace_url")
+    if isinstance(trace_url, str) and trace_url.strip():
+        st.caption(f"Trace URL: {trace_url.strip()}")
+
     unified_diff = preview.get("unified_diff") or st.session_state.get(_PREVIEW_UNIFIED_DIFF_KEY)
     if isinstance(unified_diff, str) and unified_diff.strip():
         st.markdown("**Unified diff**")

--- a/tests/test_dashboard_config_chat.py
+++ b/tests/test_dashboard_config_chat.py
@@ -75,6 +75,7 @@ def test_render_config_chat_preview_populates_session_and_renders_diff(monkeypat
         on_preview=lambda instruction: {
             "summary": f"Applied instruction: {instruction}",
             "risk_flags": ["stripped_unknown_output_keys"],
+            "trace_url": "https://smith.langchain.com/r/config-chat-123",
             "unified_diff": "--- before\n+++ after\n@@\n-n_simulations: 1000\n+n_simulations: 5000\n",
             "before_text": "n_simulations: 1000\n",
             "after_text": "n_simulations: 5000\n",
@@ -84,6 +85,10 @@ def test_render_config_chat_preview_populates_session_and_renders_diff(monkeypat
     preview = fake_st.session_state["wizard_config_chat_preview"]
     assert preview["summary"].startswith("Applied instruction:")
     assert any(kind == "warning" and "Risk flags" in message for kind, message in fake_st.messages)
+    assert any(
+        kind == "caption" and "https://smith.langchain.com/r/config-chat-123" in message
+        for kind, message in fake_st.messages
+    )
     assert any(language == "diff" for _, language in fake_st.code_blocks)
     assert any(language == "yaml" for _, language in fake_st.code_blocks)
 


### PR DESCRIPTION
Closes #1686

## Summary
- Surface the Config Chat trace URL in the preview panel when LangSmith tracing returns one.
- Add component coverage that the preview payload keeps and renders the trace URL alongside risk flags and diffs.

## Validation
- python -m pytest tests/test_llm_config_patch.py tests/test_llm_config_patch_chain.py tests/test_config_chat.py tests/test_dashboard_config_chat.py tests/test_config_chat_preview_apply_revert.py tests/test_wizard_config_chat_flow.py tests/test_wizard_config_chat_acceptance.py tests/test_config_patch_roundtrip.py tests/test_wizard_session_state.py --no-cov
- python -m ruff check dashboard/components/config_chat.py tests/test_dashboard_config_chat.py pa_core/llm/config_patch.py pa_core/llm/config_patch_chain.py pa_core/llm/config_chat.py dashboard/pages/3_Scenario_Wizard.py
- python -m black --check dashboard/components/config_chat.py tests/test_dashboard_config_chat.py