### PR TITLE
Issue #1836: declare PA data zones and LLM egress boundary

### DIFF
--- a/docs/llm_features.md
+++ b/docs/llm_features.md
@@ -6,6 +6,18 @@ previous run, and show LangSmith trace links when tracing is enabled. Required
 tests use fake clients or heuristic fallbacks and must not call real LLM
 providers.
 
+The machine-readable boundary is available through:
+
+```bash
+pa describe
+```
+
+The descriptor declares the deterministic engine as offline and the LLM zone as
+`gated-no-train`: disabled for proprietary data unless an authorized no-train
+endpoint with redaction is explicitly configured. This descriptor is a static
+declaration for tooling and backplane discovery; it does not enable provider
+calls or enforce sandboxing by itself.
+
 ## Install
 
 Install the optional LLM extra before using provider-backed dashboard features:

--- a/docs/pa_core_facade.md
+++ b/docs/pa_core_facade.md
@@ -14,6 +14,9 @@ CLI entrypoints stay consistent and regression-safe.
 - `export`: shared export helper for artifact bundles.
 
 ## Delegation from CLI
+- `pa describe` emits a static JSON tool descriptor without importing the run
+  stack. It declares the deterministic offline zone, the gated LLM zone, and
+  filesystem read/write permissions for backplane discovery.
 - `pa` (the console script) parses the top-level subcommand and forwards run
   arguments to `pa_core.cli.main` so the full run parser stays centralized.
 - `pa_core.cli.main` owns the authoritative run argument parser, builds
@@ -52,6 +55,14 @@ When adjusting parsing or output sequencing, update:
   with `tests/expected_cli_outputs.py`.
 - `pa_core/__main__.py` to keep the legacy parser synchronized with shared flags
   and ensure delegated output lines still match the constants file.
+
+## Tool Descriptor
+The descriptor returned by `pa describe` is declaration-only. It does not
+sandbox execution, change runtime behavior, or enable LLM features. It states
+that deterministic runs are offline and may operate on real/proprietary data
+locally, while LLM helpers are disabled by default and require an authorized
+no-train endpoint with redaction before proprietary data can cross that
+boundary.
 
 ## Deprecation Warning Behavior
 Non-canonical invocation paths emit `DeprecationWarning` via the Python

--- a/pa_core/pa.py
+++ b/pa_core/pa.py
@@ -270,6 +270,9 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     args, remaining = parser.parse_known_args(argv)
     if args.command == "describe":
+        if remaining:
+            parser.error(f"unrecognized arguments: {' '.join(remaining)}")
+
         from .tool_descriptor import get_tool_descriptor
 
         print(json.dumps(get_tool_descriptor(), indent=2, sort_keys=True))

--- a/pa_core/pa.py
+++ b/pa_core/pa.py
@@ -122,6 +122,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         argv = sys.argv[1:]
     parser = argparse.ArgumentParser(prog="pa")
     sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("describe", help="Emit the static tool descriptor as JSON")
     sub.add_parser("run", help="Run simulation")
     sub.add_parser("validate", help="Validate scenario YAML")
     sweep_parser = sub.add_parser("sweep", help="Run parameter sweep from sweep configuration")
@@ -268,7 +269,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     convert_parser.add_argument("yaml", nargs="?", help="Output YAML file (default: <input>.yml)")
 
     args, remaining = parser.parse_known_args(argv)
-    if args.command == "run":
+    if args.command == "describe":
+        from .tool_descriptor import get_tool_descriptor
+
+        print(json.dumps(get_tool_descriptor(), indent=2, sort_keys=True))
+    elif args.command == "run":
         from .cli import main as run_main
 
         run_main(list(remaining), emit_deprecation_warning=False)

