### PR TITLE
Fix Scenario Wizard first-load simulation default

### DIFF
--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -792,7 +792,7 @@ def _render_step_1_analysis_mode(config: Any) -> Any:
             "Number of Simulations",
             min_value=100,
             max_value=10000,
-            value=config.n_simulations,
+            value=max(int(config.n_simulations), 100),
             step=100,
             help="More simulations provide more accurate results but take longer",
         )

--- a/tests/test_wizard_config_wiring.py
+++ b/tests/test_wizard_config_wiring.py
@@ -25,12 +25,17 @@ class _Column:
 def test_step_1_render_clamps_default_simulations_to_widget_min(monkeypatch) -> None:
     module = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
     config = get_default_config(AnalysisMode.RETURNS)
-    assert config.n_simulations < 100
+    config.n_simulations = 1
 
     monkeypatch.setattr(module["st"], "subheader", lambda *args, **kwargs: None)
     monkeypatch.setattr(module["st"], "markdown", lambda *args, **kwargs: None)
     monkeypatch.setattr(module["st"], "info", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module["st"], "columns", lambda count: [_Column() for _ in range(count)])
+
+    def columns(spec: int | list[Any], *args: Any, **kwargs: Any) -> list[_Column]:
+        count = spec if isinstance(spec, int) else len(spec)
+        return [_Column() for _ in range(count)]
+
+    monkeypatch.setattr(module["st"], "columns", columns)
     monkeypatch.setattr(
         module["st"],
         "selectbox",

--- a/tests/test_wizard_config_wiring.py
+++ b/tests/test_wizard_config_wiring.py
@@ -1,5 +1,6 @@
 import runpy
 from pathlib import Path
+from typing import Any
 
 import streamlit as st
 
@@ -11,6 +12,44 @@ from pa_core.wizard_schema import AnalysisMode, RiskMetric, get_default_config
 def _load_build_yaml() -> tuple[callable, dict]:
     module = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
     return module["_build_yaml_from_config"], module
+
+
+class _Column:
+    def __enter__(self) -> "_Column":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+
+def test_step_1_render_clamps_default_simulations_to_widget_min(monkeypatch) -> None:
+    module = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
+    config = get_default_config(AnalysisMode.RETURNS)
+    assert config.n_simulations < 100
+
+    monkeypatch.setattr(module["st"], "subheader", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module["st"], "markdown", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module["st"], "info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module["st"], "columns", lambda count: [_Column() for _ in range(count)])
+    monkeypatch.setattr(
+        module["st"],
+        "selectbox",
+        lambda _label, options, index=0, **_kwargs: options[index],
+    )
+
+    def number_input(label: str, *args: Any, **kwargs: Any) -> Any:
+        min_value = kwargs.get("min_value")
+        value = kwargs.get("value")
+        if label == "Number of Simulations":
+            assert min_value == 100
+            assert value >= min_value
+        return value
+
+    monkeypatch.setattr(module["st"], "number_input", number_input)
+
+    rendered = module["_render_step_1_analysis_mode"](config)
+
+    assert rendered.n_simulations == 100
 
 
 def test_build_yaml_maps_all_fields() -> None:


### PR DESCRIPTION
Closes #1899

## Summary
- Clamp the Scenario Wizard Step 1 simulation widget initial value to the Streamlit minimum when the default config carries the test placeholder value.
- Add a focused Step 1 render smoke regression that fails if the widget receives a value below its min_value.

## Validation
- python -m pytest tests/test_wizard_config_wiring.py tests/test_wizard_config_chat_acceptance.py tests/test_llm_config_patch.py -q
- python -m ruff check dashboard/pages/3_Scenario_Wizard.py tests/test_wizard_config_wiring.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only default clamping on one wizard field plus a focused regression test; no auth, data, or simulation core logic changes.
> 
> **Overview**
> Fixes **Scenario Wizard Step 1** first-load behavior when `config.n_simulations` is below the Streamlit **Number of Simulations** widget floor (`min_value=100`), e.g. a test placeholder of `1`.
> 
> The Step 1 `st.number_input` now passes **`value=max(int(config.n_simulations), 100)`** instead of the raw config value, so the initial widget value always respects `min_value` and the returned config is clamped to **100** on that render.
> 
> Adds **`test_step_1_render_clamps_default_simulations_to_widget_min`**, which monkeypatches Streamlit, renders `_render_step_1_analysis_mode` with `n_simulations=1`, and asserts the simulations input uses `min_value=100`, `value >= 100`, and `rendered.n_simulations == 100`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e56f449ed99d3cd9f99b06ac3f0c8edc6eeaa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->