### PR TITLE
baseline-kit: track Workflows @main (un-freeze SHA) via no-emit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,15 @@ include = ["pa_core*", "archive*", "scripts*", "dashboard*"]
 requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
+# Do not emit app-baseline-kit into requirements.lock. It is consumed from the
+# Workflows monorepo via an unpinned `@main` git URL (see the dev optional
+# dependencies), so freezing a commit SHA in the lock conflicts with that URL
+# the moment Workflows main advances ("conflicting URLs for package
+# app-baseline-kit" -> uv install aborts). Leaving it unpinned lets the editable
+# project install resolve it from main, with no lock to keep refreshed.
+[tool.uv.pip]
+no-emit-package = ["app-baseline-kit"]
+
 [project]
 name = "portable-alpha-extension-model"
 version = "0.1.0"
@@ -129,10 +138,13 @@ dev = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-xdist>=3.8.0",
-    # Shared app behavior baseline harness (pulls pytest-regressions). Pinned
-    # to the Workflows merge commit that introduced the package; move to a
-    # tagged ref once the package is versioned.
-    "app-baseline-kit @ git+https://github.com/stranske/Workflows.git@4581ee9c91240b6d3ef628f0f8ff982f6bcaba36#subdirectory=packages/app-baseline-kit",
+    # Shared app behavior baseline harness (pulls pytest-regressions). Tracked
+    # as an unpinned `@main` git direct reference so it picks up upstream
+    # baseline_kit improvements (e.g. the py.typed marker) instead of staying
+    # frozen at one commit. Excluded from requirements.lock via [tool.uv.pip]
+    # no-emit-package below so a frozen SHA in the lock cannot conflict with the
+    # unpinned URL.
+    "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
     "coverage>=7.14.0",
     "hypothesis>=6.115.1",
     "pre-commit",

--- a/requirements.lock
+++ b/requirements.lock
@@ -20,8 +20,6 @@ anyio==4.13.0
     #   httpx
     #   jupyter-server
     #   openai
-app-baseline-kit @ git+https://github.com/stranske/Workflows.git@4581ee9c91240b6d3ef628f0f8ff982f6bcaba36#subdirectory=packages/app-baseline-kit
-    # via portable-alpha-extension-model (pyproject.toml)
 appnope==0.1.4 ; sys_platform == 'darwin'
     # via ipykernel
 argon2-cffi==25.1.0
@@ -45,6 +43,8 @@ babel==2.18.0
     # via
     #   jupyterlab-server
     #   sphinx
+backports-tarfile==1.2.0 ; python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'
+    # via jaraco-context
 bandit==1.9.4
     # via portable-alpha-extension-model (pyproject.toml)
 beautifulsoup4==4.14.3
@@ -100,8 +100,6 @@ coverage==7.14.0
     #   pytest-cov
 cryptography==46.0.7 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via secretstorage
-dataclasses-json==0.6.7
-    # via langchain-community
 debugpy==1.8.20
     # via ipykernel
 decorator==5.2.1
@@ -178,6 +176,8 @@ idna==3.11
     #   yarl
 imagesize==2.0.0
     # via sphinx
+importlib-metadata==9.0.0 ; python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'
+    # via keyring
 iniconfig==2.3.0
     # via pytest
 ipykernel==7.2.0
@@ -185,7 +185,12 @@ ipykernel==7.2.0
     #   jupyter
     #   jupyter-console
     #   jupyterlab
-ipython==9.12.0
+ipython==9.12.0 ; python_full_version >= '3.12'
+    # via
+    #   ipykernel
+    #   ipywidgets
+    #   jupyter-console
+ipython==9.14.0 ; python_full_version < '3.12'
     # via
     #   ipykernel
     #   ipywidgets
@@ -308,13 +313,13 @@ kaleido==1.2.0
     # via portable-alpha-extension-model (pyproject.toml)
 keyring==25.7.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x'
     # via twine
-langchain==1.2.18
+langchain==1.3.1
     # via portable-alpha-extension-model (pyproject.toml)
 langchain-anthropic==1.4.3
     # via portable-alpha-extension-model (pyproject.toml)
-langchain-classic==1.0.3
+langchain-classic==1.0.7
     # via langchain-community