--- a/pa_core/tool_descriptor.py
+++ b/pa_core/tool_descriptor.py
@@ -1,0 +1,83 @@
+"""Static tool descriptor for backplane and privacy-boundary discovery."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+_DESCRIPTOR: dict[str, Any] = {
+    "schema_version": "pa-tool-descriptor/v1",
+    "tool": {
+        "name": "portable-alpha-extension-model",
+        "command": "pa",
+        "description": (
+            "Offline deterministic portable-alpha simulations with optional "
+            "gated LLM dashboard helpers."
+        ),
+    },
+    "network": {
+        "deterministic": "offline",
+        "llm": "gated-no-train",
+    },
+    "data_zones": [
+        {
+            "id": "deterministic",
+            "name": "Deterministic local engine",
+            "data_sensitivity": "real-or-proprietary",
+            "network": "offline",
+            "default_enabled": True,
+            "boundary": (
+                "Runs locally with the numpy backend and does not require network egress "
+                "for simulation, validation, sweep, or calibration commands."
+            ),
+        },
+        {
+            "id": "llm",
+            "name": "Optional LLM dashboard helpers",
+            "data_sensitivity": "synthetic-or-redacted-only",
+            "network": "gated-no-train",
+            "default_enabled": False,
+            "boundary": (
+                "Disabled for proprietary data unless an authorized no-train endpoint "
+                "with redaction is explicitly configured."
+            ),
+        },
+        {
+            "id": "filesystem",
+            "name": "Declared filesystem I/O",
+            "data_sensitivity": "depends-on-inputs",
+            "network": "local-filesystem",
+            "default_enabled": True,
+            "boundary": (
+                "Reads declared config/index files and writes run artifacts under "
+                "declared output paths."
+            ),
+        },
+    ],
+    "permissions": {
+        "reads": [
+            "--config",
+            "--index",
+            "--input",
+            "--returns",
+            "scenario registry entries",
+        ],
+        "writes": [
+            "Outputs.xlsx",
+            "Sweep.xlsx",
+            "runs/<run_id>/",
+            ".pa_registry/",
+            "asset_library.yaml",
+        ],
+        "network": {
+            "deterministic": "offline",
+            "llm": "requires explicit authorized no-train provider configuration and redaction",
+        },
+    },
+}
+
+
+def get_tool_descriptor() -> dict[str, Any]:
+    """Return a mutable copy of the static tool descriptor."""
+
+    return deepcopy(_DESCRIPTOR)

--- a/pa_core/tool_descriptor.py
+++ b/pa_core/tool_descriptor.py
@@ -71,7 +71,7 @@ _DESCRIPTOR: dict[str, Any] = {
         ],
         "network": {
             "deterministic": "offline",
-            "llm": "requires explicit authorized no-train provider configuration and redaction",
+            "llm": "gated-no-train",
         },
     },
 }

--- a/tests/test_tool_descriptor.py
+++ b/tests/test_tool_descriptor.py
@@ -1,0 +1,58 @@
+"""Smoke tests for the static PA tool descriptor."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import socket
+import sys
+
+from pa_core.pa import main as pa_main
+from pa_core.tool_descriptor import get_tool_descriptor
+
+
+def _drop_heavy_modules() -> None:
+    for name in list(sys.modules):
+        if name == "numpy" or name.startswith("numpy."):
+            sys.modules.pop(name)
+        if name == "pandas" or name.startswith("pandas."):
+            sys.modules.pop(name)
+
+
+def test_describe_emits_zones(capsys) -> None:
+    pa_main(["describe"])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert {"network", "data_zones", "permissions"} <= payload.keys()
+    zone_ids = {zone["id"] for zone in payload["data_zones"]}
+    assert {"deterministic", "llm", "filesystem"} <= zone_ids
+    llm_zone = next(zone for zone in payload["data_zones"] if zone["id"] == "llm")
+    assert llm_zone["network"] == "gated-no-train"
+    assert "no-train" in llm_zone["boundary"]
+    assert payload["network"]["llm"] == "gated-no-train"
+
+
+def test_llm_zone_consistent_with_no_network_guarantee(socket_connect_guard) -> None:
+    attempts, blocked = socket_connect_guard
+    descriptor = get_tool_descriptor()
+
+    for name in list(sys.modules):
+        if name == "pa_core.llm" or name.startswith("pa_core.llm."):
+            sys.modules.pop(name)
+
+    importlib.import_module("pa_core.llm")
+
+    assert descriptor["network"]["deterministic"] == "offline"
+    assert socket.socket.connect is blocked
+    assert attempts == []
+
+
+def test_describe_does_not_import_numpy_or_pandas(capsys) -> None:
+    _drop_heavy_modules()
+
+    pa_main(["describe"])
+
+    assert json.loads(capsys.readouterr().out)["network"]["deterministic"] == "offline"
+    assert "numpy" not in sys.modules
+    assert "pandas" not in sys.modules

