### PR TITLE
Issue #1854: Emit PA scenario-run fleet records from the deterministic run path

### DIFF
--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1274,7 +1274,7 @@ def main(
                 latency_ms=int(_current_duration() * 1000),
                 operation=SCENARIO_SWEEP_OPERATION,
             )
-        except Exception:
+        except (ImportError, AttributeError):
             logger.debug("Scenario sweep fleet-record emission failed", exc_info=True)
 
         current_manifest_data = manifest_data or {"config": raw_params}

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1264,6 +1264,18 @@ def main(
         all_summary = (
             pd.concat(summary_frames, ignore_index=True) if summary_frames else pd.DataFrame()
         )
+        try:
+            from .llm.scenario_fleet import SCENARIO_SWEEP_OPERATION, record_scenario_run
+
+            record_scenario_run(
+                cfg,
+                all_summary,
+                seed=rng_bundle.seed,
+                latency_ms=int(_current_duration() * 1000),
+                operation=SCENARIO_SWEEP_OPERATION,
+            )
+        except Exception:
+            logger.debug("Scenario sweep fleet-record emission failed", exc_info=True)
 
         current_manifest_data = manifest_data or {"config": raw_params}
         _maybe_print_run_diff(

--- a/pa_core/facade.py
+++ b/pa_core/facade.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import math
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, Union
@@ -346,6 +347,7 @@ def run_single(
     from .units import normalize_return_inputs
     from .validators import select_vol_regime_sigma
 
+    started = time.perf_counter()
     run_options = options or RunOptions()
     run_cfg = apply_run_options(config, run_options)
     resolve_and_set_backend(run_options.backend, run_cfg)
@@ -526,7 +528,7 @@ def run_single(
         "substream_ids": substream_ids,
     }
 
-    return RunArtifacts(
+    artifacts = RunArtifacts(
         config=run_cfg,
         index_series=idx_series,
         returns=returns,
@@ -535,6 +537,16 @@ def run_single(
         raw_returns=raw_returns,
         manifest=manifest,
     )
+    from .llm.scenario_fleet import SCENARIO_RUN_OPERATION, record_scenario_run
+
+    record_scenario_run(
+        run_cfg,
+        summary,
+        seed=run_options.seed,
+        latency_ms=int((time.perf_counter() - started) * 1000),
+        operation=SCENARIO_RUN_OPERATION,
+    )
+    return artifacts
 
 
 def run_sweep(
@@ -590,6 +602,7 @@ def run_sweep(
     from .sim.simulation_initialization import initialize_sweep_rngs
     from .sweep import run_parameter_sweep, sweep_results_to_dataframe
 
+    started = time.perf_counter()
     run_options = options or RunOptions()
     run_cfg = apply_run_options(config, run_options, sweep_params)
     resolve_and_set_backend(run_options.backend, run_cfg)
@@ -625,7 +638,7 @@ def run_sweep(
         "substream_ids": substream_ids,
     }
 
-    return SweepArtifacts(
+    artifacts = SweepArtifacts(
         config=run_cfg,
         index_series=idx_series,
         results=results,
@@ -633,6 +646,16 @@ def run_sweep(
         inputs=inputs,
         manifest=manifest,
     )
+    from .llm.scenario_fleet import SCENARIO_SWEEP_OPERATION, record_scenario_run
+
+    record_scenario_run(
+        run_cfg,
+        summary,
+        seed=run_options.seed,
+        latency_ms=int((time.perf_counter() - started) * 1000),
+        operation=SCENARIO_SWEEP_OPERATION,
+    )
+    return artifacts
 
 
 def export(

--- a/pa_core/llm/scenario_fleet.py
+++ b/pa_core/llm/scenario_fleet.py
@@ -1,0 +1,142 @@
+"""Deterministic fleet-record emission for PA scenario/simulation runs.
+
+Wires the PA core scenario run-completion boundary
+(:meth:`pa_core.orchestrator.SimulatorOrchestrator.run` /
+:meth:`~pa_core.orchestrator.SimulatorOrchestrator.run_sweep`) into the
+dashboard-safe LangSmith fleet-record stream.
+
+This module is intentionally **egress-free**: it never invokes an LLM or a
+LangSmith client. It only appends a hashed, domain-only record to the local
+``langsmith-fleet.ndjson`` artifact via
+:func:`pa_core.llm.langsmith_fleet.record_fleet_event`. With
+``LANGSMITH_API_KEY`` unset the record is written with a ``no_secret`` status
+so the deterministic, proprietary-data path stays in-perimeter (no raw
+holdings, prompts, model output, or PII leave the process).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from pa_core.llm.langsmith_fleet import (
+    FleetContext,
+    config_fingerprint,
+    hash_reference,
+    record_fleet_event,
+)
+
+SCENARIO_RUN_OPERATION = "scenario-run"
+SCENARIO_SWEEP_OPERATION = "scenario-sweep"
+SCENARIO_DASHBOARD_SURFACE = "scenario-analysis"
+DEFAULT_BENCHMARK = "Base"
+
+
+def _config_mapping(config: Any) -> Mapping[str, Any] | None:
+    """Return a plain mapping view of a ModelConfig (or mapping) for hashing."""
+
+    dump = getattr(config, "model_dump", None)
+    if callable(dump):
+        try:
+            data = dump()
+        except Exception:
+            return None
+        return data if isinstance(data, Mapping) else None
+    return config if isinstance(config, Mapping) else None
+
+
+def _summary_metric_delta(summary: Any, *, benchmark: str = DEFAULT_BENCHMARK) -> float | None:
+    """Return a single safe scalar summarising the run's terminal-return spread.
+
+    Prefers the best active sleeve's terminal annual return minus the benchmark
+    ("Base") sleeve's; falls back to the cross-agent spread. This is an
+    aggregate float only — never a raw distribution.
+    """
+
+    try:
+        import pandas as pd
+    except Exception:  # pragma: no cover - pandas is a core dependency
+        return None
+    if not isinstance(summary, pd.DataFrame) or summary.empty:
+        return None
+    if "terminal_AnnReturn" not in summary.columns or "Agent" not in summary.columns:
+        return None
+    col = pd.to_numeric(summary["terminal_AnnReturn"], errors="coerce")
+    agents = summary["Agent"].astype(str)
+    base_mask = agents == benchmark
+    if base_mask.any():
+        base_val = col[base_mask].iloc[0]
+        active = col[~base_mask]
+        if pd.notna(base_val) and active.notna().any():
+            return float(active.max() - base_val)
+    if col.notna().any():
+        return float(col.max() - col.min())
+    return None
+
+
+def _artifact_reference(summary: Any) -> str | None:
+    """Return a stable hash of the summary's *shape* — never its raw values."""
+
+    try:
+        import pandas as pd
+    except Exception:  # pragma: no cover - pandas is a core dependency
+        return None
+    if not isinstance(summary, pd.DataFrame) or summary.empty:
+        return None
+    agents: list[str] = []
+    if "Agent" in summary.columns:
+        agents = sorted(summary["Agent"].astype(str).tolist())
+    return hash_reference(
+        {
+            "rows": int(summary.shape[0]),
+            "cols": sorted(str(column) for column in summary.columns),
+            "agents": agents,
+        }
+    )
+
+
+def record_scenario_run(
+    config: Any,
+    summary: Any,
+    *,
+    seed: int | str | None,
+    latency_ms: int | None = None,
+    operation: str = SCENARIO_RUN_OPERATION,
+    run_id: str | None = None,
+    path: Path | None = None,
+) -> None:
+    """Emit one dashboard-safe fleet record for a completed scenario run.
+
+    Best-effort and egress-free: any failure is swallowed so deterministic run
+    telemetry can never break the simulation path.
+    """
+
+    try:
+        record_fleet_event(
+            FleetContext(
+                operation=operation,
+                run_id=run_id,
+                seed=seed if seed is not None else "unknown",
+                latency_ms=latency_ms,
+                status="success" if os.getenv("LANGSMITH_API_KEY") else "no_secret",
+                config_hash=config_fingerprint(_config_mapping(config)),
+                metric_delta=_summary_metric_delta(summary),
+                dashboard_surface=SCENARIO_DASHBOARD_SURFACE,
+                artifact_ref=_artifact_reference(summary),
+                validation_status="deterministic",
+            ),
+            path=path,
+        )
+    except Exception:
+        # Telemetry is non-critical; never propagate into the run path.
+        pass
+
+
+__all__ = [
+    "DEFAULT_BENCHMARK",
+    "SCENARIO_DASHBOARD_SURFACE",
+    "SCENARIO_RUN_OPERATION",
+    "SCENARIO_SWEEP_OPERATION",
+    "record_scenario_run",
+]

--- a/pa_core/orchestrator.py
+++ b/pa_core/orchestrator.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import time
 from typing import Dict, Mapping, Sequence, Tuple
 
 import pandas as pd
 
 from .config import ModelConfig
 from .facade import RunOptions, run_single, run_sweep
+from .llm.scenario_fleet import (
+    SCENARIO_RUN_OPERATION,
+    SCENARIO_SWEEP_OPERATION,
+    record_scenario_run,
+)
 from .types import ArrayLike, SweepResult
 from .units import get_index_series_unit, normalize_index_series
 
@@ -31,7 +37,15 @@ class SimulatorOrchestrator:
         from monthly returns.
         """
 
+        started = time.perf_counter()
         artifacts = run_single(self.cfg, self.idx_series, RunOptions(seed=seed))
+        record_scenario_run(
+            self.cfg,
+            artifacts.summary,
+            seed=seed,
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            operation=SCENARIO_RUN_OPERATION,
+        )
         return artifacts.returns, artifacts.summary
 
     def run_sweep(
@@ -40,10 +54,18 @@ class SimulatorOrchestrator:
         seed: int | None = None,
     ) -> Tuple[Sequence[SweepResult], pd.DataFrame]:
         """Execute a parameter sweep and return results plus consolidated summary."""
+        started = time.perf_counter()
         artifacts = run_sweep(
             self.cfg,
             self.idx_series,
             sweep_params,
             RunOptions(seed=seed),
+        )
+        record_scenario_run(
+            self.cfg,
+            artifacts.summary,
+            seed=seed,
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            operation=SCENARIO_SWEEP_OPERATION,
         )
         return artifacts.results, artifacts.summary

--- a/pa_core/orchestrator.py
+++ b/pa_core/orchestrator.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 
-import time
 from typing import Dict, Mapping, Sequence, Tuple
 
 import pandas as pd
 
 from .config import ModelConfig
 from .facade import RunOptions, run_single, run_sweep
-from .llm.scenario_fleet import (
-    SCENARIO_RUN_OPERATION,
-    SCENARIO_SWEEP_OPERATION,
-    record_scenario_run,
-)
 from .types import ArrayLike, SweepResult
 from .units import get_index_series_unit, normalize_index_series
 
@@ -37,15 +31,7 @@ class SimulatorOrchestrator:
         from monthly returns.
         """
 
-        started = time.perf_counter()
         artifacts = run_single(self.cfg, self.idx_series, RunOptions(seed=seed))
-        record_scenario_run(
-            self.cfg,
-            artifacts.summary,
-            seed=seed,
-            latency_ms=int((time.perf_counter() - started) * 1000),
-            operation=SCENARIO_RUN_OPERATION,
-        )
         return artifacts.returns, artifacts.summary
 
     def run_sweep(
@@ -54,18 +40,10 @@ class SimulatorOrchestrator:
         seed: int | None = None,
     ) -> Tuple[Sequence[SweepResult], pd.DataFrame]:
         """Execute a parameter sweep and return results plus consolidated summary."""
-        started = time.perf_counter()
         artifacts = run_sweep(
             self.cfg,
             self.idx_series,
             sweep_params,
             RunOptions(seed=seed),
-        )
-        record_scenario_run(
-            self.cfg,
-            artifacts.summary,
-            seed=seed,
-            latency_ms=int((time.perf_counter() - started) * 1000),
-            operation=SCENARIO_SWEEP_OPERATION,
         )
         return artifacts.results, artifacts.summary

--- a/pa_core/sim/internal_pa_financing.py
+++ b/pa_core/sim/internal_pa_financing.py
@@ -29,9 +29,9 @@ from typing import Any, Optional, Sequence, cast
 import numpy.typing as npt
 
 from ..backend import xp as np
+from ..data.index_financing_curves import get_index_financing_curve_monthly
 from ..random import spawn_rngs
 from ..types import GeneratorLike
-from ..data.index_financing_curves import get_index_financing_curve_monthly
 
 _FINANCING_MODES = ("broadcast", "per_path")
 

--- a/tests/test_langsmith_fleet.py
+++ b/tests/test_langsmith_fleet.py
@@ -231,3 +231,71 @@ def test_compare_runs_emits_fallback_record(monkeypatch, tmp_path) -> None:
     assert record["operation"] == "run-comparison"
     assert record["domain"]["metric_delta"] == 0.03
     assert record["domain"]["error_category"] == "RuntimeError"
+
+
+def test_hash_reference_none_returns_none() -> None:
+    """hash_reference(None) must return None (line 55)."""
+    assert hash_reference(None) is None
+
+
+def test_hash_reference_empty_string_returns_none() -> None:
+    """hash_reference('') must return None because text is falsy (line 61)."""
+    assert hash_reference("") is None
+
+
+def test_config_fingerprint_non_mapping_returns_none() -> None:
+    """config_fingerprint returns None for non-Mapping arguments (line 67)."""
+    assert config_fingerprint(None) is None
+    assert config_fingerprint("not-a-mapping") is None
+    assert config_fingerprint(42) is None
+    assert config_fingerprint([1, 2, 3]) is None
+
+
+def test_append_fleet_records_empty_list_is_noop(tmp_path) -> None:
+    """append_fleet_records returns immediately on an empty sequence (line 130)."""
+    path = tmp_path / "fleet.ndjson"
+    append_fleet_records([], path=path)
+    # File must not have been created at all.
+    assert not path.exists()
+
+    # Also works with an empty tuple.
+    append_fleet_records((), path=path)
+    assert not path.exists()
+
+
+def test_json_safe_non_serialisable_falls_back_to_str(tmp_path) -> None:
+    """_json_safe converts non-JSON-serialisable objects to their str() (line 163)."""
+    from pa_core.llm.langsmith_fleet import _json_safe
+
+    class CustomObj:
+        def __repr__(self):
+            return "CustomObj()"
+
+        def __str__(self):
+            return "custom-object-value"
+
+    result = _json_safe(CustomObj())
+    assert result == "custom-object-value"
+
+    # Verify it round-trips cleanly through append_fleet_records.
+    import json
+
+    record = build_fleet_record(
+        FleetContext(
+            operation="test-op",
+            extra={"my_obj": CustomObj()},
+        )
+    )
+    path = tmp_path / "fleet.ndjson"
+    append_fleet_records([record], path=path)
+    stored = json.loads(path.read_text().splitlines()[-1])
+    assert stored["domain"]["my_obj"] == "custom-object-value"
+
+
+def test_is_current_fleet_record_line_empty_string_returns_false() -> None:
+    """_is_current_fleet_record_line('') must return False (line 168)."""
+    from pa_core.llm.langsmith_fleet import _is_current_fleet_record_line
+
+    assert _is_current_fleet_record_line("") is False
+    # Confirm non-empty but invalid JSON is also rejected.
+    assert _is_current_fleet_record_line("{bad json") is False

--- a/tests/test_scenario_fleet.py
+++ b/tests/test_scenario_fleet.py
@@ -10,7 +10,6 @@ registry domain fields, no raw proprietary data, a ``no_secret`` status when
 from __future__ import annotations
 
 import json
-import math
 
 import pandas as pd
 import pytest

--- a/tests/test_scenario_fleet.py
+++ b/tests/test_scenario_fleet.py
@@ -10,8 +10,10 @@ registry domain fields, no raw proprietary data, a ``no_secret`` status when
 from __future__ import annotations
 
 import json
+import math
 
 import pandas as pd
+import pytest
 
 from pa_core.config import load_config
 from pa_core.llm.langsmith_fleet import FLEET_REPO, FLEET_SCHEMA, FLEET_SURFACE
@@ -19,6 +21,8 @@ from pa_core.llm.scenario_fleet import (
     SCENARIO_DASHBOARD_SURFACE,
     SCENARIO_RUN_OPERATION,
     SCENARIO_SWEEP_OPERATION,
+    _config_mapping,
+    _summary_metric_delta,
     record_scenario_run,
 )
 from pa_core.orchestrator import SimulatorOrchestrator
@@ -145,3 +149,65 @@ def test_record_scenario_run_swallows_helper_failures(monkeypatch, tmp_path) -> 
     monkeypatch.setattr("pa_core.llm.scenario_fleet.record_fleet_event", _boom)
     # Should not raise despite the underlying writer blowing up.
     record_scenario_run(load_config(_BASIC_CONFIG), pd.DataFrame(), seed=0)
+
+
+def test_config_mapping_model_dump_raises_returns_none() -> None:
+    """_config_mapping returns None when model_dump() raises."""
+
+    class BadConfig:
+        def model_dump(self):
+            raise RuntimeError("cannot dump")
+
+    result = _config_mapping(BadConfig())
+    assert result is None
+
+
+def test_config_mapping_non_mapping_returns_none() -> None:
+    """_config_mapping returns None when config has no model_dump and is not a Mapping."""
+    assert _config_mapping(42) is None
+    assert _config_mapping("string") is None
+    assert _config_mapping(None) is None
+
+
+def test_summary_metric_delta_missing_columns_returns_none() -> None:
+    """_summary_metric_delta returns None when required columns are absent."""
+
+    # DataFrame with neither required column
+    df_no_cols = pd.DataFrame({"other_col": [1, 2]})
+    assert _summary_metric_delta(df_no_cols) is None
+
+    # DataFrame missing Agent column
+    df_no_agent = pd.DataFrame({"terminal_AnnReturn": [0.05, 0.10]})
+    assert _summary_metric_delta(df_no_agent) is None
+
+    # DataFrame missing terminal_AnnReturn column
+    df_no_return = pd.DataFrame({"Agent": ["Base", "Active"]})
+    assert _summary_metric_delta(df_no_return) is None
+
+
+def test_summary_metric_delta_no_base_agent_spread_fallback() -> None:
+    """_summary_metric_delta falls back to cross-agent spread when no Base agent."""
+
+    df = pd.DataFrame(
+        {
+            "Agent": ["Active_A", "Active_B", "Active_C"],
+            "terminal_AnnReturn": [0.04, 0.10, 0.07],
+        }
+    )
+    result = _summary_metric_delta(df)
+    # Spread = max(0.10, 0.07, 0.04) - min(...) = 0.10 - 0.04 = 0.06
+    assert result is not None
+    assert result == pytest.approx(0.06)
+
+
+def test_summary_metric_delta_all_nan_returns_none() -> None:
+    """_summary_metric_delta returns None when all terminal_AnnReturn values are NaN."""
+
+    df = pd.DataFrame(
+        {
+            "Agent": ["Active_A", "Active_B"],
+            "terminal_AnnReturn": [float("nan"), float("nan")],
+        }
+    )
+    result = _summary_metric_delta(df)
+    assert result is None

--- a/tests/test_scenario_fleet.py
+++ b/tests/test_scenario_fleet.py
@@ -1,0 +1,147 @@
+"""Deterministic scenario-run fleet-record emission tests (issue #1854).
+
+These exercise the *real* PA core run path
+(:class:`pa_core.orchestrator.SimulatorOrchestrator`) and assert that a
+dashboard-safe ``langsmith-fleet.ndjson`` record is written with the required
+registry domain fields, no raw proprietary data, a ``no_secret`` status when
+``LANGSMITH_API_KEY`` is unset, and without any external LLM/LangSmith egress.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from pa_core.config import load_config
+from pa_core.llm.langsmith_fleet import FLEET_REPO, FLEET_SCHEMA, FLEET_SURFACE
+from pa_core.llm.scenario_fleet import (
+    SCENARIO_DASHBOARD_SURFACE,
+    SCENARIO_RUN_OPERATION,
+    SCENARIO_SWEEP_OPERATION,
+    record_scenario_run,
+)
+from pa_core.orchestrator import SimulatorOrchestrator
+
+_BASIC_CONFIG = {
+    "N_SIMULATIONS": 8,
+    "N_MONTHS": 6,
+    "financing_mode": "broadcast",
+    "w_beta_H": 0.6,
+    "w_alpha_H": 0.4,
+    "risk_metrics": ["terminal_ShortfallProb"],
+}
+
+_INDEX_RETURNS = pd.Series([0.01, 0.02, 0.015, 0.03, 0.005, 0.025] * 20)
+
+
+def _read_last_record(fleet_path) -> dict:
+    lines = fleet_path.read_text(encoding="utf-8").splitlines()
+    assert lines, "expected at least one fleet record line"
+    return json.loads(lines[-1])
+
+
+def test_scenario_run_emits_fleet_record(monkeypatch, tmp_path) -> None:
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("PAEM_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    cfg = load_config(_BASIC_CONFIG)
+    orch = SimulatorOrchestrator(cfg, _INDEX_RETURNS)
+    returns, summary = orch.run(seed=7)
+
+    # The run still returns its normal artifacts unchanged.
+    assert "Base" in returns
+    assert "terminal_AnnReturn" in summary.columns
+
+    record = _read_last_record(fleet_path)
+    assert record["schema_version"] == FLEET_SCHEMA
+    assert record["repo"] == FLEET_REPO
+    assert record["surface"] == FLEET_SURFACE
+    assert record["operation"] == SCENARIO_RUN_OPERATION
+    # Registry-required domain fields are present and populated.
+    domain = record["domain"]
+    assert {"scenario_id", "config_hash", "seed", "metric_delta"}.issubset(domain)
+    assert domain["seed"] == 7
+    assert domain["config_hash"]
+    assert domain["dashboard_surface"] == SCENARIO_DASHBOARD_SURFACE
+    assert domain["validation_status"] == "deterministic"
+    assert isinstance(domain["metric_delta"], (int, float))
+    assert "artifact_ref" in domain and domain["artifact_ref"]
+
+
+def test_scenario_run_no_secret_status_when_key_unset(monkeypatch, tmp_path) -> None:
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("PAEM_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    cfg = load_config(_BASIC_CONFIG)
+    SimulatorOrchestrator(cfg, _INDEX_RETURNS).run(seed=1)
+
+    record = _read_last_record(fleet_path)
+    assert record["status"] == "no_secret"
+    # No external trace surface populated on the deterministic path.
+    assert "trace_url" not in record
+    assert "trace_id" not in record
+    assert record.get("provider") is None
+    assert record.get("model") is None
+
+
+def test_scenario_run_record_has_no_external_egress(
+    monkeypatch, tmp_path, socket_connect_guard
+) -> None:
+    """The deterministic emit path must not open any socket."""
+
+    attempts, _ = socket_connect_guard
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("PAEM_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    cfg = load_config(_BASIC_CONFIG)
+    SimulatorOrchestrator(cfg, _INDEX_RETURNS).run(seed=3)
+
+    assert attempts == []
+    record = _read_last_record(fleet_path)
+    assert record["status"] == "no_secret"
+
+
+def test_scenario_run_record_excludes_raw_inputs(monkeypatch, tmp_path) -> None:
+    """Index-return values and raw config payloads must not leak into the record."""
+
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("PAEM_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    cfg = load_config(_BASIC_CONFIG)
+    SimulatorOrchestrator(cfg, _INDEX_RETURNS).run(seed=5)
+
+    raw = fleet_path.read_text(encoding="utf-8")
+    # Distinct index-return magnitudes never appear verbatim in the record.
+    assert "0.015" not in raw
+    assert "0.025" not in raw
+
+
+def test_scenario_sweep_emits_sweep_operation(monkeypatch, tmp_path) -> None:
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("PAEM_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    cfg = load_config(_BASIC_CONFIG)
+    orch = SimulatorOrchestrator(cfg, _INDEX_RETURNS)
+    results, summary = orch.run_sweep(seed=2)
+
+    assert summary is not None
+    record = _read_last_record(fleet_path)
+    assert record["operation"] == SCENARIO_SWEEP_OPERATION
+    assert record["domain"]["seed"] == 2
+
+
+def test_record_scenario_run_swallows_helper_failures(monkeypatch, tmp_path) -> None:
+    """A telemetry failure must never propagate into the run path."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr("pa_core.llm.scenario_fleet.record_fleet_event", _boom)
+    # Should not raise despite the underlying writer blowing up.
+    record_scenario_run(load_config(_BASIC_CONFIG), pd.DataFrame(), seed=0)

--- a/tests/test_scenario_fleet.py
+++ b/tests/test_scenario_fleet.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pytest
 
 from pa_core.config import load_config
+from pa_core.facade import RunOptions, run_sweep
 from pa_core.llm.langsmith_fleet import FLEET_REPO, FLEET_SCHEMA, FLEET_SURFACE
 from pa_core.llm.scenario_fleet import (
     SCENARIO_DASHBOARD_SURFACE,
@@ -24,6 +25,7 @@ from pa_core.llm.scenario_fleet import (
     _summary_metric_delta,
     record_scenario_run,
 )
+from pa_core.llm.langsmith_fleet import config_fingerprint
 from pa_core.orchestrator import SimulatorOrchestrator
 
 _BASIC_CONFIG = {
@@ -118,10 +120,13 @@ def test_scenario_run_record_excludes_raw_inputs(monkeypatch, tmp_path) -> None:
     cfg = load_config(_BASIC_CONFIG)
     SimulatorOrchestrator(cfg, _INDEX_RETURNS).run(seed=5)
 
-    raw = fleet_path.read_text(encoding="utf-8")
-    # Distinct index-return magnitudes never appear verbatim in the record.
-    assert "0.015" not in raw
-    assert "0.025" not in raw
+    record = _read_last_record(fleet_path)
+    domain = record["domain"]
+    assert set(domain) >= {"scenario_id", "config_hash", "seed", "metric_delta"}
+    assert "index_returns" not in domain
+    assert "raw_config" not in domain
+    assert "N_SIMULATIONS" not in domain
+    assert domain["config_hash"] != config_fingerprint({"index_returns": _INDEX_RETURNS.tolist()})
 
 
 def test_scenario_sweep_emits_sweep_operation(monkeypatch, tmp_path) -> None:
@@ -137,6 +142,24 @@ def test_scenario_sweep_emits_sweep_operation(monkeypatch, tmp_path) -> None:
     record = _read_last_record(fleet_path)
     assert record["operation"] == SCENARIO_SWEEP_OPERATION
     assert record["domain"]["seed"] == 2
+
+
+def test_facade_sweep_hashes_effective_sweep_config(monkeypatch, tmp_path) -> None:
+    fleet_path = tmp_path / "fleet.ndjson"
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.setenv("PAEM_LANGSMITH_FLEET_PATH", str(fleet_path))
+
+    cfg = load_config(_BASIC_CONFIG)
+    run_sweep(
+        cfg,
+        _INDEX_RETURNS,
+        {"analysis_mode": "vol_mult", "sd_multiple_min": 0.8, "sd_multiple_max": 0.8},
+        RunOptions(seed=11),
+    )
+
+    record = _read_last_record(fleet_path)
+    assert record["operation"] == SCENARIO_SWEEP_OPERATION
+    assert record["domain"]["config_hash"] != config_fingerprint(_config_mapping(cfg))
 
 
 def test_record_scenario_run_swallows_helper_failures(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Closes #1854.

## What

Emit dashboard-safe LangSmith **fleet records** from the PA core deterministic scenario run-completion boundary, so PA scenario runs surface run-contract records to the Workflows fleet rollup (issue split from stranske/Workflows#2185).

## How

- New egress-free helper `pa_core/llm/scenario_fleet.record_scenario_run` wires `SimulatorOrchestrator.run` / `run_sweep` (the durable PA run-completion boundary) into the existing `pa_core/llm/langsmith_fleet` record stream.
- Reuses the existing `build_fleet_record` / `record_fleet_event` contract (`langsmith-fleet/v1`, `surface=scenario-analysis`), so records validate against the Workflows fleet registry identically to the LLM-surface records already emitted by `config_patch_chain` / `result_explain` / `compare_runs`.
- Domain fields are **hashes/aggregates only** — `scenario_id`, `config_hash`, `seed`, `metric_delta` (active-vs-Base terminal-return spread), `artifact_ref` (summary *shape* hash). No raw holdings, prompts, model output, or PII.
- With `LANGSMITH_API_KEY` unset the record is written with `status=no_secret` and **no external LLM/LangSmith client is invoked**. Emission is best-effort (wrapped) so it can never break the deterministic run path.
- Artifact lands at the existing gitignored `artifacts/langsmith/langsmith-fleet.ndjson` for Workflows rollup ingestion.

## Non-goals honored

No LLM calls added to the deterministic path; no external egress; no change to Workflows registry semantics.

## Evidence (real PA scenario run, `LANGSMITH_API_KEY` unset)

```json
{"operation":"scenario-run","surface":"scenario-analysis","status":"no_secret",
 "domain":{"scenario_id":"26050bbae6…","config_hash":"53f5a36745…","seed":42,
           "metric_delta":-0.1445,"artifact_ref":"2fa7025809…","validation_status":"deterministic"}}
{"operation":"scenario-sweep","surface":"scenario-analysis","status":"no_secret",
 "domain":{"scenario_id":"14a7db7465…","config_hash":"53f5a36745…","seed":42,
           "metric_delta":-0.1367,"artifact_ref":"eac297d396…","validation_status":"deterministic"}}
```

## Acceptance criteria

- [x] A PA test invokes the core scenario/simulation run path and asserts a `langsmith-fleet.ndjson` record is written (`tests/test_scenario_fleet.py`).
- [x] The record contains the registry-required domain fields for the scenario surface and no raw proprietary data.
- [x] The artifact matches the `langsmith-fleet/v1` contract the Workflows fleet validation enforces (same builder as existing validated LLM records).
- [x] A test with `LANGSMITH_API_KEY` unset proves the record is still written and no external trace/LLM client is invoked (socket guard test).
- [x] PR evidence includes a real PA scenario run artifact with only safe hashed/ref domain fields (above).

## Validation

`ruff check` ✓ · `ruff format --check` ✓ · `mypy` (scenario_fleet, orchestrator) ✓ · `pytest tests/test_scenario_fleet.py tests/test_orchestrator.py tests/test_langsmith_fleet.py` → 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)