-langchain-community==0.4.1
+langchain-community==0.4.2
     # via portable-alpha-extension-model (pyproject.toml)
 langchain-core==1.4.0
     # via
@@ -328,23 +333,23 @@ langchain-core==1.4.0
     #   langgraph
     #   langgraph-checkpoint
     #   langgraph-prebuilt
-langchain-openai==1.2.1
+langchain-openai==1.2.2
     # via portable-alpha-extension-model (pyproject.toml)
 langchain-protocol==0.0.15
     # via langchain-core
-langchain-text-splitters==1.1.1
+langchain-text-splitters==1.1.2
     # via langchain-classic
-langgraph==1.1.10
+langgraph==1.2.2
     # via langchain
-langgraph-checkpoint==4.0.1
+langgraph-checkpoint==4.1.1
     # via
     #   langgraph
     #   langgraph-prebuilt
-langgraph-prebuilt==1.0.13
+langgraph-prebuilt==1.1.0
     # via langgraph
 langgraph-sdk==0.3.12
     # via langgraph
-langsmith==0.8.3
+langsmith==0.8.5
     # via
     #   portable-alpha-extension-model (pyproject.toml)
     #   langchain-classic
@@ -368,8 +373,6 @@ markupsafe==3.0.3
     # via
     #   jinja2
     #   nbconvert
-marshmallow==3.26.2
-    # via dataclasses-json
 matplotlib-inline==0.2.1
     # via
     #   ipykernel
@@ -394,7 +397,6 @@ mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
-    #   typing-inspect
 narwhals==2.14.0
     # via
     #   altair
@@ -449,6 +451,8 @@ orjson==3.11.5
     #   langsmith
 ormsgpack==1.12.2
     # via langgraph-checkpoint
+overrides==7.7.0 ; python_full_version < '3.12'
+    # via jupyter-server
 packaging==25.0
     # via
     #   altair
@@ -462,7 +466,6 @@ packaging==25.0
     #   kaleido
     #   langchain-core
     #   langsmith
-    #   marshmallow
     #   nbconvert
     #   plotly
     #   pytest
@@ -514,7 +517,9 @@ propcache==0.4.1
 protobuf==6.33.2
     # via streamlit
 psutil==7.2.2
-    # via ipykernel
+    # via
+    #   ipykernel
+    #   ipython
 ptyprocess==0.7.0 ; os_name != 'nt' or (sys_platform != 'emscripten' and sys_platform != 'win32')
     # via
     #   pexpect
@@ -564,11 +569,18 @@ pyproject-hooks==1.2.0
 pytest==9.0.3
     # via
     #   portable-alpha-extension-model (pyproject.toml)
+    #   app-baseline-kit
     #   pytest-cov
+    #   pytest-datadir
+    #   pytest-regressions
     #   pytest-timeout
     #   pytest-xdist
 pytest-cov==7.1.0
     # via portable-alpha-extension-model (pyproject.toml)
+pytest-datadir==1.8.0
+    # via pytest-regressions
+pytest-regressions==2.11.0
+    # via app-baseline-kit
 pytest-timeout==2.4.0
     # via kaleido
 pytest-xdist==3.8.0
@@ -600,6 +612,7 @@ pywinpty==3.0.3 ; os_name == 'nt'
 pyyaml==6.0.3
     # via
     #   portable-alpha-extension-model (pyproject.toml)
+    #   app-baseline-kit
     #   bandit
     #   jupyter-events
     #   jupyter-nbextensions-configurator
@@ -607,6 +620,7 @@ pyyaml==6.0.3
     #   langchain-community
     #   langchain-core
     #   pre-commit
+    #   pytest-regressions
 pyzmq==27.1.0
     # via
     #   ipykernel
@@ -622,7 +636,7 @@ referencing==0.37.0
     #   jupyter-events
 regex==2026.2.28
     # via tiktoken
-requests==2.34.0
+requests==2.34.2
     # via
     #   portable-alpha-extension-model (pyproject.toml)
     #   jupyterlab-server
@@ -689,7 +703,13 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.8.3
     # via beautifulsoup4
-sphinx==9.1.0
+sphinx==9.0.4 ; python_full_version < '3.12'
+    # via
+    #   portable-alpha-extension-model (pyproject.toml)
+    #   nbsphinx
+    #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
+sphinx==9.1.0 ; python_full_version >= '3.12'
     # via
     #   portable-alpha-extension-model (pyproject.toml)
     #   nbsphinx
