### PR TITLE
fix(sweep): apply regime switching in parameter sweeps (#1910)

### DIFF
--- a/pa_core/facade.py
+++ b/pa_core/facade.py
@@ -629,6 +629,7 @@ def run_sweep(
         rng_returns,
         fin_rngs,
         seed=child_seed,
+        rng_regime=rng_bundle.rng_regime,
     )
     summary = sweep_results_to_dataframe(results)
     inputs = run_cfg.model_dump()

--- a/pa_core/sim/simulation_initialization.py
+++ b/pa_core/sim/simulation_initialization.py
@@ -24,6 +24,7 @@ class SweepRNGBundle:
     """RNG bundle for a parameter sweep run."""
 
     rng_returns: GeneratorLike
+    rng_regime: GeneratorLike
     rngs_financing: Mapping[str, GeneratorLike]
     substream_ids: Mapping[str, str]
     seed: int
@@ -70,7 +71,7 @@ def initialize_sweep_rngs(
     """Create per-sweep RNGs derived from the run seed."""
     base_rng = spawn_rngs(seed, 1)[0]
     child_seed = int(base_rng.integers(0, 2**32, dtype="uint32"))
-    rng_returns = spawn_rngs(child_seed, 1)[0]
+    rng_returns, rng_regime = spawn_rngs(child_seed, 2)
     rngs_financing, substream_ids = spawn_agent_rngs_with_ids(
         child_seed,
         financing_agents,
@@ -78,6 +79,7 @@ def initialize_sweep_rngs(
     )
     return SweepRNGBundle(
         rng_returns=rng_returns,
+        rng_regime=rng_regime,
         rngs_financing=rngs_financing,
         substream_ids=substream_ids,
         seed=child_seed,

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -38,6 +38,7 @@ from .sim.params import (
     build_params,
     resolve_covariance_inputs,
 )
+from .sim.regimes import build_regime_draw_params, resolve_regime_start, simulate_regime_paths
 from .simulations import simulate_agents
 from .types import GeneratorLike, SweepResult
 from .units import (
@@ -304,6 +305,7 @@ class SweepRunner:
             rng_bundle.rng_returns,
             rng_bundle.rngs_financing,
             seed=rng_bundle.seed,
+            rng_regime=rng_bundle.rng_regime,
             progress=self.progress,
         )
 
@@ -341,6 +343,7 @@ def run_parameter_sweep(
     rng_returns: GeneratorLike,
     fin_rngs: Mapping[str, GeneratorLike],
     seed: Optional[int] = None,
+    rng_regime: GeneratorLike | None = None,
     progress: Optional[Callable[[int, int], None]] = None,
 ) -> List[SweepResult]:
     """Run the parameter sweep and collect results.
@@ -356,6 +359,8 @@ def run_parameter_sweep(
         ``None``, a ``tqdm`` progress bar is displayed.
     """
     results: List[SweepResult] = []
+    if rng_regime is None:
+        rng_regime = spawn_rngs(seed, 2)[1] if seed is not None else spawn_rngs(None, 1)[0]
 
     index_series = normalize_index_series(pd.Series(index_series), get_index_series_unit())
     mu_idx = float(index_series.mean())
@@ -430,6 +435,8 @@ def run_parameter_sweep(
     }
     reuse_return_shocks = not override_keys.intersection(shock_incompatible_keys)
     reuse_financing_series = not override_keys.intersection(financing_keys)
+    if cfg.regimes is not None:
+        reuse_return_shocks = False
     if cfg.covariance_shrinkage != "none" and override_keys.intersection(sigma_override_keys):
         reuse_return_shocks = False
     returns_static = not override_keys.intersection(return_param_keys)
@@ -440,13 +447,15 @@ def run_parameter_sweep(
     # is provided, derive the baseline RNG state from that seed.
     if seed is None:
         rng_returns_state = copy.deepcopy(rng_returns.bit_generator.state)
+        rng_regime_state = copy.deepcopy(rng_regime.bit_generator.state)
         fin_rng_states = {
             name: copy.deepcopy(rng.bit_generator.state) for name, rng in fin_rngs.items()
         }
     else:
-        base_rng_returns = spawn_rngs(seed, 1)[0]
+        base_rng_returns, base_rng_regime = spawn_rngs(seed, 2)
         base_fin_rngs = spawn_agent_rngs(seed, list(fin_rngs.keys()))
         rng_returns_state = copy.deepcopy(base_rng_returns.bit_generator.state)
+        rng_regime_state = copy.deepcopy(base_rng_regime.bit_generator.state)
         fin_rng_states = {
             name: copy.deepcopy(base_fin_rngs[name].bit_generator.state) for name in fin_rngs.keys()
         }
@@ -454,6 +463,8 @@ def run_parameter_sweep(
     base_sigma = None
     base_corr = None
     base_params = None
+    base_regime_params = None
+    base_regime_paths = None
     if returns_static or reuse_return_shocks:
         base_return_inputs = normalize_return_inputs(cfg)
         sigma_h = float(base_return_inputs["sigma_H"])
@@ -492,6 +503,24 @@ def run_parameter_sweep(
             idx_sigma=float(base_sigma[0]),
             return_overrides=build_covariance_return_overrides(base_sigma, base_corr),
         )
+        if cfg.regimes is not None:
+            if cfg.regime_transition is None:
+                raise ValueError("regime_transition is required when regimes are specified")
+            base_regime_params, _labels = build_regime_draw_params(
+                cfg,
+                mu_idx=mu_idx,
+                idx_sigma=float(base_sigma[0]),
+                n_samples=n_samples,
+            )
+            rng_regime_base = spawn_rngs(None, 1)[0]
+            rng_regime_base.bit_generator.state = copy.deepcopy(rng_regime_state)
+            base_regime_paths = simulate_regime_paths(
+                n_sim=cfg.N_SIMULATIONS,
+                n_months=cfg.N_MONTHS,
+                transition=cfg.regime_transition,
+                start_state=resolve_regime_start(cfg),
+                rng=rng_regime_base,
+            )
 
     return_shocks = None
     if reuse_return_shocks:
@@ -531,6 +560,7 @@ def run_parameter_sweep(
     for i, overrides in iterator:
         if return_shocks is None:
             rng_returns.bit_generator.state = copy.deepcopy(rng_returns_state)
+            rng_regime.bit_generator.state = copy.deepcopy(rng_regime_state)
         if financing_series is None:
             for name, rng in fin_rngs.items():
                 rng.bit_generator.state = copy.deepcopy(fin_rng_states[name])
@@ -585,12 +615,37 @@ def run_parameter_sweep(
                 return_overrides=build_covariance_return_overrides(sigma_vec, corr_mat),
             )
 
+        regime_params = None
+        regime_paths = None
+        if mod_cfg.regimes is not None:
+            if mod_cfg.regime_transition is None:
+                raise ValueError("regime_transition is required when regimes are specified")
+            if returns_static and base_regime_params is not None and base_regime_paths is not None:
+                regime_params = base_regime_params
+                regime_paths = base_regime_paths
+            else:
+                regime_params = build_regime_draw_params(
+                    mod_cfg,
+                    mu_idx=mu_idx,
+                    idx_sigma=float(params["idx_sigma_month"]),
+                    n_samples=n_samples,
+                )[0]
+                regime_paths = simulate_regime_paths(
+                    n_sim=mod_cfg.N_SIMULATIONS,
+                    n_months=mod_cfg.N_MONTHS,
+                    transition=mod_cfg.regime_transition,
+                    start_state=resolve_regime_start(mod_cfg),
+                    rng=rng_regime,
+                )
+
         r_beta, r_H, r_E, r_M = draw_joint_returns(
             n_months=mod_cfg.N_MONTHS,
             n_sim=mod_cfg.N_SIMULATIONS,
             params=params,
             rng=None if return_shocks is not None else rng_returns,
             shocks=return_shocks,
+            regime_paths=regime_paths,
+            regime_params=regime_params,
         )
         if financing_series is None:
             f_int, f_ext, f_act = draw_financing_series(

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -337,6 +337,23 @@ def _get_empty_results_dataframe() -> pd.DataFrame:
     return _EMPTY_RESULTS_DF.copy()
 
 
+def _derive_regime_rng(rng_returns: GeneratorLike) -> GeneratorLike:
+    """Derive a regime RNG deterministically from ``rng_returns``'s state.
+
+    Used when neither a master ``seed`` nor an explicit ``rng_regime`` is
+    supplied: the regime path generator is seeded from a stable hash of the
+    ``rng_returns`` bit-generator state so repeated runs with the same seeded
+    ``rng_returns`` reproduce identical regime paths, while remaining an
+    independent stream from the return draws.
+    """
+    state_repr = json.dumps(
+        rng_returns.bit_generator.state, sort_keys=True, default=str
+    )
+    digest = hashlib.sha256(("pa_core.regime:" + state_repr).encode("utf-8")).digest()
+    entropy = int.from_bytes(digest, "big")
+    return spawn_rngs(entropy, 1)[0]
+
+
 def run_parameter_sweep(
     cfg: ModelConfig,
     index_series: pd.Series,
@@ -360,7 +377,16 @@ def run_parameter_sweep(
     """
     results: List[SweepResult] = []
     if rng_regime is None:
-        rng_regime = spawn_rngs(seed, 2)[1] if seed is not None else spawn_rngs(None, 1)[0]
+        if seed is not None:
+            rng_regime = spawn_rngs(seed, 2)[1]
+        else:
+            # No master seed and no explicit regime RNG: derive one
+            # deterministically from the supplied ``rng_returns`` so that direct
+            # callers that seed ``rng_returns``/``fin_rngs`` (the established
+            # reproducibility pattern) still get repeatable regime paths instead
+            # of OS entropy. Reading ``bit_generator.state`` does not advance
+            # ``rng_returns``, so this leaves the downstream draws untouched.
+            rng_regime = _derive_regime_rng(rng_returns)
 
     index_series = normalize_index_series(pd.Series(index_series), get_index_series_unit())
     mu_idx = float(index_series.mean())

--- a/tests/test_facade_run_sweep.py
+++ b/tests/test_facade_run_sweep.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from pa_core.config import load_config
+from pa_core.config import RegimeConfig, load_config
 from pa_core.facade import RunOptions, run_sweep
 
 
@@ -52,3 +52,58 @@ def test_run_sweep_applies_config_overrides() -> None:
     )
 
     assert artifacts.config.N_SIMULATIONS == 1
+
+
+def test_run_sweep_applies_regime_switching() -> None:
+    base_cfg = load_config("examples/scenarios/my_first_scenario.yml").model_copy(
+        update={
+            "N_SIMULATIONS": 128,
+            "N_MONTHS": 12,
+            "return_unit": "monthly",
+            "financing_mode": "broadcast",
+            "sigma_H": 0.02,
+            "sigma_E": 0.02,
+            "sigma_M": 0.02,
+            "rho_idx_H": 0.1,
+            "rho_idx_E": 0.1,
+            "rho_idx_M": 0.1,
+            "rho_H_E": 0.2,
+            "rho_H_M": 0.2,
+            "rho_E_M": 0.2,
+        }
+    )
+    regime_cfg = base_cfg.model_copy(
+        update={
+            "regimes": [
+                RegimeConfig(name="calm"),
+                RegimeConfig(
+                    name="stress",
+                    idx_sigma_multiplier=2.0,
+                    sigma_H=0.05,
+                    sigma_E=0.05,
+                    sigma_M=0.05,
+                    rho_idx_H=0.8,
+                    rho_idx_E=0.8,
+                    rho_idx_M=0.8,
+                    rho_H_E=0.85,
+                    rho_H_M=0.85,
+                    rho_E_M=0.85,
+                ),
+            ],
+            "regime_transition": [[0.8, 0.2], [0.2, 0.8]],
+            "regime_start": "calm",
+        }
+    )
+    idx = pd.Series([0.01, -0.02, 0.015, 0.0, 0.005, -0.01] * 2)
+    sweep_params = {
+        "analysis_mode": "vol_mult",
+        "sd_multiple_min": 1.0,
+        "sd_multiple_max": 1.0,
+        "sd_multiple_step": 1.0,
+    }
+
+    without_regimes = run_sweep(base_cfg, idx, sweep_params, RunOptions(seed=123))
+    with_regimes = run_sweep(regime_cfg, idx, sweep_params, RunOptions(seed=123))
+
+    assert len(with_regimes.results) == len(without_regimes.results) == 1
+    assert not with_regimes.summary.equals(without_regimes.summary)

--- a/tests/test_sweep_reproducibility.py
+++ b/tests/test_sweep_reproducibility.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from pa_core import sweep as sweep_module
-from pa_core.config import load_config
+from pa_core.config import RegimeConfig, load_config
 from pa_core.random import spawn_agent_rngs, spawn_rngs
 
 
@@ -83,6 +83,57 @@ def test_sweep_seed_resets_rng_state(monkeypatch):
     rng_returns_2 = spawn_rngs(555, 1)[0]
     fin_rngs_2 = spawn_agent_rngs(555, ["internal", "external_pa", "active_ext"])
     res2 = sweep_module.run_parameter_sweep(cfg, idx, rng_returns_2, fin_rngs_2, seed=123)
+
+    assert len(res1) == len(res2)
+    for left, right in zip(res1, res2):
+        assert left["parameters"] == right["parameters"]
+        pd.testing.assert_frame_equal(left["summary"], right["summary"])
+
+
+def test_regime_sweep_reproducible_without_seed_or_rng_regime(monkeypatch):
+    """Regime-enabled direct calls stay reproducible from seeded rng_returns.
+
+    Regression for the case where callers seed ``rng_returns``/``fin_rngs`` but
+    pass neither ``seed`` nor ``rng_regime``: the fallback regime RNG must be
+    derived deterministically rather than from OS entropy.
+    """
+    cfg = load_config("examples/scenarios/my_first_scenario.yml").model_copy(
+        update={
+            "N_SIMULATIONS": 2,
+            "N_MONTHS": 3,
+            "analysis_mode": "returns",
+            "regimes": [
+                RegimeConfig(name="calm"),
+                RegimeConfig(name="stress", idx_sigma_multiplier=2.0),
+            ],
+            "regime_transition": [[0.8, 0.2], [0.2, 0.8]],
+            "regime_start": "calm",
+        }
+    )
+    idx = pd.Series([0.01, -0.02, 0.015])
+    combos = [
+        {
+            "mu_H": cfg.mu_H,
+            "sigma_H": cfg.sigma_H,
+            "mu_E": cfg.mu_E,
+            "sigma_E": cfg.sigma_E,
+        }
+    ]
+    monkeypatch.setattr(
+        sweep_module,
+        "generate_parameter_combinations",
+        lambda _cfg: iter(combos),
+    )
+
+    def _run():
+        rng_returns = spawn_rngs(777, 1)[0]
+        fin_rngs = spawn_agent_rngs(777, ["internal", "external_pa", "active_ext"])
+        # No seed / rng_regime passed — the regime RNG must be derived
+        # deterministically from rng_returns.
+        return sweep_module.run_parameter_sweep(cfg, idx, rng_returns, fin_rngs)
+
+    res1 = _run()
+    res2 = _run()
 
     assert len(res1) == len(res2)
     for left, right in zip(res1, res2):

--- a/tests/test_sweep_runner.py
+++ b/tests/test_sweep_runner.py
@@ -9,10 +9,19 @@ def test_sweep_runner_calls_run_parameter_sweep(monkeypatch) -> None:
     idx = pd.Series([0.01, 0.02, -0.01])
     captured: dict[str, object] = {}
 
-    def fake_run_parameter_sweep(cfg_arg, idx_arg, rng_returns, fin_rngs, seed=None, progress=None):
+    def fake_run_parameter_sweep(
+        cfg_arg,
+        idx_arg,
+        rng_returns,
+        fin_rngs,
+        seed=None,
+        rng_regime=None,
+        progress=None,
+    ):
         captured["cfg"] = cfg_arg
         captured["idx"] = idx_arg
         captured["seed"] = seed
+        captured["rng_regime"] = rng_regime
         captured["progress"] = progress
         return [{"combination_id": 0, "parameters": {}, "summary": pd.DataFrame()}]
 
@@ -25,3 +34,4 @@ def test_sweep_runner_calls_run_parameter_sweep(monkeypatch) -> None:
     assert captured["cfg"] is cfg
     assert isinstance(captured["idx"], pd.Series)
     assert captured["seed"] is not None
+    assert captured["rng_regime"] is not None


### PR DESCRIPTION
## Summary
- add a dedicated sweep regime RNG stream and pass it through facade/sweep helpers
- build and reuse regime draw parameters/paths during parameter sweeps
- pass regime paths/params into joint return draws so configured regimes affect sweep outputs
- add a regression proving sweep summaries change when regimes are configured

## Validation
- python -m pytest tests/test_facade_run_sweep.py tests/test_sweep_reproducibility.py tests/test_sweep_common_random_numbers.py tests/test_regime_switching.py -q
- python -m ruff check pa_core/sweep.py pa_core/facade.py pa_core/sim/simulation_initialization.py tests/test_facade_run_sweep.py

Closes #1910

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Monte Carlo sweep logic and RNG stream wiring; behavior shifts for regime-enabled configs and could affect sweep reproducibility patterns, but aligns sweeps with existing single-run regime handling and adds targeted tests.
> 
> **Overview**
> Parameter sweeps now honor **regime switching** the same way single runs do: a separate **`rng_regime`** stream is created in sweep RNG initialization and threaded through **`run_sweep`**, **`SweepRunner`**, and **`run_parameter_sweep`**.
> 
> **`run_parameter_sweep`** builds regime draw parameters and simulates regime paths when `regimes` is set, passes **`regime_paths`** / **`regime_params`** into **`draw_joint_returns`**, and resets the regime RNG under common random numbers. Regime configs **disable precomputed return-shock reuse** so paths stay consistent with regime-dependent draws. Callers without an explicit regime RNG get one from the master **`seed`** or, deterministically, from a hash of **`rng_returns`**’s bit-generator state.
> 
> Tests assert sweep summaries differ with regimes enabled and that regime sweeps stay reproducible when only return/financing RNGs are seeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd792b23e3fe559ab1db1c65eac01a1429d8afe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->