### PR TITLE
Issue #1835: Persist data-quality states

### DIFF
--- a/docs/DATA_IMPORT_SPEC.md
+++ b/docs/DATA_IMPORT_SPEC.md
@@ -28,3 +28,13 @@
 - ≥ 36 monthly observations per instrument by default
 - No duplicate dates per instrument
 - Missing values handled by forward-fill for prices; rows with NA returns dropped
+
+## Persisted data quality
+- `load_index_returns` attaches `series.attrs["data_quality"]` with:
+  - `rows_in`: source return rows before numeric coercion and drop filtering.
+  - `coerced_non_numeric`: non-empty source values that became missing during numeric coercion.
+  - `rows_dropped`: rows excluded from the returned series after value/date drop filtering.
+  - `detected_frequency`: the inferred or fallback frequency recorded on the series.
+- Simulation manifests persist the index `data_quality` block so downstream readers can distinguish clean inputs from runs with dropped/coerced rows.
+- `DataImportAgent` records per-series calibration quality under `data_quality.series.<id>` with `n_obs` and `below_min_obs`.
+- The default importer still raises on series below `min_obs`. The calibrate `--input` command enables the additive record-and-filter path so below-threshold series are omitted from estimates while their `n_obs` and `below_min_obs: true` state remains in the asset-library YAML.

--- a/pa_core/calibration.py
+++ b/pa_core/calibration.py
@@ -347,10 +347,11 @@ def build_calibration_report(
     result: CalibrationResult,
     *,
     alpha_map: Mapping[str, str] | None = None,
+    min_obs: int | None = None,
 ) -> dict[str, object]:
     series_payload = {}
     for series_id, stats in result.series.items():
-        series_payload[series_id] = {
+        payload = {
             "n_obs": stats.n_obs,
             "mean_ci": ([stats.mean_ci.lower, stats.mean_ci.upper] if stats.mean_ci else None),
             "volatility_ci": (
@@ -359,6 +360,9 @@ def build_calibration_report(
                 else None
             ),
         }
+        if min_obs is not None:
+            payload["below_min_obs"] = stats.n_obs < min_obs
+        series_payload[series_id] = payload
 
     corr_payload = []
     for corr in result.correlations:

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1245,6 +1245,7 @@ def main(
             run_log=run_log_path,
             previous_run=args.prev_manifest,
             run_timing=run_timer.snapshot(),
+            data_quality=idx_series.attrs.get("data_quality"),
         )
         manifest_json = Path(args.output).with_name("manifest.json")
         manifest_path = manifest_json
@@ -1707,6 +1708,7 @@ def main(
             run_log=run_log_path,
             previous_run=args.prev_manifest,
             run_timing=run_timer.snapshot(),
+            data_quality=idx_series.attrs.get("data_quality"),
         )
         manifest_path = Path(flags.save_xlsx or "Outputs.xlsx").with_name("manifest.json")
     except (OSError, PermissionError, FileNotFoundError) as e:

--- a/pa_core/data/calibration.py
+++ b/pa_core/data/calibration.py
@@ -103,20 +103,28 @@ class CalibrationAgent:
             }
             for series_id, n_obs in counts.items()
         }
-        data_quality: Dict[str, Any] = {
-            "min_obs": int(self.min_obs),
-            "series": series_quality,
-        }
+        data_quality: Dict[str, Any] = {}
+        incoming_series: Dict[str, Any] = {}
         if isinstance(incoming_quality, dict):
