### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -1,15 +1,15 @@
-# Shared formatter/type checker pins consumed by local scripts and dependency sync.
+# Shared formatter/type checker pins consumed by CI workflows and local scripts.
 # Update in lock-step when bumping tooling and keep values in sync with autofix images.
 #
 # NOTE: Only include dev tools here (linters, formatters, test runners).
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.12
+RUFF_VERSION=0.15.13
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.0.0
+MYPY_VERSION=2.1.0
 PYTEST_VERSION=9.0.3
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.13.5
+COVERAGE_VERSION=7.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,14 +117,14 @@ llm = [
 
 # Development dependencies
 dev = [
-    "ruff>=0.15.12",
+    "ruff>=0.15.13",
     "black>=26.3.1",
     "isort>=8.0.1",
-    "mypy==2.0.0",
+    "mypy>=2.1.0",
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-xdist>=3.8.0",
-    "coverage==7.13.5",
+    "coverage>=7.14.0",
     "hypothesis>=6.115.1",
     "pre-commit",
     "bandit",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ openpyxl
 jupyter
 pytest==9.0.3
 hypothesis
-ruff==0.15.12
+ruff==0.15.13
 pydantic
 rich
 PyYAML>=6
@@ -23,7 +23,7 @@ pre-commit         # Git hooks
 pytest-cov==7.1.0  # Test coverage
 pytest-xdist==3.8.0  # Parallel testing
 bandit             # Security linting
-mypy==2.0.0        # Additional type checking
+mypy==2.1.0        # Additional type checking
 types-PyYAML       # Type stubs for PyYAML
 flake8             # Additional linting
 isort==8.0.1       # Import sorting

--- a/requirements.lock
+++ b/requirements.lock
@@ -90,7 +90,7 @@ comm==0.2.3
     # via
     #   ipykernel
     #   ipywidgets
-coverage==7.13.5
+coverage==7.14.0
     # via
     #   portable-alpha-extension-model (pyproject.toml)
     #   pytest-cov
@@ -384,7 +384,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==2.0.0
+mypy==2.1.0
     # via portable-alpha-extension-model (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -657,7 +657,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.12
+ruff==0.15.13
     # via portable-alpha-extension-model (pyproject.toml)
 secretstorage==3.5.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via keyring

--- a/requirements.lock
+++ b/requirements.lock
@@ -28,6 +28,8 @@ argon2-cffi-bindings==25.1.0
     # via argon2-cffi
 arrow==1.4.0
     # via isoduration
+ast-serialize==0.3.0
+    # via mypy
 asttokens==3.0.1
     # via stack-data
 async-lru==2.3.0
@@ -348,7 +350,7 @@ langsmith==0.8.3
     #   langchain-core
 lark==1.3.1
     # via rfc3987-syntax
-librt==0.10.0 ; platform_python_implementation != 'PyPy'
+librt==0.11.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 logistro==2.0.1
     # via


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 6 version updates:
  - ruff: >=0.15.12 -> >=0.15.13
  - mypy: ==2.0.0 -> >=2.1.0
  - coverage: ==7.13.5 -> >=7.14.0
  - requirements.lock:coverage: 7.13.5 -> ==7.14.0
  - requirements.lock:mypy: 2.0.0 -> ==2.1.0
  - requirements.lock:ruff: 0.15.12 -> ==0.15.13

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`