### PR TITLE
feat(dashboard): one-click bundled sample data (no upload required) (#1900)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -11,6 +11,7 @@ import pandas as pd
 import streamlit as st
 
 from dashboard.glossary import GLOSSARY
+from dashboard.utils import bundled_sample_index_path
 from pa_core.contracts import (
     ALL_RETURNS_SHEET_NAME,
     DEFAULT_OUTPUT_FILENAME,
@@ -172,6 +173,37 @@ def load_history(parquet: str = "Outputs.parquet") -> pd.DataFrame | None:
     )
 
 
+def _render_getting_started() -> None:
+    """Surface the bundled sample dataset so first-run users aren't upload-gated.
+
+    The data-driven pages (Stress Lab, Scenario Grid) now offer a "Use bundled
+    sample data" option, so a non-technical first-run user can run an end-to-end
+    example in one click. This section advertises that and offers the bundled CSV
+    as a download for users who prefer the explicit upload flow. See issue #1900.
+    """
+    sample_path = bundled_sample_index_path()
+    if not sample_path.exists():
+        return
+    with st.expander("New here? Try the bundled sample data", expanded=True):
+        st.markdown(
+            "No data yet? The **Stress Lab** and **Scenario Grid** pages each have a "
+            "**“Use bundled sample data (no upload needed)”** checkbox that loads the "
+            "bundled S&P 500 TR / FRED dividend-yield series so you can run a complete "
+            "example in one click — no upload required."
+        )
+        try:
+            sample_bytes = sample_path.read_bytes()
+        except OSError:
+            return
+        st.download_button(
+            "Download sample index CSV",
+            data=sample_bytes,
+            file_name=sample_path.name,
+            mime="text/csv",
+            help="Use this with any page's upload control if you prefer the explicit flow.",
+        )
+
+
 def main() -> None:
     """Render the dashboard home page."""
 
@@ -188,6 +220,8 @@ def main() -> None:
     st.page_link("pages/4_Results.py", label="Results")
     st.page_link("pages/5_Scenario_Grid.py", label="Scenario Grid & Frontier (beta)")
     st.page_link("pages/6_Stress_Lab.py", label="Stress Lab (presets)")
+
+    _render_getting_started()
 
     history = load_history()
     if history is not None:

--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -230,7 +230,11 @@ def main() -> None:
                 # Ensure a plain pandas Series for type-checker
                 index_series = pd.Series(idx_df[num_cols[0]].dropna().to_numpy())
             else:
-                index_series = load_bundled_sample_index()
+                try:
+                    index_series = load_bundled_sample_index()
+                except (FileNotFoundError, ValueError) as exc:
+                    st.error(f"Bundled sample data could not be loaded: {exc}")
+                    return
 
             base_cfg = ModelConfig.model_validate(
                 {

--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -16,6 +16,7 @@ from dashboard.app import _DEF_THEME, apply_theme
 from dashboard.utils import (
     build_alpha_shares_payload,
     bump_session_token,
+    load_bundled_sample_index,
     make_grid_cache_key,
 )
 from pa_core.config import ModelConfig
@@ -177,6 +178,12 @@ def main() -> None:
         idx_file = st.file_uploader(
             "Index returns CSV (single numeric column)", type=["csv"], key="idx_csv"
         )
+        use_sample = st.checkbox(
+            "Use bundled sample data (no upload needed)",
+            value=False,
+            key="grid_use_sample",
+            help="Loads the bundled S&P 500 TR / FRED dividend-yield series for a one-click demo.",
+        )
         seed = st.number_input("Random seed", value=42, step=1)
 
         # Optional step controls
@@ -206,19 +213,24 @@ def main() -> None:
             )
 
         run_sweep = st.button("Run sweep")
-        if idx_file is None:
-            st.info("Upload an index returns CSV to run the sweep.")
+        if idx_file is None and not use_sample:
+            st.info("Upload an index returns CSV or tick 'Use bundled sample data' to run the sweep.")
             return
 
         try:
-            idx_df = _read_csv(idx_file)
-            # Use first numeric column as index series
-            num_cols = [c for c in idx_df.columns if pd.api.types.is_numeric_dtype(idx_df[c])]
-            if not num_cols:
-                st.error("No numeric column found in index CSV")
-                return
-            # Ensure a plain pandas Series for type-checker
-            index_series = pd.Series(idx_df[num_cols[0]].dropna().to_numpy())
+            if idx_file is not None:
+                idx_df = _read_csv(idx_file)
+                # Use first numeric column as index series
+                num_cols = [
+                    c for c in idx_df.columns if pd.api.types.is_numeric_dtype(idx_df[c])
+                ]
+                if not num_cols:
+                    st.error("No numeric column found in index CSV")
+                    return
+                # Ensure a plain pandas Series for type-checker
+                index_series = pd.Series(idx_df[num_cols[0]].dropna().to_numpy())
+            else:
+                index_series = load_bundled_sample_index()
 
             base_cfg = ModelConfig.model_validate(
                 {

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -19,6 +19,7 @@ from dashboard.utils import (
     config_capital_defaults,
     current_index_returns,
     current_scenario_config,
+    load_bundled_sample_index,
 )
 from pa_core.config import ModelConfig
 from pa_core.orchestrator import SimulatorOrchestrator
@@ -72,8 +73,16 @@ def main() -> None:
     idx_file = st.file_uploader(
         "Index returns CSV (single numeric column)", type=["csv"], key="stress_idx"
     )
-    if idx_file is None and session_index is None:
-        st.info("Provide index CSV to simulate.")
+    use_sample = st.checkbox(
+        "Use bundled sample data (no upload needed)",
+        value=False,
+        key="stress_use_sample",
+        help="Loads the bundled S&P 500 TR / FRED dividend-yield series for a one-click demo.",
+    )
+    if idx_file is None and not use_sample and session_index is None:
+        st.info(
+            "Upload an index CSV, tick 'Use bundled sample data', or run a scenario first to simulate."
+        )
         return
 
     seed = st.number_input("Random seed", value=42, step=1)
@@ -148,9 +157,16 @@ def main() -> None:
 
     if st.button("Run stress test"):
         try:
-            index_series = _read_index_csv(idx_file) if idx_file is not None else session_index
+            if idx_file is not None:
+                index_series = _read_index_csv(idx_file)
+            elif use_sample:
+                index_series = load_bundled_sample_index()
+            else:
+                index_series = session_index
             if index_series is None:
-                raise ValueError("Provide index CSV to simulate.")
+                raise ValueError(
+                    "Provide an index CSV, enable bundled sample data, or run a scenario first."
+                )
 
             base_cfg = ModelConfig.model_validate(
                 {

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -76,6 +76,42 @@ def config_capital_defaults(config: ModelConfig | None) -> dict[str, float]:
     }
 
 
+# Bundled index-returns dataset shipped with the repo so first-run users can run
+# an end-to-end example without uploading their own file (see issue #1900).
+SAMPLE_INDEX_FILENAME = "sp500tr_fred_divyield.csv"
+
+
+def bundled_sample_index_path() -> Path:
+    """Return the path to the bundled sample index-returns CSV.
+
+    The file lives in the repository ``data/`` directory and is the same series
+    referenced by the README onboarding ("upload sample and run"). Returning a
+    path (rather than reading eagerly) keeps callers free to stream it into a
+    download button or read it lazily only when the user opts in.
+    """
+    return Path(__file__).resolve().parents[1] / "data" / SAMPLE_INDEX_FILENAME
+
+
+def load_bundled_sample_index() -> pd.Series:
+    """Return the bundled sample index returns as a numeric ``pd.Series``.
+
+    Mirrors the per-page CSV readers: the first numeric column is used as the
+    index-returns series, with non-numeric/NaN values dropped. Raises
+    ``FileNotFoundError`` if the bundled dataset is missing and ``ValueError``
+    if it contains no numeric column.
+    """
+    path = bundled_sample_index_path()
+    if not path.exists():
+        raise FileNotFoundError(f"Bundled sample dataset not found at {path}")
+    df = pd.read_csv(path)
+    num_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
+    if not num_cols:
+        raise ValueError(
+            f"Bundled sample dataset {path.name} has no numeric column to use as index returns."
+        )
+    return pd.Series(df[num_cols[0]].dropna().to_numpy())
+
+
 def build_alpha_shares_payload(
     active_share: float | None, theta_extpa: float | None
 ) -> dict[str, float] | None:
@@ -224,4 +260,7 @@ __all__ = [
     "apply_promoted_alpha_shares",
     "run_sleeve_suggestions",
     "run_sleeve_frontier",
+    "SAMPLE_INDEX_FILENAME",
+    "bundled_sample_index_path",
+    "load_bundled_sample_index",
 ]

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from importlib import resources
 from collections.abc import MutableMapping
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,7 @@ from typing import Any
 import pandas as pd
 
 from pa_core.config import ModelConfig, normalize_share
+from pa_core.data import load_index_returns
 from pa_core.sleeve_suggestor import generate_sleeve_frontier, suggest_sleeve_sizes
 
 # Keep dashboard normalization aligned with core config behavior.
@@ -84,32 +86,24 @@ SAMPLE_INDEX_FILENAME = "sp500tr_fred_divyield.csv"
 def bundled_sample_index_path() -> Path:
     """Return the path to the bundled sample index-returns CSV.
 
-    The file lives in the repository ``data/`` directory and is the same series
-    referenced by the README onboarding ("upload sample and run"). Returning a
-    path (rather than reading eagerly) keeps callers free to stream it into a
-    download button or read it lazily only when the user opts in.
+    The file is shipped as package data so installed ``pa-dashboard`` users get
+    the same sample series as repo-checkout users. Returning a path keeps
+    callers free to stream it into a download button or read it lazily only when
+    the user opts in.
     """
-    return Path(__file__).resolve().parents[1] / "data" / SAMPLE_INDEX_FILENAME
+    resource = resources.files("data").joinpath(SAMPLE_INDEX_FILENAME)
+    with resources.as_file(resource) as path:
+        return path
 
 
 def load_bundled_sample_index() -> pd.Series:
     """Return the bundled sample index returns as a numeric ``pd.Series``.
 
-    Mirrors the per-page CSV readers: the first numeric column is used as the
-    index-returns series, with non-numeric/NaN values dropped. Raises
-    ``FileNotFoundError`` if the bundled dataset is missing and ``ValueError``
-    if it contains no numeric column.
+    Uses the core index-return loader so the one-click sample follows the same
+    ``Monthly_TR`` column and date-sorting rules as CLI and wizard simulations.
     """
     path = bundled_sample_index_path()
-    if not path.exists():
-        raise FileNotFoundError(f"Bundled sample dataset not found at {path}")
-    df = pd.read_csv(path)
-    num_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
-    if not num_cols:
-        raise ValueError(
-            f"Bundled sample dataset {path.name} has no numeric column to use as index returns."
-        )
-    return pd.Series(df[num_cols[0]].dropna().to_numpy())
+    return load_index_returns(path)
 
 
 def build_alpha_shares_payload(

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,1 @@
+"""Package data for bundled dashboard sample datasets."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,10 @@ markers = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["pa_core*", "archive*", "scripts*", "dashboard*"]
+include = ["pa_core*", "archive*", "scripts*", "dashboard*", "data*"]
+
+[tool.setuptools.package-data]
+data = ["*.csv"]
 
 [build-system]
 requires = ["setuptools>=82.0.1"]

--- a/tests/test_dashboard_sample_data.py
+++ b/tests/test_dashboard_sample_data.py
@@ -1,0 +1,52 @@
+"""Tests for the bundled sample-data onboarding affordance (issue #1900).
+
+The dashboard previously gated every data-driven page behind a file upload and
+never auto-surfaced the bundled ``data/sp500tr_fred_divyield.csv`` series, so a
+first-run user saw only empty placeholders. These tests cover the shared helper
+that exposes the bundled series and verify it runs end-to-end through the
+simulator, which is what the "Use bundled sample data" one-click affordance relies
+on.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from dashboard.utils import (
+    SAMPLE_INDEX_FILENAME,
+    bundled_sample_index_path,
+    load_bundled_sample_index,
+)
+from pa_core.config import ModelConfig
+from pa_core.orchestrator import SimulatorOrchestrator
+
+
+def test_bundled_sample_index_path_points_at_repo_data_file() -> None:
+    path = bundled_sample_index_path()
+    assert path.exists(), f"bundled sample dataset missing at {path}"
+    assert path.name == SAMPLE_INDEX_FILENAME
+    assert path.parent.name == "data"
+
+
+def test_load_bundled_sample_index_returns_non_empty_numeric_series() -> None:
+    series = load_bundled_sample_index()
+    assert isinstance(series, pd.Series)
+    assert len(series) > 0
+    assert pd.api.types.is_numeric_dtype(series)
+    assert not series.isna().any()
+
+
+def test_bundled_sample_runs_through_orchestrator_end_to_end() -> None:
+    """The bundled series must produce a real summary (the one-click demo claim)."""
+    index_series = load_bundled_sample_index()
+    cfg = ModelConfig.model_validate(
+        {
+            "Number of simulations": 100,
+            "Number of months": 12,
+            "financing_mode": "broadcast",
+        }
+    )
+    orch = SimulatorOrchestrator(cfg, index_series)
+    _, summary = orch.run(seed=42)
+    assert summary is not None
+    assert not summary.empty

--- a/tests/test_dashboard_sample_data.py
+++ b/tests/test_dashboard_sample_data.py
@@ -18,6 +18,7 @@ from dashboard.utils import (
     load_bundled_sample_index,
 )
 from pa_core.config import ModelConfig
+from pa_core.data import load_index_returns
 from pa_core.orchestrator import SimulatorOrchestrator
 
 
@@ -30,10 +31,12 @@ def test_bundled_sample_index_path_points_at_repo_data_file() -> None:
 
 def test_load_bundled_sample_index_returns_non_empty_numeric_series() -> None:
     series = load_bundled_sample_index()
+    expected = load_index_returns(bundled_sample_index_path())
     assert isinstance(series, pd.Series)
     assert len(series) > 0
     assert pd.api.types.is_numeric_dtype(series)
     assert not series.isna().any()
+    assert series.equals(expected)
 
 
 def test_bundled_sample_runs_through_orchestrator_end_to_end() -> None:


### PR DESCRIPTION
## Summary
Closes #1900.

First-run users (especially the non-technical target audience) previously saw mostly empty / upload-gated placeholders: every data-driven page required a file upload, and the bundled `data/sp500tr_fred_divyield.csv` series referenced by the README onboarding was never auto-surfaced.

This adds a one-click path to a runnable end-to-end example without an upload.

## Changes
- **`dashboard/utils.py`** — shared helpers `bundled_sample_index_path()` and `load_bundled_sample_index()` (first numeric column → `pd.Series`, mirroring the per-page CSV readers).
- **Stress Lab (`6_Stress_Lab.py`)** and **Scenario Grid (`5_Scenario_Grid.py`)** — a **"Use bundled sample data (no upload needed)"** checkbox; when ticked (and no file uploaded) the page runs on the bundled series.
- **Home page (`app.py`)** — a "New here? Try the bundled sample data" affordance that advertises the one-click option and offers the sample CSV as a download for users who prefer the explicit upload flow.
- **Tests (`tests/test_dashboard_sample_data.py`)** — helper coverage plus an end-to-end check that the bundled series produces a real summary through `SimulatorOrchestrator`.

## Validation
- `pytest tests/test_dashboard_sample_data.py tests/test_dashboard_utils.py tests/test_dashboard_pages.py tests/test_scenario_grid.py tests/test_stress_lab.py tests/test_dashboard.py tests/test_dashboard_app_helpers.py` → **30 passed**.
- `ruff check` clean on all changed files.

## Scope note
Scenario Wizard (`3_Scenario_Wizard.py`, ~2k lines) also has index uploaders but was intentionally left out of this bounded change to keep risk low; the shared `load_bundled_sample_index()` helper makes extending the same affordance there a small follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding and optional demo data paths only; simulation logic is unchanged aside from a new index input source. Packaging adds static CSV assets with no security-sensitive behavior.
> 
> **Overview**
> First-run users can run demos without uploading a CSV by opting into a **bundled S&P 500 TR / FRED dividend-yield** index series shipped with the package.
> 
> **`dashboard/utils`** adds `bundled_sample_index_path()` and `load_bundled_sample_index()`, resolving the CSV via `importlib.resources` and loading it through **`pa_core.data.load_index_returns`** so parsing matches CLI/wizard rules. **`pyproject.toml`** registers the new **`data`** package and includes `*.csv` as package data for installed builds.
> 
> **Stress Lab** and **Scenario Grid** gain a **“Use bundled sample data (no upload needed)”** checkbox; when no file is uploaded, sweeps and stress runs use the bundled series instead of blocking on upload. The **home page** adds an expanded **“New here?”** section that points users to those checkboxes and offers the sample CSV as a download.
> 
> **Tests** assert the bundled file exists, loads as a numeric series, and produces a non-empty summary through **`SimulatorOrchestrator`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a6dfdc5513394a1fac946f41d152e6cd6f8ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->