### PR TITLE
Issue #1833: add privacy-safe browser demo path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
     }
   },
   "postCreateCommand": "bash .devcontainer/setup.sh",
-  "postStartCommand": "echo 'Codespace ready! Run ./dev.sh demo to get started.'",
+  "postStartCommand": "bash -lc 'if ! pgrep -f \"streamlit run dashboard/app.py\" >/dev/null; then nohup python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501 --server.address=0.0.0.0 > /tmp/paem-dashboard.log 2>&1 & fi; echo \"Dashboard auto-started on forwarded port 8501. Logs: /tmp/paem-dashboard.log\"'",
   "mounts": [
     "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=cached"
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
     }
   },
   "postCreateCommand": "bash .devcontainer/setup.sh",
-  "postStartCommand": "bash -lc 'if ! pgrep -f \"streamlit run dashboard/app.py\" >/dev/null; then nohup python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501 --server.address=0.0.0.0 > /tmp/paem-dashboard.log 2>&1 & fi; echo \"Dashboard auto-started on forwarded port 8501. Logs: /tmp/paem-dashboard.log\"'",
+  "postStartCommand": "bash -lc 'if ! pgrep -f \"[s]treamlit run dashboard/app.py\" >/dev/null; then nohup python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501 --server.address=0.0.0.0 > /tmp/paem-dashboard.log 2>&1 & fi; echo \"Dashboard auto-started on forwarded port 8501. Logs: /tmp/paem-dashboard.log\"'",
   "mounts": [
     "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=cached"
   ],

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -86,6 +86,48 @@ jobs:
           echo "✅ Codespace setup script syntax is valid"
 
   # ───────────────────────────────────────────────────────────────────────────