-            data_quality.update(incoming_quality)
-            data_quality["series"] = {
-                **series_quality,
-                **{
-                    str(series_id): dict(payload)
-                    for series_id, payload in incoming_quality.get("series", {}).items()
-                    if isinstance(payload, dict)
-                },
+            # Preserve ancillary incoming fields (rows_in, rows_dropped,
+            # coerced_non_numeric, detected_frequency, etc.) but never let a stale
+            # incoming min_obs/series threshold override the active calibration values.
+            data_quality.update(
+                {k: v for k, v in incoming_quality.items() if k not in ("min_obs", "series")}
+            )
+            incoming_series = {
+                str(series_id): dict(payload)
+                for series_id, payload in incoming_quality.get("series", {}).items()
+                if isinstance(payload, dict)
             }
+        data_quality["min_obs"] = int(self.min_obs)
+        # Freshly recomputed per-series values (n_obs/below_min_obs at this calibrator's
+        # min_obs) win over stale incoming entries; incoming-only ancillary per-series
+        # fields and series ids the calibrator did not recompute are still preserved.
+        merged_series: Dict[str, Any] = dict(incoming_series)
+        for series_id, payload in series_quality.items():
+            merged_series[series_id] = {**merged_series.get(series_id, {}), **payload}
+        data_quality["series"] = merged_series
         filtered = cast(pd.Series, counts[counts >= self.min_obs])
         valid_ids = cast(pd.Index, filtered.index).tolist()
         df = cast(pd.DataFrame, df[df["id"].isin(valid_ids)].copy())

--- a/pa_core/data/calibration.py
+++ b/pa_core/data/calibration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, cast
+from typing import Any, Dict, List, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -42,6 +42,7 @@ class CalibrationResult:
     assets: List[Asset]
     correlations: List[Correlation]
     diagnostics: CalibrationDiagnostics | None = None
+    data_quality: Dict[str, Any] | None = None
 
 
 def _ledoit_wolf_shrinkage(returns: np.ndarray) -> tuple[np.ndarray, float]:
@@ -93,7 +94,29 @@ class CalibrationAgent:
         self.vol_regime_window = vol_regime_window
 
     def calibrate(self, df: pd.DataFrame, index_id: str) -> CalibrationResult:
+        incoming_quality = getattr(df, "attrs", {}).get("data_quality")
         counts = cast(pd.Series, df.groupby("id")["return"].count())
+        series_quality = {
+            str(series_id): {
+                "n_obs": int(n_obs),
+                "below_min_obs": bool(int(n_obs) < self.min_obs),
+            }
+            for series_id, n_obs in counts.items()
+        }
+        data_quality: Dict[str, Any] = {
+            "min_obs": int(self.min_obs),
+            "series": series_quality,
+        }
+        if isinstance(incoming_quality, dict):
+            data_quality.update(incoming_quality)
+            data_quality["series"] = {
+                **series_quality,
+                **{
+                    str(series_id): dict(payload)
+                    for series_id, payload in incoming_quality.get("series", {}).items()
+                    if isinstance(payload, dict)
+                },
+            }
         filtered = cast(pd.Series, counts[counts >= self.min_obs])
         valid_ids = cast(pd.Index, filtered.index).tolist()
         df = cast(pd.DataFrame, df[df["id"].isin(valid_ids)].copy())
@@ -167,7 +190,11 @@ class CalibrationAgent:
             vol_regime_state=regime_state,
         )
         return CalibrationResult(
-            index=index_obj, assets=assets, correlations=pairs, diagnostics=diagnostics
+            index=index_obj,
+            assets=assets,
+            correlations=pairs,
+            diagnostics=diagnostics,
+            data_quality=data_quality,
         )
 
     def to_yaml(self, result: CalibrationResult, path: str | Path) -> None:
@@ -176,4 +203,6 @@ class CalibrationAgent:
             "assets": [a.model_dump() for a in result.assets],
             "correlations": [{"pair": list(c.pair), "rho": c.rho} for c in result.correlations],
         }
+        if result.data_quality:
+            data["data_quality"] = result.data_quality
         Path(path).write_text(yaml.safe_dump(data))

--- a/pa_core/data/importer.py
+++ b/pa_core/data/importer.py
@@ -27,6 +27,7 @@ class DataImportAgent:
         frequency: Literal["monthly", "daily"] = "monthly",
         monthly_rule: Literal["ME", "MS"] = "ME",
         min_obs: int = 36,
+        allow_below_min_obs: bool = False,
         # Optional I/O parsing controls
         sheet_name: str | int | None = None,
         na_values: list[str] | None = None,
@@ -43,6 +44,7 @@ class DataImportAgent:
             raise ValueError("monthly_rule must be 'ME' or 'MS'")
         self.monthly_rule = monthly_rule
         self.min_obs = min_obs
+        self.allow_below_min_obs = allow_below_min_obs
         # I/O parsing options (safe defaults keep existing behavior)
         self.sheet_name = sheet_name
         self.na_values = na_values
@@ -150,8 +152,19 @@ class DataImportAgent:
             raise ValueError("dates must be strictly increasing within each id")
 
         counts = cast(pd.Series, long_df.groupby("id").size())
+        series_quality = {
+            str(series_id): {
+                "n_obs": int(n_obs),
+                "below_min_obs": bool(int(n_obs) < self.min_obs),
+            }
+            for series_id, n_obs in counts.items()
+        }
+        data_quality = {
+            "min_obs": int(self.min_obs),
+            "series": series_quality,
+        }
         bad = cast(pd.Series, counts[counts < self.min_obs])
-        if not bad.empty:
+        if not bad.empty and not self.allow_below_min_obs:
             max_ids = 10
             id_list = [str(x) for x in sorted(bad.index.tolist())]
             shown_ids = id_list[:max_ids]
