### PR TITLE
fix(robustness): guard NaN/ZeroDivision edge cases (#1919)

### DIFF
--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -258,7 +258,9 @@ class ModelConfig(BaseModel):
     external_pa_capital: float = Field(default=0.0, alias="External PA capital (mm)")
     active_ext_capital: float = Field(default=0.0, alias="Active Extension capital (mm)")
     internal_pa_capital: float = Field(default=0.0, alias="Internal PA capital (mm)")
-    total_fund_capital: float = Field(default=1000.0, alias="Total fund capital (mm)")
+    total_fund_capital: float = Field(
+        default=1000.0, gt=0, alias="Total fund capital (mm)"
+    )
     agents: List[AgentConfig] = Field(default_factory=list)
 
     w_beta_H: float = Field(default=0.5, alias="In-House beta share")
@@ -297,9 +299,11 @@ class ModelConfig(BaseModel):
         default=0.0, alias="Internal financing mean (monthly %)"
     )
     internal_financing_sigma_month: float = Field(
-        default=0.0, alias="Internal financing vol (monthly %)"
+        default=0.0, ge=0, alias="Internal financing vol (monthly %)"
     )
-    internal_spike_prob: float = Field(default=0.0, alias="Internal monthly spike prob")
+    internal_spike_prob: float = Field(
+        default=0.0, ge=0, le=1, alias="Internal monthly spike prob"
+    )
     internal_spike_factor: float = Field(default=0.0, alias="Internal spike multiplier")
 
     # Internal-PA financing cost (issue #1849). Distinct from the margin
@@ -316,6 +320,7 @@ class ModelConfig(BaseModel):
     )
     internal_pa_financing_sigma_month: float = Field(
         default=0.0,
+        ge=0,
         alias="Internal PA financing vol (monthly %)",
         description="Optional monthly stochastic vol for the internal-PA financing cost.",
     )
@@ -334,18 +339,22 @@ class ModelConfig(BaseModel):
         default=0.0, alias="External PA financing mean (monthly %)"
     )
     ext_pa_financing_sigma_month: float = Field(
-        default=0.0, alias="External PA financing vol (monthly %)"
+        default=0.0, ge=0, alias="External PA financing vol (monthly %)"
     )
-    ext_pa_spike_prob: float = Field(default=0.0, alias="External PA monthly spike prob")
+    ext_pa_spike_prob: float = Field(
+        default=0.0, ge=0, le=1, alias="External PA monthly spike prob"
+    )
     ext_pa_spike_factor: float = Field(default=0.0, alias="External PA spike multiplier")
 
     act_ext_financing_mean_month: float = Field(
         default=0.0, alias="Active Ext financing mean (monthly %)"
     )
     act_ext_financing_sigma_month: float = Field(
-        default=0.0, alias="Active Ext financing vol (monthly %)"
+        default=0.0, ge=0, alias="Active Ext financing vol (monthly %)"
     )