@@ -736,6 +756,10 @@ tinycss2==1.4.0
     # via bleach
 toml==0.10.2
     # via streamlit
+tomli==2.4.1 ; python_full_version < '3.12'
+    # via
+    #   portable-alpha-extension-model (pyproject.toml)
+    #   coverage
 tornado==6.5.4
     # via
     #   ipykernel
@@ -780,6 +804,7 @@ typing-extensions==4.15.0
     #   anthropic
     #   anyio
     #   beautifulsoup4
+    #   ipython
     #   langchain-core
     #   langchain-protocol
     #   mypy
@@ -790,10 +815,7 @@ typing-extensions==4.15.0
     #   referencing
     #   sqlalchemy
     #   streamlit
-    #   typing-inspect
     #   typing-inspection
-typing-inspect==0.9.0
-    # via dataclasses-json
 typing-inspection==0.4.2
     # via
     #   pydantic
@@ -802,8 +824,6 @@ tzdata==2025.3
     # via
     #   arrow
     #   pandas
-untokenize==0.1.1
-    # via docformatter
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.6.2
@@ -841,5 +861,10 @@ xxhash==3.6.0
     #   langsmith
 yarl==1.23.0
     # via aiohttp
+zipp==4.1.0 ; python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'
+    # via importlib-metadata
 zstandard==0.25.0
     # via langsmith
+
+# The following packages were excluded from the output:
+# app-baseline-kit

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -107,6 +107,19 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
                 continue
             declared.add(pkg_name)
 
+    # Packages intentionally excluded from the lock via uv's no-emit-package
+    # (monorepo deps consumed from an unpinned @main git URL, e.g.
+    # app-baseline-kit) are not pinned in requirements.lock, so don't expect
+    # them there.
+    no_emit = {
+        str(name).strip().lower().replace("_", "-")
+        for name in pyproject.get("tool", {})
+        .get("uv", {})
+        .get("pip", {})
+        .get("no-emit-package", [])
+    }
+    declared -= no_emit
+
     lock_versions = _load_lock_versions(Path("requirements.lock"))
 
     missing = []


### PR DESCRIPTION
## Summary
Migrates `app-baseline-kit` from a **frozen SHA** (`4581ee9c...`, Pattern C) to the canonical **Pattern A** (unpinned `@main` + `no-emit-package`) used by trip-planner and Counter_Risk, so it tracks Workflows `main` and picks up upstream `baseline_kit` improvements (e.g. the `py.typed` marker from Workflows #2204) instead of staying frozen.

## Changes
- **`pyproject.toml`**
  - Drop the `@4581ee9c...` fragment from the `app-baseline-kit` dev dependency → now `git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit`.
  - Add `[tool.uv.pip] no-emit-package = ["app-baseline-kit"]` so `uv pip compile` excludes it from `requirements.lock` (no SHA in the lock → no "conflicting URLs for package app-baseline-kit" error when Workflows `main` advances).
- **`requirements.lock`** — regenerated with the documented `uv pip compile` command. `app-baseline-kit` now appears under "packages excluded from the output"; its transitive deps (`pytest-regressions`, `pytest-datadir`, etc.) remain locked.
- **`tests/test_dependency_version_alignment.py`** — subtract `[tool.uv.pip].no-emit-package` names from the declared set (mirrors Counter_Risk) so the now-absent-from-lock `app-baseline-kit` does not trip the alignment test.

## Verification (cold resolve, dedicated venv, no cache reliance)
- `uv venv .venv-x && uv pip install --python .venv-x -e ".[dev]"` — **succeeds, no "conflicting URLs" error**.
- Installed `app-baseline-kit` `direct_url.json` resolves to Workflows `main` HEAD `2ca51033...` (NOT the old frozen `4581ee9c...`), confirming it now tracks `@main`. The `baseline_kit/py.typed` marker is present.
- `pytest tests/test_dependency_version_alignment.py -q` → **1 passed**.
- `PYTHONHASHSEED=0 pytest tests/baseline -q` → **7 passed, 2 skipped**.
- `ruff check` / `ruff format --check` on the changed test → clean.

Draft — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)