### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -4,8 +4,8 @@
 # NOTE: Only include dev tools here (linters, formatters, test runners).
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
-BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.13
+BLACK_VERSION=26.5.1
+RUFF_VERSION=0.15.14
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ llm = [
 
 # Development dependencies
 dev = [
-    "ruff>=0.15.13",
-    "black>=26.3.1",
+    "ruff>=0.15.14",
+    "black>=26.5.1",
     "isort>=8.0.1",
     "mypy>=2.1.0",
     "pytest==9.0.3",

--- a/requirements.lock
+++ b/requirements.lock
@@ -49,7 +49,7 @@ bandit==1.9.4
     # via portable-alpha-extension-model (pyproject.toml)
 beautifulsoup4==4.14.3
     # via nbconvert
-black==26.3.1
+black==26.5.1
     # via portable-alpha-extension-model (pyproject.toml)
 bleach==6.3.0
     # via nbconvert
@@ -675,7 +675,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.13
+ruff==0.15.14
     # via portable-alpha-extension-model (pyproject.toml)
 secretstorage==3.5.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via keyring


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 4 version updates:
  - ruff: >=0.15.13 -> >=0.15.14
  - black: >=26.3.1 -> >=26.5.1
  - requirements.lock:black: 26.3.1 -> ==26.5.1
  - requirements.lock:ruff: 0.15.13 -> ==0.15.14

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`