-    act_ext_spike_prob: float = Field(default=0.0, alias="Active Ext monthly spike prob")
+    act_ext_spike_prob: float = Field(
+        default=0.0, ge=0, le=1, alias="Active Ext monthly spike prob"
+    )
     act_ext_spike_factor: float = Field(default=0.0, alias="Active Ext spike multiplier")
     financing_mode: Literal["broadcast", "per_path"] = Field(
         ...,
@@ -556,6 +565,12 @@ class ModelConfig(BaseModel):
             return field_info.default
 
         total_cap = float(_get_value("total_fund_capital", ("Total fund capital (mm)",)))
+        if total_cap <= 0:
+            # Guard the sleeve `capital / total_cap` shares below: a zero/negative
+            # total fund capital previously raised ZeroDivisionError here, before
+            # the gt=0 Field constraint could report it. Raise a clean validation
+            # error instead.
+            raise ValueError("total_fund_capital must be greater than 0")
         w_beta = normalize_share(_get_value("w_beta_H", ("In-House beta share",)))
         w_alpha = normalize_share(_get_value("w_alpha_H", ("In-House alpha share",)))
         theta = normalize_share(_get_value("theta_extpa", ("External PA alpha fraction",)))

--- a/pa_core/sim/metrics.py
+++ b/pa_core/sim/metrics.py
@@ -153,7 +153,9 @@ def annualised_vol(returns: ArrayLike, periods_per_year: int = 12) -> float:
     annualised. This is a monthly-draw metric.
     """
     arr = np.asarray(returns, dtype=np.float64)
-    if arr.size < 2:
+    if arr.size == 0:
+        raise ValueError("returns must not be empty")
+    if arr.size == 1:
         # The ddof=1 sample standard deviation is undefined for a single
         # observation; report 0.0 rather than NaN from the divide-by-zero.
         return 0.0

--- a/pa_core/sim/metrics.py
+++ b/pa_core/sim/metrics.py
@@ -136,7 +136,14 @@ def annualised_return(returns: ArrayLike, periods_per_year: int = 12) -> float:
     comp = compound(returns)
     total_return = comp[:, -1]
     years = returns.shape[1] / periods_per_year
-    return float(np.power(1.0 + np.mean(total_return), 1.0 / years) - 1.0)
+    base = 1.0 + float(np.mean(total_return))
+    if base <= 0.0:
+        # Mean terminal multiple is wiped out (mean compounded return <= -100%):
+        # the annualised compound return is a total loss. Return -1.0 rather than
+        # raising a RuntimeWarning / returning NaN from a fractional power of a
+        # non-positive base.
+        return -1.0
+    return float(np.power(base, 1.0 / years) - 1.0)
 
 
 def annualised_vol(returns: ArrayLike, periods_per_year: int = 12) -> float:
@@ -146,6 +153,10 @@ def annualised_vol(returns: ArrayLike, periods_per_year: int = 12) -> float:
     annualised. This is a monthly-draw metric.
     """
     arr = np.asarray(returns, dtype=np.float64)
+    if arr.size < 2:
+        # The ddof=1 sample standard deviation is undefined for a single
+        # observation; report 0.0 rather than NaN from the divide-by-zero.
+        return 0.0
     return float(np.std(arr, ddof=1) * np.sqrt(periods_per_year))
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -231,6 +231,35 @@ def test_invalid_capital(tmp_path):
         raise AssertionError("Expected validation failure")
 
 
+def test_total_fund_capital_must_be_positive():
+    # total_fund_capital == 0 previously reached the agent-compile validator and
+    # raised ZeroDivisionError on `sleeve_cap / total_cap`. A gt=0 Field
+    # constraint now rejects it cleanly at validation time.
+    data = {
+        "N_SIMULATIONS": 1,
+        "N_MONTHS": 1,
+        "financing_mode": "broadcast",
+        "total_fund_capital": 0.0,
+        "external_pa_capital": 100.0,
+    }
+    with pytest.raises(ValidationError):
+        ModelConfig(**data)
+
+
+def test_spike_prob_and_financing_sigma_bounds():
+    base = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
+    # spike probabilities are bounded to [0, 1]
+    with pytest.raises(ValidationError):
+        ModelConfig(**base, internal_spike_prob=1.5)
+    with pytest.raises(ValidationError):
+        ModelConfig(**base, ext_pa_spike_prob=-0.1)
+    # financing vols cannot be negative
+    with pytest.raises(ValidationError):
+        ModelConfig(**base, internal_financing_sigma_month=-0.01)
+    with pytest.raises(ValidationError):
+        ModelConfig(**base, internal_pa_financing_sigma_month=-0.01)
+
+
 def test_agents_missing_benchmark():
     data = {
         "N_SIMULATIONS": 1,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -63,6 +63,25 @@ def test_compound_and_summary():
     assert np.isfinite(ann_vol)
 
 
+def test_annualised_return_total_loss_is_finite():
+    # A catastrophic month (<= -100%) drives the mean terminal multiple to <= 0
+    # (base 1 + mean <= 0); this must not produce NaN / RuntimeWarning from a
+    # fractional power of a non-positive base.
+    arr = np.array([[-1.5, 0.2]])
+    ann_ret = annualised_return(arr)
+    assert np.isfinite(ann_ret)
+    assert ann_ret == -1.0
+
+
+def test_annualised_vol_single_observation_is_finite():
+    # ddof=1 sample std is undefined for a single observation; guard returns 0.0
+    # rather than NaN from the divide-by-zero.
+    arr = np.array([[0.01]])
+    ann_vol = annualised_vol(arr)
+    assert np.isfinite(ann_vol)
+    assert ann_vol == 0.0
+
+
 def test_summary_table_adds_total_when_benchmark_present():
     base = np.zeros((2, 3))
     ext = np.array([[0.01, -0.01, 0.02], [0.0, 0.01, -0.02]])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -82,6 +82,11 @@ def test_annualised_vol_single_observation_is_finite():
     assert ann_vol == 0.0
 
 
+def test_annualised_vol_rejects_empty_input():
+    with pytest.raises(ValueError, match="returns must not be empty"):
+        annualised_vol(np.array([]))
+
+
 def test_summary_table_adds_total_when_benchmark_present():
     base = np.zeros((2, 3))
     ext = np.array([[0.01, -0.01, 0.02], [0.0, 0.01, -0.02]])


### PR DESCRIPTION
Closes #1919

Fixes the robustness edge cases found in the 2026-06-13 whole-repo audit. All are one-line guards / Field constraints.

## Changes
- **`annualised_return`** (`pa_core/sim/metrics.py`): when the mean terminal compounded multiple is non-positive (a monthly return ≤ −100%), return `-1.0` (total loss) instead of `NaN` / a `RuntimeWarning` from a fractional power of a non-positive base.
- **`annualised_vol`** (`pa_core/sim/metrics.py`): return `0.0` for a single observation instead of `NaN` from the `ddof=1` divide-by-zero.
- **`total_fund_capital`** (`pa_core/config.py`): adds a `gt=0` Field constraint, and the agent-compile step now raises a clean validation error instead of `ZeroDivisionError` on `sleeve_cap / total_cap` when capital is 0 (the compile runs in a `mode="before"` validator, ahead of field-constraint enforcement).
- **Bounds** (`pa_core/config.py`): `*_spike_prob` fields bounded to `[0, 1]`; `*_financing_sigma_month` vol fields bounded to `ge=0`.

## Tests
- `tests/test_metrics.py`: `test_annualised_return_total_loss_is_finite`, `test_annualised_vol_single_observation_is_finite`.
- `tests/test_config.py`: `test_total_fund_capital_must_be_positive`, `test_spike_prob_and_financing_sigma_bounds`.

## Validation
- `pytest tests/test_metrics.py tests/test_config.py` → 73 passed
- `pytest tests/test_simulations.py tests/test_schema.py tests/test_schema_export.py tests/test_sweep_config.py tests/test_orchestrator.py tests/test_integration_regressions.py` → 46 passed
- `ruff check` on touched files → clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive validation and metric guards with no behavior change on valid inputs; only invalid or extreme edge cases are handled differently.
> 
> **Overview**
> Hardens **config validation** and **summary metrics** against edge cases from the repo audit.
> 
> **`ModelConfig`** now requires **`total_fund_capital > 0`** (`gt=0`) and checks the same in **`compile_agent_config`** before sleeve `capital / total_cap`, so zero capital fails with a clear error instead of **`ZeroDivisionError`**. Spike probabilities are bounded to **`[0, 1]`** and financing volatility fields to **`ge=0`**.
> 
> **`annualised_return`** returns **`-1.0`** when the mean terminal multiple is non-positive (catastrophic returns), avoiding NaN/`RuntimeWarning` from fractional powers. **`annualised_vol`** raises on empty input and returns **`0.0`** for a single observation instead of NaN from `ddof=1`.
> 
> Tests in **`test_config.py`** and **`test_metrics.py`** cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8905a9609ef25439187480606523e7cd21f94ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->