### PR TITLE
Issue #1852: Add app behavior baseline kit

### DIFF
--- a/.project_modules.txt
+++ b/.project_modules.txt
@@ -1,3 +1,5 @@
 expected_cli_outputs
+# app-baseline-kit ships the `baseline_kit` import; declared via app-baseline-kit pin
 baseline_kit
+# local pytest fixtures imported relatively (from .conftest import ...)
 conftest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,10 @@ dev = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-xdist>=3.8.0",
-    # Shared app behavior baseline harness (pulls pytest-regressions). Pinned to
-    # the Workflows default branch; move to a tagged ref once the package is versioned.
-    "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
+    # Shared app behavior baseline harness (pulls pytest-regressions). Pinned
+    # to the Workflows merge commit that introduced the package; move to a
+    # tagged ref once the package is versioned.
+    "app-baseline-kit @ git+https://github.com/stranske/Workflows.git@4581ee9c91240b6d3ef628f0f8ff982f6bcaba36#subdirectory=packages/app-baseline-kit",
     "coverage>=7.14.0",
     "hypothesis>=6.115.1",
     "pre-commit",

--- a/requirements.lock
+++ b/requirements.lock
@@ -20,6 +20,8 @@ anyio==4.13.0
     #   httpx
     #   jupyter-server
     #   openai
+app-baseline-kit @ git+https://github.com/stranske/Workflows.git@4581ee9c91240b6d3ef628f0f8ff982f6bcaba36#subdirectory=packages/app-baseline-kit
+    # via portable-alpha-extension-model (pyproject.toml)
 appnope==0.1.4 ; sys_platform == 'darwin'
     # via ipykernel
 argon2-cffi==25.1.0

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -24,7 +24,9 @@ SEED = 42
 BASE_PATCH: dict[str, Any] = {"N_SIMULATIONS": 400, "N_MONTHS": 12}
 
 # Deterministic 12-month benchmark index (no external data file needed).
-INDEX = pd.Series([0.01, -0.02, 0.015, 0.005, -0.01, 0.02, 0.01, 0.005, -0.015, 0.02, 0.01, -0.005])
+INDEX = pd.Series(
+    [0.01, -0.02, 0.015, 0.005, -0.01, 0.02, 0.01, 0.005, -0.015, 0.02, 0.01, -0.005]
+)
 
 # Numeric metric columns from the simulation summary table.
 METRIC_COLS = [

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -59,7 +59,9 @@ def run(patch: Mapping[str, Any] | None = None) -> pd.DataFrame:
     """Run the simulation with an input patch; return the summary indexed by Agent."""
     from pa_core.facade import RunOptions, run_single
 
-    cfg = _base_config().model_copy(update={**BASE_PATCH, **(patch or {})})
+    data = _base_config().model_dump()
+    data.update({**BASE_PATCH, **(patch or {})})
+    cfg = _base_config().__class__.model_validate(data)
     artifacts = run_single(cfg, INDEX, RunOptions(seed=SEED))
     return artifacts.summary.set_index("Agent")
 

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -24,9 +24,7 @@ SEED = 42
 BASE_PATCH: dict[str, Any] = {"N_SIMULATIONS": 400, "N_MONTHS": 12}
 
 # Deterministic 12-month benchmark index (no external data file needed).
-INDEX = pd.Series(
-    [0.01, -0.02, 0.015, 0.005, -0.01, 0.02, 0.01, 0.005, -0.015, 0.02, 0.01, -0.005]
-)
+INDEX = pd.Series([0.01, -0.02, 0.015, 0.005, -0.01, 0.02, 0.01, 0.005, -0.015, 0.02, 0.01, -0.005])
 
 # Numeric metric columns from the simulation summary table.
 METRIC_COLS = [

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -21,6 +21,10 @@ def _split_spec(raw: str) -> tuple[str, str | None]:
         entry = entry.strip()
         condition = condition.strip()
 
+    if " @ " in entry:
+        name, _ = entry.split(" @ ", 1)
+        return name.strip().split("[")[0], condition
+
     for operator in _OPERATORS:
         if operator in entry:
             name, _ = entry.split(operator, 1)
@@ -61,6 +65,10 @@ def _load_lock_versions(path: Path) -> Dict[str, str]:
             continue
         if stripped.startswith("--"):
             continue
+        if " @ " in stripped:
+            name, _ = stripped.split(" @ ", 1)
+            versions[name.lower().strip()] = "<direct-reference>"
+            continue
         # Handle conditional markers in lock file (e.g., ; sys_platform == 'win32')
         if "==" in stripped:
             entry = stripped.split(";")[0].strip() if ";" in stripped else stripped
@@ -77,8 +85,6 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
 
     declared = set()
     for entry in project.get("dependencies", []):
-        if " @ " in entry:  # PEP 508 direct reference (git/url): pinned by URL, not by == in lock
-            continue
         pkg_name, condition = _split_spec(entry)
         pkg_name = pkg_name.lower()
         # Skip self-references
@@ -91,8 +97,6 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
 
     for group in project.get("optional-dependencies", {}).values():
         for entry in group:
-            if " @ " in entry:  # PEP 508 direct reference (git/url): pinned by URL, not by == in lock
-                continue
             pkg_name, condition = _split_spec(entry)
             pkg_name = pkg_name.lower()
             # Skip self-references


### PR DESCRIPTION
Closes #1852
Supersedes #1847
Related #1849

## Why

This replaces #1847 on a registry-routed Codex branch so keepalive and closer can process the baseline-kit work normally.

The implementation adds the shared app behavior baseline kit to PAEM: deterministic regression and sensibility coverage over the real `pa_core.facade.run_single` scenario path.

## Scope

- Add `tests/baseline/` golden-master, directional, invariant, and coverage-manifest tests.
- Generate `docs/reports/baseline-coverage.md`.
- Add dependency alignment for `app-baseline-kit` from Workflows.
- Preserve the surfaced baseline findings with owner decisions:
  - `active_share` should affect ActiveExt; follow-up should fix config patch revalidation/recompilation rather than treating it as mode-dependent.
  - InternalPA financing cost is a real model requirement, now tracked in #1849, not merely a report-only baseline oddity.

## Verification From Original PR

`PYTHONHASHSEED=0 pytest tests/baseline/ -n0` -> 7 passed, 2 skipped/report-only findings.

## Routing Repair

- Branch: `codex/issue-1852-app-baseline-kit`
- Required labels: `agent:codex`, `agents:keepalive`, `autofix`
- Source issue: #1852

