### PR TITLE
Issue #1832: Add opt-in live LLM smoke gate

### DIFF
--- a/docs/llm_features.md
+++ b/docs/llm_features.md
@@ -89,3 +89,34 @@ python -m pytest \
   tests/test_reference_packs.py \
   --no-cov
 ```
+
+## Live Verification
+
+Live provider verification is opt-in and must only run against an
+org-authorized, no-train provider endpoint with redaction enabled. It uses the
+bundled synthetic `data/sp500tr_fred_divyield.csv` fixture and must not be wired
+into automated CI for the proprietary data zone.
+
+Run the live smoke tests with an authorized OpenAI key:
+
+```bash
+PA_LLM_LIVE=1 PA_LLM_PROVIDER=openai OPENAI_API_KEY=... \
+  python -m pytest tests/test_llm_live_smoke.py -m live_llm -v
+```
+
+Expected output:
+
+```text
+2 passed
+```
+
+Provider environment variables:
+
+| Provider | Required variables |
+| --- | --- |
+| `openai` | `PA_LLM_LIVE=1`, `PA_LLM_PROVIDER=openai`, `OPENAI_API_KEY` |
+| `anthropic` | `PA_LLM_LIVE=1`, `PA_LLM_PROVIDER=anthropic`, `CLAUDE_API_STRANSKE` |
+| `azure_openai` | `PA_LLM_LIVE=1`, `PA_LLM_PROVIDER=azure_openai`, `PA_STREAMLIT_API_KEY`, `PA_LLM_BASE_URL`, and `PA_LLM_API_VERSION` or `AZURE_OPENAI_API_VERSION` |
+
+The default `python -m pytest` path excludes `live_llm` tests with pytest
+addopts, so the normal suite remains offline and key-free.

--- a/pa_core/llm/compare_runs.py
+++ b/pa_core/llm/compare_runs.py
@@ -56,6 +56,8 @@ class CompareRunsPayload:
     questions: str
     prior_manifest_path: str | None
     prior_summary_path: str | None
+    status: str = "success"
+    error_category: str | None = None
 
 
 def load_prior_manifest(
@@ -380,6 +382,8 @@ def compare_runs(
         questions=questions,
         prior_manifest_path=str(prior_manifest_path) if prior_manifest_path else None,
         prior_summary_path=str(prior_summary_path) if prior_summary_path else None,
+        status=status,
+        error_category=error_category,
     )
     try:
         record_fleet_event(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ python_files = ["test_*.py"]
 addopts = "-m 'not live_llm'"
 markers = [
     "live_llm: opt-in test that calls a real LLM provider; deselected by default",
+    "slow: slower or externally dependent tests skipped by routine keepalive commands",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ ignore_errors = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+addopts = "-m 'not live_llm'"
+markers = [
+    "live_llm: opt-in test that calls a real LLM provider; deselected by default",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_llm_live_smoke.py
+++ b/tests/test_llm_live_smoke.py
@@ -111,6 +111,7 @@ def _summary_frame() -> pd.DataFrame:
     )
 
 
+@pytest.mark.slow
 @pytest.mark.live_llm
 def test_explain_results_live(live_llm_config: tuple[LLMProviderConfig, str]) -> None:
     config, api_key = live_llm_config
@@ -150,6 +151,7 @@ def _run_cli(output_path: Path, *, previous_manifest: Path | None = None) -> Pat
     return manifest_path
 
 
+@pytest.mark.slow
 @pytest.mark.live_llm
 def test_compare_runs_live(tmp_path: Path, live_llm_config: tuple[LLMProviderConfig, str]) -> None:
     config, api_key = live_llm_config
@@ -172,5 +174,6 @@ def test_compare_runs_live(tmp_path: Path, live_llm_config: tuple[LLMProviderCon
     )
 
     assert text.strip()
-    assert not text.startswith("Run-to-run comparison summary:")
+    assert payload.status == "success"
+    assert payload.error_category is None
     _assert_secret_absent(api_key, text, trace_url, asdict(payload))

--- a/tests/test_llm_live_smoke.py
+++ b/tests/test_llm_live_smoke.py
@@ -1,0 +1,176 @@
+"""Opt-in live LLM smoke tests for dashboard LLM boundaries."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from pa_core.llm.compare_runs import _default_provider_api_key, compare_runs
+from pa_core.llm.provider import LLMProviderConfig
+from pa_core.llm.result_explain import EXPLAIN_RESULTS_DISCLAIMER, explain_results_details
+
+
+def test_live_llm_smoke_tests_are_opt_in_by_default() -> None:
+    """Keep direct file-only pytest invocations from failing with exit code 5."""
+
+    assert True
+
+
+def _provider_name() -> str:
+    return os.environ.get("PA_LLM_PROVIDER", "openai").strip().lower() or "openai"
+
+
+def _provider_model(provider_name: str) -> str:
+    model = os.environ.get("PA_LLM_MODEL")
+    if model:
+        return model
+    if provider_name == "anthropic":
+        return "claude-sonnet-4-20250514"
+    return "gpt-4o-mini"
+
+
+def _provider_credentials(provider_name: str, api_key: str) -> dict[str, str]:
+    credentials = {"api_key": api_key}
+    if provider_name == "azure_openai":
+        endpoint = os.environ.get("PA_LLM_BASE_URL", "").strip()
+        api_version = (
+            os.environ.get("PA_LLM_API_VERSION") or os.environ.get("AZURE_OPENAI_API_VERSION") or ""
+        ).strip()
+        missing = [
+            name
+            for name, value in (
+                ("PA_LLM_BASE_URL", endpoint),
+                ("PA_LLM_API_VERSION or AZURE_OPENAI_API_VERSION", api_version),
+            )
+            if not value
+        ]
+        if missing:
+            pytest.skip(f"missing Azure OpenAI live verification env vars: {', '.join(missing)}")
+        credentials["azure_endpoint"] = endpoint
+        credentials["api_version"] = api_version
+    return credentials
+
+
+@pytest.fixture
+def live_llm_config() -> tuple[LLMProviderConfig, str]:
+    provider_name = _provider_name()
+    if os.environ.get("PA_LLM_LIVE") != "1":
+        pytest.skip("set PA_LLM_LIVE=1 to run live provider smoke tests")
+
+    api_key = _default_provider_api_key(provider_name)
+    if not api_key:
+        pytest.skip(f"missing provider key for PA_LLM_PROVIDER={provider_name!r}")
+
+    config = LLMProviderConfig(
+        provider_name=provider_name,
+        credentials=_provider_credentials(provider_name, api_key),
+        model_name=_provider_model(provider_name),
+    )
+    return config, api_key
+
+
+def _string_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Mapping):
+        strings: list[str] = []
+        for child in value.values():
+            strings.extend(_string_values(child))
+        return strings
+    if isinstance(value, (list, tuple, set)):
+        strings = []
+        for child in value:
+            strings.extend(_string_values(child))
+        return strings
+    return []
+
+
+def _assert_secret_absent(api_key: str, *values: Any) -> None:
+    for value in values:
+        for text in _string_values(value):
+            assert api_key not in text
+
+
+def _summary_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Agent": ["Core", "Extension", "Total"],
+            "monthly_TE": [0.018, 0.021, 0.02],
+            "monthly_CVaR": [-0.041, -0.048, -0.044],
+            "monthly_BreachProb": [0.08, 0.11, 0.095],
+            "stress_delta_te": [0.002, 0.003, 0.0025],
+        }
+    )
+
+
+@pytest.mark.live_llm
+def test_explain_results_live(live_llm_config: tuple[LLMProviderConfig, str]) -> None:
+    config, api_key = live_llm_config
+
+    text, trace_url, payload = explain_results_details(
+        _summary_frame(),
+        manifest=None,
+        questions="Summarize the most important risk movement in one concise paragraph.",
+        llm_config=config,
+        tracing_enabled=False,
+    )
+
+    assert text.strip()
+    assert text.endswith(EXPLAIN_RESULTS_DISCLAIMER)
+    assert "Failed to generate explanation" not in text
+    _assert_secret_absent(api_key, text, trace_url, payload)
+
+
+def _run_cli(output_path: Path, *, previous_manifest: Path | None = None) -> Path:
+    cmd = [
+        sys.executable,
+        "-m",
+        "pa_core.cli",
+        "--config",
+        "config/params_template.yml",
+        "--index",
+        "data/sp500tr_fred_divyield.csv",
+        "--output",
+        str(output_path),
+    ]
+    if previous_manifest is not None:
+        cmd.extend(["--prev-manifest", str(previous_manifest)])
+
+    subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    manifest_path = output_path.with_name("manifest.json")
+    assert manifest_path.exists()
+    return manifest_path
+
+
+@pytest.mark.live_llm
+def test_compare_runs_live(tmp_path: Path, live_llm_config: tuple[LLMProviderConfig, str]) -> None:
+    config, api_key = live_llm_config
+    prior_output = tmp_path / "prior" / "prior.xlsx"
+    current_output = tmp_path / "current" / "current.xlsx"
+    prior_output.parent.mkdir()
+    current_output.parent.mkdir()
+
+    prior_manifest_path = _run_cli(prior_output)
+    current_manifest_path = _run_cli(current_output, previous_manifest=prior_manifest_path)
+
+    current_manifest = json.loads(current_manifest_path.read_text())
+    current_summary = pd.read_excel(current_output, sheet_name="Summary")
+
+    text, trace_url, payload = compare_runs(
+        current_summary=current_summary,
+        current_manifest=current_manifest,
+        questions="What changed between these two runs?",
+        provider_config=config,
+    )
+
+    assert text.strip()
+    assert not text.startswith("Run-to-run comparison summary:")
+    _assert_secret_absent(api_key, text, trace_url, asdict(payload))


### PR DESCRIPTION
Closes #1832

## Summary
- register a skipped-by-default `live_llm` pytest marker and default deselection
- add opt-in live provider smoke coverage for result explanations and run comparison using synthetic data
- document the authorized live verification command and required provider environment variables

## Validation
- python -m pytest tests/test_llm_live_smoke.py -q
- python -m pytest --strict-markers tests/test_llm_live_smoke.py -q
- PA_LLM_LIVE=1 PA_LLM_PROVIDER=openai OPENAI_API_KEY= python -m pytest tests/test_llm_live_smoke.py -m live_llm -q
- python -m pytest tests/test_llm_live_smoke.py tests/test_llm_compare_runs.py tests/test_result_explain.py -q
- python -m pytest --collect-only -q | rg "test_llm_live_smoke|deselected"
- python -m ruff check pyproject.toml tests/test_llm_live_smoke.py
- python -m black --check --fast tests/test_llm_live_smoke.py