+  # PAEM-specific: Dashboard Boot Smoke
+  # Proves the browser demo entry starts without the optional LLM extra.
+  # ───────────────────────────────────────────────────────────────────────────
+  dashboard-smoke:
+    name: Dashboard Smoke
+    needs: detect
+    if: ${{ needs.detect.outputs.is_docs_only != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install base dependencies only
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Start dashboard and check Streamlit health
+        run: |
+          set -euo pipefail
+          python -m streamlit run dashboard/app.py \
+            --server.headless=true \
+            --server.port=8501 \
+            --server.address=127.0.0.1 \
+            > streamlit.log 2>&1 &
+          dashboard_pid=$!
+          trap 'kill "$dashboard_pid" 2>/dev/null || true; cat streamlit.log' EXIT
+
+          for _ in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8501/_stcore/health; then
+              echo "Dashboard health check passed"
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "::error::Dashboard did not become healthy on /_stcore/health"
+          exit 1
+
+  # ───────────────────────────────────────────────────────────────────────────
   # PAEM-specific: Integration Tests (CLI + Golden Tutorials)
   # Runs in PARALLEL with python-ci for faster feedback
   # ───────────────────────────────────────────────────────────────────────────
@@ -125,7 +167,7 @@ jobs:
   # ───────────────────────────────────────────────────────────────────────────
   summary:
     name: gate-summary
-    needs: [detect, python-ci, codespace-validation, integration-tests]
+    needs: [detect, python-ci, codespace-validation, dashboard-smoke, integration-tests]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -142,12 +184,14 @@ jobs:
           DETECT_RESULT: ${{ needs.detect.result || 'skipped' }}
           PYTHON_RESULT: ${{ needs.python-ci.result || 'skipped' }}
           CODESPACE_RESULT: ${{ needs.codespace-validation.result || 'skipped' }}
+          DASHBOARD_RESULT: ${{ needs.dashboard-smoke.result || 'skipped' }}
           INTEGRATION_RESULT: ${{ needs.integration-tests.result || 'skipped' }}
         run: |
           set -euo pipefail
 
           python_result="${PYTHON_RESULT:-skipped}"
           codespace_result="${CODESPACE_RESULT:-skipped}"
+          dashboard_result="${DASHBOARD_RESULT:-skipped}"
           integration_result="${INTEGRATION_RESULT:-skipped}"
 
           state="success"
@@ -166,6 +210,12 @@ jobs:
           if [[ "$state" == "success" && "$codespace_result" == "failure" ]]; then
             state="failure"
             description="Codespace validation failed"
+          fi
+
+          # Check dashboard smoke (only fail if earlier checks passed)
+          if [[ "$state" == "success" && "$dashboard_result" == "failure" ]]; then
+            state="failure"
+            description="Dashboard smoke failed"
           fi
 
           # Check Integration tests (only fail if CI passed)

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -103,22 +103,23 @@ jobs:
       - name: Install base dependencies only
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
           pip install -e .
       - name: Start dashboard and check Streamlit health
         run: |
           set -euo pipefail
+          smoke_status=1
           python -m streamlit run dashboard/app.py \
             --server.headless=true \
             --server.port=8501 \
             --server.address=127.0.0.1 \
             > streamlit.log 2>&1 &
           dashboard_pid=$!
-          trap 'kill "$dashboard_pid" 2>/dev/null || true; cat streamlit.log' EXIT
+          trap 'status=$?; kill "$dashboard_pid" 2>/dev/null || true; if [[ "$status" -ne 0 || "$smoke_status" -ne 0 ]]; then cat streamlit.log; fi' EXIT
 
           for _ in {1..30}; do
             if curl --fail --silent --show-error http://127.0.0.1:8501/_stcore/health; then
               echo "Dashboard health check passed"
+              smoke_status=0
               exit 0
             fi
             sleep 1

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ The demo installs only the base package. LLM panels are disabled by default and 
 Boot smoke gate used by PRs:
 
 ```bash
-python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501 --server.address=127.0.0.1
-curl --fail http://127.0.0.1:8501/_stcore/health
+python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501 --server.address=127.0.0.1 > streamlit.log 2>&1 &
+dashboard_pid=$!
+until curl --fail http://127.0.0.1:8501/_stcore/health; do sleep 1; done
+kill "$dashboard_pid"
 ```
 
 To see sample output, upload `data/sp500tr_fred_divyield.csv` in the wizard and run the bundled scenario flow.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,33 @@ Start here: Run the Dashboard Wizard (recommended)
 
 Most users should begin with the interactive dashboard wizard. It guides you through loading data and running a scenario without touching the command line.
 
-1) Setup (first time only)
-  - ./dev.sh setup
-2) Launch the dashboard wizard
-  - ./dev.sh dashboard
-  - Or: python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501
-3) In the app, open “Scenario Wizard” and follow the prompts to run and view results.
+## Try It In Your Browser
+
+The privacy-safe browser demo uses GitHub Codespaces. Click the Codespaces badge above and create a Codespace; the dashboard auto-starts on forwarded port 8501 and GitHub shows a forwarded-port notification. Open that forwarded URL and go to **Scenario Wizard**.
+
+This path keeps the app and uploaded files inside the user's own Codespace. Do not deploy real proprietary index data to Streamlit Community Cloud, Hugging Face Spaces, or another public/shared SaaS host. If an external demo is ever used, it must be synthetic-data only.
+
+The pure client-side WASM/stlite path is intentionally not claimed here: the base dependency surface includes `kaleido` for Plotly static export and `python-pptx` for board packs, both of which are not viable in Pyodide/stlite. The supported terminal-free path is therefore Codespace auto-start or an internal/on-prem host with equivalent data controls.
+
+The demo installs only the base package. LLM panels are disabled by default and show the install/key prompt instead of making provider calls. Enabling LLM features requires `.[llm]`, a provider key, and an org-authorized no-train endpoint.
+
+Boot smoke gate used by PRs:
+
+```bash
+python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501 --server.address=127.0.0.1
+curl --fail http://127.0.0.1:8501/_stcore/health
+```
+
+To see sample output, upload `data/sp500tr_fred_divyield.csv` in the wizard and run the bundled scenario flow.
+
+Local terminal setup is still available for developers:
+
+1. Setup (first time only)
+  - `./dev.sh setup`
+2. Launch the dashboard wizard
+  - `./dev.sh dashboard`
+  - Or: `python -m streamlit run dashboard/app.py --server.headless=true --server.port=8501`
+3. In the app, open **Scenario Wizard** and follow the prompts to run and view results.
 
 Wizard preview:
 
@@ -67,13 +88,9 @@ Click the "Open in GitHub Codespaces" badge above for an instant, fully-configur
 - Install all dependencies
 - Configure VS Code with optimal settings
 - Enable debugging and testing
-- Start with port forwarding for the dashboard
+- Auto-start the dashboard and notify on forwarded port 8501
 
-Once the Codespace loads, run:
-```bash
-./dev.sh dashboard # Start the dashboard wizard (opens on port 8501)
-./dev.sh demo      # Optional: quick demo via CLI
-```
+Once the Codespace loads, open the forwarded port 8501 URL and select **Scenario Wizard**. For CLI-only development, `./dev.sh dashboard` and `./dev.sh demo` remain available in the terminal.
 
 ### dev.sh helper script
 


### PR DESCRIPTION
Closes #1833

## Summary
- auto-start the Streamlit dashboard in Codespaces on forwarded port 8501
- document the privacy-safe browser demo path, the rejected WASM/stlite dependency surface, and disabled-by-default LLM boundary
- add a Gate dashboard smoke job that installs base dependencies only, starts `dashboard/app.py`, and checks `/_stcore/health`

## Validation
- `python -m json.tool .devcontainer/devcontainer.json`
- parsed `.github/workflows/pr-00-gate.yml` with PyYAML
- local Streamlit boot smoke returned `ok` from `http://127.0.0.1:8501/_stcore/health`
- `git diff --check`