@@ -177,7 +190,9 @@ class DataImportAgent:
                 "id": self.id_col,
                 "value": self.value_col,
             },
+            "data_quality": data_quality,
         }
+        long_df.attrs["data_quality"] = data_quality
 
         return cast(pd.DataFrame, long_df.reset_index(drop=True))
 
@@ -202,6 +217,7 @@ class DataImportAgent:
             "frequency": self.frequency,
             "monthly_rule": self.monthly_rule,
             "min_obs": self.min_obs,
+            "allow_below_min_obs": self.allow_below_min_obs,
             # I/O options
             "sheet_name": self.sheet_name,
             "na_values": list(self.na_values) if self.na_values is not None else None,
@@ -228,6 +244,7 @@ class DataImportAgent:
             "frequency": str,
             "monthly_rule": str,
             "min_obs": int,
+            "allow_below_min_obs": bool,
             # I/O options
             "sheet_name": (str | int | type(None)),
             "na_values": (list | type(None)),

--- a/pa_core/data/loaders.py
+++ b/pa_core/data/loaders.py
@@ -299,7 +299,13 @@ def load_index_returns(path: str | Path, *, date_format: str | None = None) -> p
             date_column = candidate
             break
 
+    rows_in = int(len(raw))
     numeric = pd.to_numeric(raw, errors="coerce")
+    coerced_non_numeric = int((raw.notna() & numeric.isna()).sum())
+    data_quality: dict[str, object] = {
+        "rows_in": rows_in,
+        "coerced_non_numeric": coerced_non_numeric,
+    }
     if date_column:
         try:
             if date_format:
@@ -329,5 +335,9 @@ def load_index_returns(path: str | Path, *, date_format: str | None = None) -> p
 
     if len(series) == 0:
         raise ValueError(f"No valid numeric data found in CSV file: {path}")
+
+    data_quality["rows_dropped"] = rows_in - int(len(series))
+    data_quality["detected_frequency"] = series.attrs.get("frequency", "unknown")
+    series.attrs["data_quality"] = data_quality
 
     return series

--- a/pa_core/manifest.py
+++ b/pa_core/manifest.py
@@ -26,6 +26,7 @@ class Manifest:
     run_timing: Mapping[str, Any] | None = None
     warnings: Sequence[Mapping[str, Any]] | None = None
     cost: Mapping[str, Any] | None = None
+    data_quality: Mapping[str, Any] | None = None
 
 
 class ManifestWriter:
@@ -55,12 +56,13 @@ class ManifestWriter:
         run_timing: Mapping[str, Any] | None = None,
         warnings: Sequence[Mapping[str, Any]] | None = None,
         cost: Mapping[str, Any] | None = None,
+        data_quality: Mapping[str, Any] | None = None,
     ) -> None:
         """Write manifest to ``self.path``.
 
-        ``warnings`` and ``cost`` are additive optional fields (see
-        ``MANIFEST_OPTIONAL_FIELDS``); they default to ``None`` so existing
-        callers are unaffected and may be finalized post-run by the CLI.
+        ``warnings``, ``cost``, and ``data_quality`` are additive optional
+        fields (see ``MANIFEST_OPTIONAL_FIELDS``); they default to ``None`` so
+        existing callers are unaffected and may be finalized post-run by the CLI.
         """
 
         repo_root = Path(__file__).resolve().parents[1]
@@ -87,5 +89,6 @@ class ManifestWriter:
             run_timing=timing,
             warnings=[dict(w) for w in warnings] if warnings is not None else None,
             cost=dict(cost) if cost is not None else None,
+            data_quality=dict(data_quality) if data_quality is not None else None,
         )
         self.path.write_text(json.dumps(asdict(manifest), indent=2))

--- a/pa_core/pa.py
+++ b/pa_core/pa.py
@@ -385,7 +385,9 @@ def main(argv: Sequence[str] | None = None) -> None:
                 "financing_mode": "broadcast",
                 **model_config,
             }
-            report = build_calibration_report(returns_result, alpha_map=alpha_map)
+            report = build_calibration_report(
+                returns_result, alpha_map=alpha_map, min_obs=int(args.min_obs)
+            )
             payload["calibration"] = report
 
             yaml = _require_yaml()
@@ -404,9 +406,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         calibration_overrides: Mapping[str, Any] = {}
         if args.mapping:
             importer = DataImportAgent.from_template(args.mapping)
+            importer.allow_below_min_obs = True
             calibration_overrides = _load_calibration_overrides(args.mapping)
         else:
