### PR TITLE
fix(financing): default to per_path and surface broadcast risk notice (#1909)

### DIFF
--- a/config/params_agents_generic.yml
+++ b/config/params_agents_generic.yml
@@ -5,7 +5,7 @@ N_SIMULATIONS: 1000
 N_MONTHS: 12
 
 total_fund_capital: 300.0
-financing_mode: broadcast # broadcast|per_path (broadcast shares one path across sims)
+financing_mode: per_path # per_path|broadcast (per_path draws independent paths per sim; recommended for risk/tail analysis)
 
 agents:
   - name: Base

--- a/config/params_template.yml
+++ b/config/params_template.yml
@@ -105,7 +105,7 @@ act_ext_financing_mean_month: 0.0 # active extension financing mean per month
 act_ext_financing_sigma_month: 0.0 # active extension financing volatility per month
 act_ext_spike_prob: 0.0 # active extension financing spike probability
 act_ext_spike_factor: 0.0 # active extension financing spike size multiplier
-financing_mode: broadcast # broadcast|per_path (broadcast shares one path across sims)
+financing_mode: per_path # per_path|broadcast (per_path draws independent paths per sim; recommended for risk/tail analysis)
 
 risk_metrics:
   - Return

--- a/docs/guides/PARAMETER_DICTIONARY.md
+++ b/docs/guides/PARAMETER_DICTIONARY.md
@@ -73,7 +73,7 @@ This reference lists canonical field names, accepted aliases, and defaults for s
 | `act_ext_financing_sigma_month` | `Active Ext financing vol (monthly %)` | `<class 'float'>` | no | `0.0` |  |
 | `act_ext_spike_prob` | `Active Ext monthly spike prob` | `<class 'float'>` | no | `0.0` |  |
 | `act_ext_spike_factor` | `Active Ext spike multiplier` | `<class 'float'>` | no | `0.0` |  |
-| `financing_mode` | `financing_mode` | `Literal['broadcast', 'per_path']` | yes |  | Financing draw mode. broadcast reuses one financing vector across all simulations; per_path draws independent financing paths per scenario. |
+| `financing_mode` | `financing_mode` | `Literal['per_path', 'broadcast']` | yes |  | Financing draw mode. per_path draws independent financing paths per scenario and is recommended for risk/tail analysis; broadcast reuses one financing vector across all simulations, which suppresses financing-cost dispersion and understates tail/CVaR risk. |
 | `analysis_mode` | `Analysis mode` | `<class 'str'>` | no | `returns` |  |
 | `sweep` | `sweep` | `Optional[pa_core.config.SweepConfig]` | no | `None` | Optional sweep configuration for custom parameter sampling. |
 | `max_external_combined_pct` | `max_external_combined_pct` | `<class 'float'>` | no | `30.0` |  |

--- a/pa_core/__main__.py
+++ b/pa_core/__main__.py
@@ -29,8 +29,9 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         "--config",
         required=True,
         help=(
-            "YAML config file (set financing_mode to broadcast for shared paths or "
-            "per_path for independent draws)"
+            "YAML config file (set financing_mode to per_path for independent "
+            "financing draws per scenario, recommended for risk/tail analysis; "
+            "broadcast shares one financing path across all sims)"
         ),
     )
     parser.add_argument("--index", required=True, help="Index returns CSV")

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1012,18 +1012,6 @@ def main(
     # Echo backend selection at start (asserted in tests/expected_cli_outputs.py::MAIN_BACKEND_STDOUT).
     print(f"[BACKEND] Using backend: {backend_choice}")
 
-    # Surface the broadcast financing-risk notice where the user can see it: a
-    # shared financing path across many sims silently understates tail/CVaR risk.
-    from .sim.financing import _FINANCING_SIGMA_KEYS, broadcast_dispersion_warning
-
-    financing_warning = broadcast_dispersion_warning(
-        getattr(cfg, "financing_mode", "broadcast"),
-        getattr(cfg, "N_SIMULATIONS", 1),
-        (getattr(cfg, key, 0.0) for key in _FINANCING_SIGMA_KEYS),
-    )
-    if financing_warning is not None:
-        print(f"⚠️  {financing_warning}")
-
     from .data import load_index_returns
     from .facade import run_single
     from .logging_utils import setup_json_logging
@@ -1036,6 +1024,7 @@ def main(
     )
     from .reporting.sweep_excel import export_sweep_results
     from .run_flags import RunFlags
+    from .sim.financing import _FINANCING_SIGMA_KEYS, broadcast_dispersion_warning
     from .sim.simulation_initialization import initialize_sweep_rngs
     from .sleeve_suggestor import suggest_sleeve_sizes
     from .stress import apply_stress_preset
@@ -1085,6 +1074,16 @@ def main(
     if args.stress_preset:
         base_cfg = cfg
         cfg = apply_stress_preset(cfg, args.stress_preset)
+
+    # Surface the broadcast financing-risk notice where the user can see it,
+    # after stress presets so the warning reflects the effective run config.
+    financing_warning = broadcast_dispersion_warning(
+        getattr(cfg, "financing_mode", "broadcast"),
+        getattr(cfg, "N_SIMULATIONS", 1),
+        (getattr(cfg, key, 0.0) for key in _FINANCING_SIGMA_KEYS),
+    )
+    if financing_warning is not None:
+        print(f"⚠️  {financing_warning}")
 
     idx_series = load_index_returns(args.index)
 

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1017,8 +1017,8 @@ def main(
     from .sim.financing import _FINANCING_SIGMA_KEYS, broadcast_dispersion_warning
 
     financing_warning = broadcast_dispersion_warning(
-        cfg.financing_mode,
-        cfg.N_SIMULATIONS,
+        getattr(cfg, "financing_mode", "broadcast"),
+        getattr(cfg, "N_SIMULATIONS", 1),
         (getattr(cfg, key, 0.0) for key in _FINANCING_SIGMA_KEYS),
     )
     if financing_warning is not None:

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -429,8 +429,9 @@ def main(
         "--config",
         required=True,
         help=(
-            "YAML config file (set financing_mode to broadcast for shared paths or "
-            "per_path for independent draws)"
+            "YAML config file (set financing_mode to per_path for independent "
+            "financing draws per scenario, recommended for risk/tail analysis; "
+            "broadcast shares one financing path across all sims)"
         ),
     )
     parser.add_argument("--index", required=False, help="Index returns CSV")
@@ -1010,6 +1011,18 @@ def main(
 
     # Echo backend selection at start (asserted in tests/expected_cli_outputs.py::MAIN_BACKEND_STDOUT).
     print(f"[BACKEND] Using backend: {backend_choice}")
+
+    # Surface the broadcast financing-risk notice where the user can see it: a
+    # shared financing path across many sims silently understates tail/CVaR risk.
+    from .sim.financing import _FINANCING_SIGMA_KEYS, broadcast_dispersion_warning
+
+    financing_warning = broadcast_dispersion_warning(
+        cfg.financing_mode,
+        cfg.N_SIMULATIONS,
+        (getattr(cfg, key, 0.0) for key in _FINANCING_SIGMA_KEYS),
+    )
+    if financing_warning is not None:
+        print(f"⚠️  {financing_warning}")
 
     from .data import load_index_returns
     from .facade import run_single

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -347,11 +347,13 @@ class ModelConfig(BaseModel):
     )
     act_ext_spike_prob: float = Field(default=0.0, alias="Active Ext monthly spike prob")
     act_ext_spike_factor: float = Field(default=0.0, alias="Active Ext spike multiplier")
-    financing_mode: Literal["broadcast", "per_path"] = Field(
+    financing_mode: Literal["per_path", "broadcast"] = Field(
         ...,
         description=(
-            "Financing draw mode. broadcast reuses one financing vector across "
-            "all simulations; per_path draws independent financing paths per scenario."
+            "Financing draw mode. per_path draws independent financing paths per "
+            "scenario and is recommended for risk/tail analysis; broadcast reuses "
+            "one financing vector across all simulations, which suppresses "
+            "financing-cost dispersion and understates tail/CVaR risk."
         ),
     )
 

--- a/pa_core/sim/__init__.py
+++ b/pa_core/sim/__init__.py
@@ -1,7 +1,11 @@
 """Vectorised Monte-Carlo helpers."""
 
 from .covariance import build_cov_matrix
-from .financing import draw_financing_series, simulate_financing
+from .financing import (
+    broadcast_dispersion_warning,
+    draw_financing_series,
+    simulate_financing,
+)
 from .internal_pa_financing import resolve_internal_pa_financing_series
 from .paths import (
     draw_joint_returns,
@@ -22,6 +26,7 @@ draw_financing = draw_financing_series
 
 __all__ = [
     "simulate_financing",
+    "broadcast_dispersion_warning",
     "prepare_mc_universe",
     "build_cov_matrix",
     "prepare_return_shocks",

--- a/pa_core/sim/financing.py
+++ b/pa_core/sim/financing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Mapping, Optional, cast
+from typing import Any, Dict, Iterable, Mapping, Optional, cast
 
 import numpy.typing as npt
 
@@ -12,7 +12,42 @@ from ..types import GeneratorLike
 logger = logging.getLogger(__name__)
 
 _FINANCING_MODES = ("broadcast", "per_path")
-_BROADCAST_WARN_THRESHOLD = 100
+
+# Financing volatility keys whose non-zero values make ``broadcast`` mode
+# suppress risk dispersion (see ``broadcast_dispersion_warning``).
+_FINANCING_SIGMA_KEYS = (
+    "internal_financing_sigma_month",
+    "ext_pa_financing_sigma_month",
+    "act_ext_financing_sigma_month",
+)
+
+
+def broadcast_dispersion_warning(
+    financing_mode: str,
+    n_sim: int,
+    financing_sigmas: Iterable[float],
+) -> Optional[str]:
+    """Return a user-facing warning when ``broadcast`` financing suppresses risk.
+
+    ``broadcast`` reuses a single financing path across every Monte-Carlo
+    scenario. When more than one scenario is simulated and any financing
+    volatility is non-zero, that shared path removes financing-cost dispersion
+    (and any return/financing co-movement), so tail/CVaR estimates are
+    understated. Returns ``None`` when broadcast is harmless (a single scenario
+    or all financing volatilities zero) or when ``per_path`` is in effect.
+    """
+    if financing_mode != "broadcast":
+        return None
+    if not n_sim or n_sim <= 1:
+        return None
+    if not any((sigma or 0.0) > 0 for sigma in financing_sigmas):
+        return None
+    return (
+        "financing_mode='broadcast' reuses a single financing path across all "
+        f"{n_sim} simulations, so financing-cost dispersion is suppressed and "
+        "tail/CVaR risk is understated. Use financing_mode='per_path' for "
+        "risk/tail analysis."
+    )
 
 
 def simulate_financing(
@@ -67,11 +102,13 @@ def draw_financing_series(
         raise ValueError("n_months must be positive")
     if n_sim <= 0:
         raise ValueError("n_sim must be positive")
-    if financing_mode == "broadcast" and n_sim >= _BROADCAST_WARN_THRESHOLD:
-        logger.warning(
-            "Financing mode 'broadcast' reuses a single financing path across %s scenarios.",
-            n_sim,
-        )
+    warning = broadcast_dispersion_warning(
+        financing_mode,
+        n_sim,
+        (params.get(key, 0.0) for key in _FINANCING_SIGMA_KEYS),
+    )
+    if warning is not None:
+        logger.warning(warning)
 
     if rngs is not None:
         tmp_int = rngs.get("internal")

--- a/pa_core/sim/financing.py
+++ b/pa_core/sim/financing.py
@@ -17,6 +17,7 @@ _FINANCING_MODES = ("broadcast", "per_path")
 # suppress risk dispersion (see ``broadcast_dispersion_warning``).
 _FINANCING_SIGMA_KEYS = (
     "internal_financing_sigma_month",
+    "internal_pa_financing_sigma_month",
     "ext_pa_financing_sigma_month",
     "act_ext_financing_sigma_month",
 )

--- a/templates/parameters_template.csv
+++ b/templates/parameters_template.csv
@@ -54,7 +54,7 @@ Active Ext financing mean (monthly %),0.0
 Active Ext financing vol (monthly %),0.0
 Active Ext monthly spike prob,0.0
 Active Ext spike multiplier,0.0
-financing_mode,broadcast
+financing_mode,per_path
 Analysis mode,returns
 sweep,
 max_external_combined_pct,30.0

--- a/templates/params_template.yaml
+++ b/templates/params_template.yaml
@@ -53,7 +53,7 @@ Active Ext financing mean (monthly %): 0.0
 Active Ext financing vol (monthly %): 0.0
 Active Ext monthly spike prob: 0.0
 Active Ext spike multiplier: 0.0
-financing_mode: broadcast
+financing_mode: per_path
 Analysis mode: returns
 sweep: null
 max_external_combined_pct: 30.0

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -16,6 +16,12 @@ from pa_core.facade import RunArtifacts
 @dataclass
 class DummyConfig:
     analysis_mode: str = "single_with_sensitivity"
+    N_SIMULATIONS: int = 1
+    financing_mode: str = "broadcast"
+    internal_financing_sigma_month: float = 0.0
+    internal_pa_financing_sigma_month: float = 0.0
+    ext_pa_financing_sigma_month: float = 0.0
+    act_ext_financing_sigma_month: float = 0.0
 
     def model_dump(self) -> dict[str, Any]:
         return {"analysis_mode": self.analysis_mode}
@@ -104,6 +110,40 @@ def test_pa_run_command_outputs_and_exit_code(monkeypatch, tmp_path, capsys) -> 
     captured = capsys.readouterr()
     assert exit_code == 0
     assert captured.out == MAIN_BACKEND_STDOUT
+    assert captured.err == EMPTY_STDERR
+
+
+def test_pa_run_warns_after_stress_preset_adds_financing_vol(monkeypatch, tmp_path, capsys) -> None:
+    cfg = DummyConfig(N_SIMULATIONS=100, financing_mode="broadcast")
+    stressed_cfg = DummyConfig(
+        N_SIMULATIONS=100,
+        financing_mode="broadcast",
+        internal_financing_sigma_month=0.05,
+    )
+    _patch_cli_run(monkeypatch, cfg)
+    monkeypatch.setattr("pa_core.stress.apply_stress_preset", lambda *_: stressed_cfg)
+
+    out_path = tmp_path / "out.xlsx"
+    exit_code = _exit_code(
+        lambda: pa_entry.main(
+            [
+                "run",
+                "--config",
+                "cfg.yaml",
+                "--index",
+                "idx.csv",
+                "--output",
+                str(out_path),
+                "--stress-preset",
+                "liquidity_squeeze",
+            ]
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "financing_mode='broadcast'" in captured.out
+    assert "per_path" in captured.out
     assert captured.err == EMPTY_STDERR
 
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -361,3 +361,52 @@ def test_run_sweep_ignores_global_rng_state() -> None:
     artifacts_b = run_sweep(cfg, idx, sweep_params, RunOptions(seed=123))
 
     pd.testing.assert_frame_equal(artifacts_a.summary, artifacts_b.summary)
+
+
+def test_broadcast_dispersion_warning_fires_when_risk_suppressed():
+    """broadcast + multiple sims + non-zero financing vol -> visible warning (#1909)."""
+    from pa_core.sim.financing import broadcast_dispersion_warning
+
+    msg = broadcast_dispersion_warning("broadcast", 1000, [0.0, 0.05, 0.0])
+    assert msg is not None
+    assert "per_path" in msg
+    assert "tail/CVaR" in msg
+
+
+def test_broadcast_dispersion_warning_silent_when_harmless():
+    """No warning for per_path, a single scenario, or all-zero financing vol."""
+    from pa_core.sim.financing import broadcast_dispersion_warning
+
+    assert broadcast_dispersion_warning("per_path", 1000, [0.05, 0.05, 0.05]) is None
+    assert broadcast_dispersion_warning("broadcast", 1, [0.05, 0.05, 0.05]) is None
+    assert broadcast_dispersion_warning("broadcast", 1000, [0.0, 0.0, 0.0]) is None
+
+
+def test_draw_financing_series_logs_broadcast_warning(caplog):
+    """draw_financing_series surfaces the broadcast risk notice via logging (#1909)."""
+    params = _build_financing_params(
+        internal_financing_mean_month=0.01,
+        internal_financing_sigma_month=0.05,
+    )
+    rng = np.random.default_rng(7)
+    with caplog.at_level("WARNING", logger="pa_core.sim.financing"):
+        draw_financing_series(
+            n_months=12,
+            n_sim=50,
+            params=params,
+            financing_mode="broadcast",
+            rng=rng,
+        )
+    assert any("per_path" in rec.message for rec in caplog.records)
+
+    caplog.clear()
+    rng = np.random.default_rng(7)
+    with caplog.at_level("WARNING", logger="pa_core.sim.financing"):
+        draw_financing_series(
+            n_months=12,
+            n_sim=50,
+            params=params,
+            financing_mode="per_path",
+            rng=rng,
+        )
+    assert not any("per_path" in rec.message for rec in caplog.records)

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -373,6 +373,23 @@ def test_broadcast_dispersion_warning_fires_when_risk_suppressed():
     assert "tail/CVaR" in msg
 
 
+def test_broadcast_dispersion_warning_includes_internal_pa_sigma_key():
+    """Internal-PA financing volatility also makes broadcast suppress dispersion."""
+    from pa_core.sim.financing import _FINANCING_SIGMA_KEYS, broadcast_dispersion_warning
+
+    sigma_by_key = {key: 0.0 for key in _FINANCING_SIGMA_KEYS}
+    sigma_by_key["internal_pa_financing_sigma_month"] = 0.05
+
+    msg = broadcast_dispersion_warning(
+        "broadcast",
+        1000,
+        (sigma_by_key[key] for key in _FINANCING_SIGMA_KEYS),
+    )
+
+    assert msg is not None
+    assert "tail/CVaR" in msg
+
+
 def test_broadcast_dispersion_warning_silent_when_harmless():
     """No warning for per_path, a single scenario, or all-zero financing vol."""
     from pa_core.sim.financing import broadcast_dispersion_warning


### PR DESCRIPTION
## Summary

`financing_mode='broadcast'` (the prior shipped default) reuses a **single** financing path across every Monte-Carlo scenario, so financing-cost dispersion — and any return/financing co-movement — is suppressed and **tail/CVaR risk is understated** for any run with non-zero financing volatility. `per_path` mode existed but was off by default, and the broadcast risk was only a debug-level `logger.warning` gated at `n_sim >= 100`.

This implements the audit recommendation: make `per_path` the recommended default and elevate the broadcast notice to a visible CLI warning.

## Changes
- **Make `per_path` canonical/recommended:** reorder the `financing_mode` `Literal` so schema-generated templates emit `per_path`; flip the hand-maintained `config/params_template.yml` and `config/params_agents_generic.yml`; regenerate `templates/parameters_template.csv`, `templates/params_template.yaml`, and `docs/guides/PARAMETER_DICTIONARY.md` (schema-drift tests pass).
- **Visible risk notice:** add `broadcast_dispersion_warning()` that fires whenever broadcast actually suppresses dispersion (`n_sim > 1` **and** any financing vol `> 0`) — broader than the old `n_sim >= 100` gate. `draw_financing_series` logs it, and `pa_core.cli` prints it at run start so users actually see it.
- **Fix misleading `--config` help text** that previously recommended `broadcast`.

## Non-goals
- `financing_mode` remains a **required** config field (locked by `test_financing_mode_is_required`); this PR changes the recommended/template default and visibility, not the required-field contract.

## Tests
- New focused tests in `tests/test_simulations.py` covering the warning helper (fires on risk-suppressing broadcast; silent for `per_path` / single scenario / zero vol) and the logged notice from `draw_financing_series`.
- Validated locally: `tests/test_simulations.py tests/test_schema_export.py tests/test_config.py tests/test_integration_regressions.py` (60 passed) and `tests/test_cli.py tests/test_pa_core_main.py tests/test_return_distributions.py tests/test_internal_pa_financing.py tests/golden/test_scenario_smoke.py` (33 passed); `ruff check` clean.

Closes #1909

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Monte Carlo risk semantics for users who keep `broadcast` with financing vol (now warned) and shifts template defaults to `per_path`, which can alter tail/CVaR vs prior template runs; simulation logic for each mode is unchanged.
> 
> **Overview**
> Makes **`per_path`** the recommended financing draw mode in templates, schema docs, and `ModelConfig` field ordering/descriptions, replacing **`broadcast`** as the shipped example default. **`financing_mode` stays a required config field**; only guidance and template values change.
> 
> Adds **`broadcast_dispersion_warning()`**, which warns when `broadcast` is used with `N_SIMULATIONS > 1` and any non-zero financing volatility (internal, internal-PA, external PA, or active ext)—broader than the old `n_sim >= 100` log-only check. **`draw_financing_series`** logs this message; **`pa run`** prints it to stdout after stress presets apply so users see understated tail/CVaR risk.
> 
> Updates **`--config` help** in `pa_core.cli` and `pa_core.__main__` to recommend `per_path` for risk/tail analysis. New tests cover the helper, logging, and CLI warning after stress presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b459da1f316af05dd2cfa077a0b334eee36e42c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->