--- a/tests/test_tool_descriptor.py
+++ b/tests/test_tool_descriptor.py
@@ -25,6 +25,19 @@ def test_describe_emits_zones(capsys) -> None:
     assert llm_zone["network"] == "gated-no-train"
     assert "no-train" in llm_zone["boundary"]
     assert payload["network"]["llm"] == "gated-no-train"
+    assert payload["permissions"]["network"]["llm"] == "gated-no-train"
+
+
+def test_describe_rejects_unknown_arguments(capsys) -> None:
+    try:
+        pa_main(["describe", "--outpt", "descriptor.json"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:  # pragma: no cover - defensive assertion for argparse behavior
+        raise AssertionError("describe accepted an unknown argument")
+
+    stderr = capsys.readouterr().err
+    assert "unrecognized arguments: --outpt descriptor.json" in stderr
 
 
 def test_llm_zone_consistent_with_no_network_guarantee(socket_connect_guard) -> None:

--- a/tests/test_tool_descriptor.py
+++ b/tests/test_tool_descriptor.py
@@ -5,18 +5,12 @@ from __future__ import annotations
 import importlib
 import json
 import socket
+import subprocess
 import sys
+from pathlib import Path
 
 from pa_core.pa import main as pa_main
 from pa_core.tool_descriptor import get_tool_descriptor
-
-
-def _drop_heavy_modules() -> None:
-    for name in list(sys.modules):
-        if name == "numpy" or name.startswith("numpy."):
-            sys.modules.pop(name)
-        if name == "pandas" or name.startswith("pandas."):
-            sys.modules.pop(name)
 
 
 def test_describe_emits_zones(capsys) -> None:
@@ -48,11 +42,21 @@ def test_llm_zone_consistent_with_no_network_guarantee(socket_connect_guard) -> 
     assert attempts == []
 
 
-def test_describe_does_not_import_numpy_or_pandas(capsys) -> None:
-    _drop_heavy_modules()
+def test_describe_does_not_import_numpy_or_pandas() -> None:
+    script = """
+import sys
+from pa_core.pa import main
 
-    pa_main(["describe"])
+main(["describe"])
+if "numpy" in sys.modules or "pandas" in sys.modules:
+    raise SystemExit("describe imported numpy or pandas")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        capture_output=True,
+    )
 
-    assert json.loads(capsys.readouterr().out)["network"]["deterministic"] == "offline"
-    assert "numpy" not in sys.modules
-    assert "pandas" not in sys.modules
+    assert json.loads(result.stdout)["network"]["deterministic"] == "offline"


### PR DESCRIPTION
Closes #1836

## Summary
- add a dependency-free static tool descriptor for deterministic, LLM, and filesystem zones
- expose it through `pa describe` as JSON without importing the run stack
- document the deterministic offline and gated no-train LLM boundary

## Validation
- `python -m pytest tests/test_tool_descriptor.py tests/test_llm_import_and_no_network.py -q --no-cov`
- `python -m ruff check pa_core/tool_descriptor.py pa_core/pa.py tests/test_tool_descriptor.py`
- `python -m black --check --fast pa_core/tool_descriptor.py pa_core/pa.py tests/test_tool_descriptor.py`
- `MYPYPATH=. python -m mypy pa_core/tool_descriptor.py pa_core/pa.py`
- `python -m pa_core.pa describe | python -m json.tool`