### PR TITLE
Issue #1687: Add LLM feature docs and offline smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The index CSV should include a `Date` column and a monthly total return column n
 
 If you're new to the project, see the [primer](docs/primer.md) for simple definitions of terms like **active share**, **active return volatility (tracking error, TE)**, and **CVaR**.
 
+## Optional LLM Features
+
+The Results page includes optional LLM panels for run explanations and current-vs-previous comparisons. Install them with `python -m pip install -e ".[llm]"`, then configure provider keys with `PA_STREAMLIT_API_KEY`, `OPENAI_API_KEY`, `CLAUDE_API_STRANSKE`, or Azure-specific `PA_LLM_*` variables. See [Streamlit LLM Features](docs/llm_features.md) for key handling, no-secret export expectations, LangSmith tracing, and the Trend reference pack used by agent runs.
+
 ## Development Setup
 
 ### 🚀 GitHub Codespaces (Recommended)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you're new to the project, see the [primer](docs/primer.md) for simple defini
 
 ## Optional LLM Features
 
-The Results page includes optional LLM panels for run explanations and current-vs-previous comparisons. Install them with `python -m pip install -e ".[llm]"`, then configure provider keys with `PA_STREAMLIT_API_KEY`, `OPENAI_API_KEY`, `CLAUDE_API_STRANSKE`, or Azure-specific `PA_LLM_*` variables. See [Streamlit LLM Features](docs/llm_features.md) for key handling, no-secret export expectations, LangSmith tracing, and the Trend reference pack used by agent runs.
+The Results page includes optional LLM panels for run explanations and current-vs-previous comparisons. Install them with `python -m pip install -e ".[llm]"`, then configure provider keys with `PA_STREAMLIT_API_KEY`, `OPENAI_API_KEY`, or `CLAUDE_API_STRANSKE`; Azure OpenAI also needs endpoint/version settings such as `PA_LLM_BASE_URL`, `PA_LLM_API_VERSION`, or `AZURE_OPENAI_API_VERSION`. See [Streamlit LLM Features](docs/llm_features.md) for key handling, no-secret export expectations, LangSmith tracing, and the Trend reference pack used by agent runs.
 
 ## Development Setup
 

--- a/docs/llm_features.md
+++ b/docs/llm_features.md
@@ -1,0 +1,74 @@
+# Streamlit LLM Features
+
+Portable Alpha keeps dashboard LLM features optional and offline-safe by
+default. The Results page can explain a run, compare the current run with a
+previous run, and show LangSmith trace links when tracing is enabled. Required
+tests use fake clients or heuristic fallbacks and must not call real LLM
+providers.
+
+## Install
+
+Install the optional LLM extra before using provider-backed dashboard features:
+
+```bash
+python -m pip install -e ".[llm]"
+```
+
+The base package can still run the dashboard and tests without this extra. If a
+provider package is missing, the Streamlit panels show an install prompt instead
+of failing the page import.
+
+## Configuration
+
+Dashboard controls accept either a literal key or an environment-variable name.
+Use environment variables for shared or repeated runs:
+
+| Variable | Purpose |
+| --- | --- |
+| `PA_LLM_PROVIDER` | `openai`, `anthropic`, or `azure_openai`; defaults to `openai`. |
+| `PA_LLM_MODEL` | Optional model override for the selected provider. |
+| `PA_STREAMLIT_API_KEY` | Dashboard-specific provider key. |
+| `OPENAI_API_KEY` | OpenAI fallback key. |
+| `CLAUDE_API_STRANSKE` | Anthropic fallback key. |
+| `PA_LLM_BASE_URL` | Azure OpenAI endpoint or custom OpenAI-compatible base URL. |
+| `PA_LLM_API_VERSION` | Azure OpenAI API version. |
+| `AZURE_OPENAI_API_VERSION` | Azure API-version fallback. |
+| `LANGSMITH_API_KEY` | Enables LangSmith trace-link resolution. |
+| `LANGSMITH_PROJECT` | Optional LangSmith project name. |
+
+Provider keys are masked before display, excluded from TXT/JSON exports, and
+redacted from user-visible error messages. Do not log raw key values in tests,
+Streamlit messages, or exported artifacts.
+
+## Reference Pack
+
+Agent runs use the curated Trend reference pack declared in
+`.github/reference_packs.json`. Workflows materializes it at
+`.reference/trend_streamlit_llm/` during keepalive runs so agents can inspect
+Trend's Streamlit LLM settings, comparison, tracing, and natural-language config
+patterns without copying the entire Trend repository.
+
+Validate the reference-pack contract before relying on it:
+
+```bash
+python scripts/reference_packs.py --format self-check
+python -m pytest tests/test_reference_packs.py -q
+```
+
+The `.reference/` directory is runtime-only and must not be committed.
+
+## Offline Checks
+
+Use these checks after touching LLM dashboard helpers:
+
+```bash
+python -m pytest \
+  tests/test_dashboard_llm_settings.py \
+  tests/test_result_explain.py \
+  tests/test_llm_compare_runs.py \
+  tests/test_llm_prompts.py \
+  tests/test_dashboard_explain_results.py \
+  tests/test_dashboard_comparison_llm.py \
+  tests/test_reference_packs.py \
+  --no-cov
+```

--- a/docs/llm_features.md
+++ b/docs/llm_features.md
@@ -30,6 +30,7 @@ Use environment variables for shared or repeated runs:
 | `PA_STREAMLIT_API_KEY` | Dashboard-specific provider key. |
 | `OPENAI_API_KEY` | OpenAI fallback key. |
 | `CLAUDE_API_STRANSKE` | Anthropic fallback key. |