-            importer = DataImportAgent(min_obs=int(args.min_obs))
+            importer = DataImportAgent(min_obs=int(args.min_obs), allow_below_min_obs=True)
         if args.index_id is None:
             raise ValueError("index-id is required when using --input")
         cov_shrinkage = cast(

--- a/pa_core/units.py
+++ b/pa_core/units.py
@@ -203,8 +203,11 @@ def normalize_index_series(idx_series: pd.Series, input_unit: str) -> pd.Series:
     """Return a monthly index series given an ``input_unit`` label."""
     unit = input_unit or CANONICAL_RETURN_UNIT
     series = pd.Series(idx_series)
+    series.attrs.update(getattr(idx_series, "attrs", {}))
     if unit == "annual":
-        return convert_annual_series_to_monthly(series)
+        converted = convert_annual_series_to_monthly(series)
+        converted.attrs.update(series.attrs)
+        return converted
     return series
 
 

--- a/tests/test_data_calibration.py
+++ b/tests/test_data_calibration.py
@@ -224,6 +224,36 @@ def test_import_min_obs_enforced(tmp_path: Path) -> None:
         agent.load(path)
 
 
+def test_import_below_min_obs_can_be_persisted_without_crashing(tmp_path: Path) -> None:
+    dates = pd.date_range("2020-01-31", periods=5, freq="ME")
+    df = pd.DataFrame(
+        {
+            "Date": dates,
+            "IDX": [0.01, 0.02, 0.00, 0.01, -0.01],
+            "SHORT": [0.02, 0.03, np.nan, np.nan, np.nan],
+        }
+    )
+    path = tmp_path / "short.csv"
+    df.to_csv(path, index=False)
+
+    importer = DataImportAgent(date_col="Date", min_obs=3, allow_below_min_obs=True)
+    loaded = importer.load(path)
+
+    assert loaded.attrs["data_quality"]["series"]["SHORT"] == {
+        "n_obs": 2,
+        "below_min_obs": True,
+    }
+
+    result = CalibrationAgent(min_obs=3).calibrate(loaded, index_id="IDX")
+    out = tmp_path / "library.yaml"
+    CalibrationAgent(min_obs=3).to_yaml(result, out)
+    data = yaml.safe_load(out.read_text())
+
+    assert data["data_quality"]["series"]["SHORT"]["below_min_obs"] is True
+    assert data["data_quality"]["series"]["SHORT"]["n_obs"] == 2
+    assert all(asset["id"] != "SHORT" for asset in data["assets"])
+
+
 @pytest.mark.parametrize(
     "periods,min_obs,should_fail",
     [

--- a/tests/test_data_calibration.py
+++ b/tests/test_data_calibration.py
@@ -254,6 +254,50 @@ def test_import_below_min_obs_can_be_persisted_without_crashing(tmp_path: Path) 
     assert all(asset["id"] != "SHORT" for asset in data["assets"])
 
 
+def test_calibration_quality_wins_over_stale_incoming_attrs(tmp_path: Path) -> None:
+    """Regression for PR #1841 review thread.
+
+    When data is loaded with a permissive threshold and then calibrated with a
+    stricter one, the persisted data_quality must reflect the *calibrator's*
+    min_obs and recomputed below_min_obs, never the stale incoming values, while
+    ancillary incoming fields (e.g. detected_frequency) are still preserved.
+    """
+    dates = pd.date_range("2020-01-31", periods=6, freq="ME")
+    df = pd.DataFrame(
+        {
+            "Date": dates,
+            "IDX": [0.01, 0.02, 0.00, 0.01, -0.01, 0.02],
+            "SHORT": [0.02, 0.03, 0.01, np.nan, np.nan, np.nan],
+        }
+    )
+    path = tmp_path / "mixed.csv"
+    df.to_csv(path, index=False)
+
+    importer = DataImportAgent(date_col="Date", min_obs=1, allow_below_min_obs=True)
+    loaded = importer.load(path)
+    # Incoming attrs report the permissive threshold: SHORT (3 obs) is not below min_obs=1.
+    assert loaded.attrs["data_quality"]["min_obs"] == 1
+    assert loaded.attrs["data_quality"]["series"]["SHORT"]["below_min_obs"] is False
+    # Ancillary incoming field that must survive the merge.
+    loaded.attrs["data_quality"]["detected_frequency"] = "ME"
+
+    result = CalibrationAgent(min_obs=4).calibrate(loaded, index_id="IDX")
+    out = tmp_path / "library.yaml"
+    CalibrationAgent(min_obs=4).to_yaml(result, out)
+    data = yaml.safe_load(out.read_text())
+
+    dq = data["data_quality"]
+    # Active calibration threshold wins over the stale incoming min_obs=1.
+    assert dq["min_obs"] == 4
+    # SHORT (3 obs) is now correctly flagged below the calibrator threshold.
+    assert dq["series"]["SHORT"] == {"n_obs": 3, "below_min_obs": True}
+    assert dq["series"]["IDX"]["below_min_obs"] is False
+    # Ancillary incoming field preserved.
+    assert dq["detected_frequency"] == "ME"
+    # SHORT is filtered out of the calibrated assets.
+    assert all(asset["id"] != "SHORT" for asset in data["assets"])
+
+
 @pytest.mark.parametrize(
     "periods,min_obs,should_fail",
     [

--- a/tests/test_data_loading_validation.py
+++ b/tests/test_data_loading_validation.py
@@ -67,6 +67,27 @@ def test_load_index_returns_with_text_in_numeric_columns():
         os.remove(temp_path)
 
 
+def test_load_index_returns_records_data_quality_for_dropped_rows():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+        f.write("Date,Monthly_TR\n")
+        f.write("2020-01-01,0.01\n")
+        f.write("2020-02-01,N/A\n")
+        f.write("2020-03-01,0.03\n")
+        f.write("2020-04-01,#DIV/0!\n")
+        temp_path = f.name
+
+    try:
+        series = load_index_returns(temp_path)
+        data_quality = series.attrs["data_quality"]
+        assert data_quality["rows_in"] == 4
+        assert data_quality["rows_dropped"] == 2
+        assert data_quality["coerced_non_numeric"] == 1
+        assert data_quality["detected_frequency"] == series.attrs["frequency"]
+        assert data_quality["rows_in"] > len(series)
+    finally:
+        os.remove(temp_path)
+
+
 def test_load_index_returns_prefers_monthly_tr_column():
     """Test that Monthly_TR is preferred when present."""
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -62,6 +62,39 @@ def test_manifest_written(tmp_path):
     assert manifest["backend"] == "numpy"
 
 
+def test_manifest_records_index_data_quality(tmp_path):
+    cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    idx_csv = tmp_path / "index.csv"
+    idx_csv.write_text(
+        "Date,Monthly_TR\n"
+        "2020-01-31,0.01\n"
+        "2020-02-29,0.02\n"
+        "2020-03-31,0.03\n"
+        "2020-04-30,#DIV/0!\n"
+    )
+    out_file = tmp_path / "out.xlsx"
+
+    main(
+        [
+            "--config",
+            str(cfg_path),
+            "--index",
+            str(idx_csv),
+            "--index-frequency",
+            "monthly",
+            "--output",
+            str(out_file),
+        ]
+    )
+
+    manifest = json.loads(out_file.with_name("manifest.json").read_text())
+    assert manifest["data_quality"]["rows_in"] == 4
+    assert manifest["data_quality"]["rows_dropped"] == 1
+    assert manifest["data_quality"]["coerced_non_numeric"] == 1
+
+
 def test_manifest_records_run_log(tmp_path, monkeypatch):
     cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
     cfg_path = tmp_path / "cfg.yaml"


### PR DESCRIPTION
Closes #1835.

## Summary
- record index-return row counts, dropped rows, coerced non-numeric values, and detected frequency in series attrs and manifests
- preserve per-series n_obs and below_min_obs flags through calibrate --input asset-library output while keeping existing filtering behavior
- add below_min_obs reporting for calibrate --returns and document the data_quality contract

## Validation
- pytest tests/test_data_loading_validation.py::test_load_index_returns_records_data_quality_for_dropped_rows tests/test_index_data_frequency.py tests/test_data_calibration.py::test_import_min_obs_enforced tests/test_data_calibration.py::test_import_below_min_obs_can_be_persisted_without_crashing tests/test_manifest.py::test_manifest_records_index_data_quality -q
- pytest tests/test_data_loading_validation.py tests/test_index_data_frequency.py tests/test_data_calibration.py tests/test_manifest.py -q -k "not rolling_panel_with_malformed_data"
- ruff check pa_core/data/loaders.py pa_core/data/importer.py pa_core/data/calibration.py pa_core/calibration.py pa_core/cli.py pa_core/manifest.py pa_core/pa.py pa_core/units.py tests/test_data_loading_validation.py tests/test_data_calibration.py tests/test_manifest.py
- mypy pa_core/data/loaders.py pa_core/data/importer.py pa_core/data/calibration.py pa_core/calibration.py pa_core/cli.py pa_core/manifest.py pa_core/pa.py pa_core/units.py

Note: the full command without the deselection still hits the pre-existing rolling_panel pandas axis failure in test_rolling_panel_with_malformed_data; the new/changed tests pass.