+| `PA_LLM_ORG` | Optional organization ID for providers that require one. |
 | `PA_LLM_BASE_URL` | Azure OpenAI endpoint or custom OpenAI-compatible base URL. |
 | `PA_LLM_API_VERSION` | Azure OpenAI API version. |
 | `AZURE_OPENAI_API_VERSION` | Azure API-version fallback. |
@@ -43,7 +44,7 @@ Streamlit messages, or exported artifacts.
 ## Reference Pack
 
 Agent runs use the curated Trend reference pack declared in
-`.github/reference_packs.json`. Workflows materializes it at
+`.github/reference_packs.json`. Workflows materialize it at
 `.reference/trend_streamlit_llm/` during keepalive runs so agents can inspect
 Trend's Streamlit LLM settings, comparison, tracing, and natural-language config
 patterns without copying the entire Trend repository.

--- a/docs/reference_packs.md
+++ b/docs/reference_packs.md
@@ -1,6 +1,8 @@
 # Reference Packs for Agent Runs
 
 Portable Alpha defines curated reference packs in `.github/reference_packs.json`.
+Dashboard LLM setup and operator expectations are covered in
+[`docs/llm_features.md`](llm_features.md).
 
 The `trend_streamlit_llm` pack pins a full Trend commit SHA and a small set of
 files that Codex can inspect as implementation patterns during keepalive runs.

--- a/tests/test_dashboard_explain_results.py
+++ b/tests/test_dashboard_explain_results.py
@@ -169,3 +169,33 @@ def test_results_page_llm_fallback_message(monkeypatch) -> None:
 
     assert any("LLM features unavailable" in message for message in fake_st.messages)
     assert any("install .[llm]" in message.lower() for message in fake_st.messages)
+
+
+def test_render_explain_results_panel_reports_missing_llm_extra(monkeypatch) -> None:
+    fake_st = FakeStreamlit(button_value=True)
+    monkeypatch.setattr(explain_module, "st", fake_st)
+    monkeypatch.setattr(explain_module, "default_api_key", lambda provider: "test-key")
+    monkeypatch.setattr(explain_module, "resolve_api_key_input", lambda raw: raw)
+    monkeypatch.setattr(
+        explain_module,
+        "resolve_llm_provider_config",
+        lambda **kwargs: SimpleNamespace(provider_name="openai", model_name="gpt-4o-mini"),
+    )
+
+    def _raise_missing_extra(*args: Any, **kwargs: Any) -> None:
+        raise ModuleNotFoundError("langchain_openai")
+
+    monkeypatch.setattr(explain_module, "explain_results_details", _raise_missing_extra)
+
+    explain_module.render_explain_results_panel(
+        summary_df=pd.DataFrame({"monthly_TE": [0.01]}),
+        manifest={"seed": 1},
+        xlsx_path="/tmp/Outputs.xlsx",
+    )
+
+    assert any(
+        kind == "error" and "LLM features unavailable" in text for kind, text in fake_st.messages
+    )
+    assert any(
+        kind == "error" and "install .[llm]" in text.lower() for kind, text in fake_st.messages
+    )

--- a/tests/test_llm_docs.py
+++ b/tests/test_llm_docs.py
@@ -1,0 +1,32 @@
+"""Documentation contracts for optional dashboard LLM features."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_llm_features_doc_names_install_env_and_reference_pack() -> None:
+    text = Path("docs/llm_features.md").read_text()
+
+    assert 'python -m pip install -e ".[llm]"' in text
+    for env_var in (
+        "PA_LLM_PROVIDER",
+        "PA_LLM_MODEL",
+        "PA_STREAMLIT_API_KEY",
+        "OPENAI_API_KEY",
+        "CLAUDE_API_STRANSKE",
+        "PA_LLM_BASE_URL",
+        "PA_LLM_API_VERSION",
+        "AZURE_OPENAI_API_VERSION",
+        "LANGSMITH_API_KEY",
+        "LANGSMITH_PROJECT",
+    ):
+        assert env_var in text
+    assert ".reference/trend_streamlit_llm/" in text
+    assert "must not be committed" in text
+
+
+def test_readme_links_llm_features_doc() -> None:
+    readme = Path("README.md").read_text()
+
+    assert "[Streamlit LLM Features](docs/llm_features.md)" in readme

--- a/tests/test_llm_docs.py
+++ b/tests/test_llm_docs.py
@@ -15,6 +15,7 @@ def test_llm_features_doc_names_install_env_and_reference_pack() -> None:
         "PA_STREAMLIT_API_KEY",
         "OPENAI_API_KEY",
         "CLAUDE_API_STRANSKE",
+        "PA_LLM_ORG",
         "PA_LLM_BASE_URL",
         "PA_LLM_API_VERSION",
         "AZURE_OPENAI_API_VERSION",


### PR DESCRIPTION
Closes #1687

## Summary
- Add `docs/llm_features.md` covering `.[llm]` install, provider env vars, no-secret export expectations, LangSmith tracing, and Trend reference-pack behavior.
- Link the new operator doc from `README.md` and `docs/reference_packs.md`.
- Add docs contract tests plus a Streamlit Explain Results fallback smoke for missing optional LLM dependencies.

## Validation
- `python -m pytest tests/test_dashboard_llm_settings.py tests/test_result_explain.py tests/test_llm_compare_runs.py tests/test_llm_prompts.py tests/test_dashboard_explain_results.py tests/test_dashboard_comparison_llm.py tests/test_reference_packs.py tests/test_llm_docs.py --no-cov`
- `python -m ruff check tests/test_dashboard_explain_results.py tests/test_llm_docs.py`
- `python -m black --check tests/test_dashboard_explain_results.py tests/test_llm_docs.py`