### PR TITLE
fix(dashboard): share wizard scenario session state (#1901)

### DIFF
--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -6,6 +6,7 @@ import math
 import os
 import re
 import tempfile
+import io
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -25,7 +26,7 @@ from dashboard.components.llm_settings import (
     resolve_llm_provider_config,
 )
 from dashboard.glossary import tooltip
-from dashboard.utils import run_sleeve_frontier, run_sleeve_suggestions
+from dashboard.utils import remember_current_scenario, run_sleeve_frontier, run_sleeve_suggestions
 from pa_core import cli as pa_cli
 from pa_core.backend import SUPPORTED_BACKENDS
 from pa_core.config import load_config
@@ -728,6 +729,15 @@ def _temp_yaml_file(data: Dict[str, Any]):
         yaml.safe_dump(data, tmp, default_flow_style=False)
         tmp.flush()  # Ensure data is written to disk
         yield tmp.name
+
+
+def _read_index_csv_bytes(data: bytes) -> pd.Series:
+    """Return the first numeric index-return column from uploaded CSV bytes."""
+    df = pd.read_csv(io.BytesIO(data))
+    num_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
+    if not num_cols:
+        raise ValueError("Index CSV must contain at least one numeric column.")
+    return pd.Series(df[num_cols[0]].dropna().to_numpy())
 
 
 def _render_progress_bar(current_step: int, total_steps: int = 5) -> None:
@@ -2080,13 +2090,17 @@ def main() -> None:
             if idx is not None:
                 # Convert config to YAML and run simulation
                 yaml_data = _build_yaml_from_config(config)
+                model_config = load_config(yaml_data)
                 with _temp_yaml_file(yaml_data) as cfg_path:
                     # Write index data to a secure temp file
                     fd, idx_path = tempfile.mkstemp(suffix=".csv")
                     sim_ok = False
+                    index_series: pd.Series | None = None
                     try:
                         os.close(fd)  # Close file descriptor before writing to path
-                        Path(idx_path).write_bytes(idx.getvalue())
+                        idx_bytes = idx.getvalue()
+                        Path(idx_path).write_bytes(idx_bytes)
+                        index_series = _read_index_csv_bytes(idx_bytes)
 
                         use_seed = st.session_state.get("wizard_use_seed", True)
                         seed_value = st.session_state.get("wizard_seed", 42)
@@ -2111,6 +2125,12 @@ def main() -> None:
                             pass
 
                     if sim_ok:
+                        remember_current_scenario(
+                            st.session_state,
+                            config=model_config,
+                            results_path=output,
+                            index_returns=index_series,
+                        )
                         st.success(f"✅ Simulation complete! Results written to {output}")
                         st.balloons()
 

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -6,7 +6,6 @@ import math
 import os
 import re
 import tempfile
-import io
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -732,12 +731,11 @@ def _temp_yaml_file(data: Dict[str, Any]):
 
 
 def _read_index_csv_bytes(data: bytes) -> pd.Series:
-    """Return the first numeric index-return column from uploaded CSV bytes."""
-    df = pd.read_csv(io.BytesIO(data))
-    num_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
-    if not num_cols:
-        raise ValueError("Index CSV must contain at least one numeric column.")
-    return pd.Series(df[num_cols[0]].dropna().to_numpy())
+    """Return index returns from uploaded CSV bytes using the core loader."""
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".csv") as tmp:
+        tmp.write(data)
+        tmp.flush()
+        return load_index_returns(tmp.name)
 
 
 def _render_progress_bar(current_step: int, total_steps: int = 5) -> None:

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -23,6 +23,7 @@ from dashboard.app import (
 from dashboard.components.comparison_llm import render_comparison_llm_panel
 from dashboard.components.explain_results import render_explain_results_panel
 from dashboard.glossary import tooltip
+from dashboard.utils import current_results_path
 from pa_core.contracts import (
     SUMMARY_BREACH_PROB_COLUMN,
     SUMMARY_CVAR_COLUMN,
@@ -176,9 +177,14 @@ def _render_comparison_panel(
     return availability
 
 
+def _default_results_path() -> str:
+    """Return the in-session wizard output path or the legacy default workbook."""
+    return current_results_path(st.session_state) or _DEF_XLSX
+
+
 def main() -> None:
     st.title("Results")
-    xlsx = st.sidebar.text_input("Results file", _DEF_XLSX)
+    xlsx = st.sidebar.text_input("Results file", _default_results_path())
     theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
     apply_theme(theme_path)
     if not Path(xlsx).exists():

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -15,6 +15,11 @@ import pandas as pd
 import streamlit as st
 
 from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.utils import (
+    config_capital_defaults,
+    current_index_returns,
+    current_scenario_config,
+)
 from pa_core.config import ModelConfig
 from pa_core.orchestrator import SimulatorOrchestrator
 from pa_core.reporting.constraints import build_constraint_report
@@ -60,11 +65,14 @@ def main() -> None:
     apply_theme(theme_path)
 
     st.markdown("Pick a preset, run base vs stressed with identical seeds, and review deltas.")
+    session_cfg = current_scenario_config(st.session_state)
+    session_index = current_index_returns(st.session_state)
+    capital_defaults = config_capital_defaults(session_cfg)
 
     idx_file = st.file_uploader(
         "Index returns CSV (single numeric column)", type=["csv"], key="stress_idx"
     )
-    if idx_file is None:
+    if idx_file is None and session_index is None:
         st.info("Provide index CSV to simulate.")
         return
 
@@ -72,30 +80,36 @@ def main() -> None:
 
     # Base configuration controls (minimal for now)
     st.sidebar.subheader("Base configuration")
-    n_sims = st.sidebar.number_input("Number of simulations", value=1000, step=100)
-    n_months = st.sidebar.number_input("Number of months", value=12, step=1)
+    n_sims_default = int(session_cfg.N_SIMULATIONS if session_cfg else 1000)
+    n_months_default = int(session_cfg.N_MONTHS if session_cfg else 12)
+    n_sims = st.sidebar.number_input("Number of simulations", value=n_sims_default, step=100)
+    n_months = st.sidebar.number_input("Number of months", value=n_months_default, step=1)
 
     # Capital breakout (kept simple but non-zero to activate agents)
     st.sidebar.markdown("---")
     st.sidebar.markdown("**Capital ($mm)**")
-    total_cap = st.sidebar.number_input("Total fund capital", value=1000.0, step=50.0)
+    total_cap = st.sidebar.number_input(
+        "Total fund capital",
+        value=capital_defaults["total_fund_capital"],
+        step=50.0,
+    )
     ext_cap = st.sidebar.number_input(
         "External PA capital",
-        value=200.0,
+        value=min(capital_defaults["external_pa_capital"], total_cap),
         step=10.0,
         min_value=0.0,
         max_value=total_cap,
     )
     act_cap = st.sidebar.number_input(
         "Active Extension capital",
-        value=200.0,
+        value=min(capital_defaults["active_ext_capital"], total_cap),
         step=10.0,
         min_value=0.0,
         max_value=total_cap,
     )
     int_cap = st.sidebar.number_input(
         "Internal PA capital",
-        value=200.0,
+        value=min(capital_defaults["internal_pa_capital"], total_cap),
         step=10.0,
         min_value=0.0,
         max_value=total_cap,
@@ -105,11 +119,15 @@ def main() -> None:
         "External PA alpha fraction θ",
         min_value=0.0,
         max_value=1.0,
-        value=0.5,
+        value=float(session_cfg.external_alpha_frac if session_cfg else 0.5),
         step=0.05,
     )
     active_share = st.sidebar.slider(
-        "Active share", min_value=0.0, max_value=1.0, value=0.5, step=0.05
+        "Active share",
+        min_value=0.0,
+        max_value=1.0,
+        value=float(session_cfg.active_share if session_cfg else 0.5),
+        step=0.05,
     )
 
     st.sidebar.markdown("---")
@@ -130,7 +148,9 @@ def main() -> None:
 
     if st.button("Run stress test"):
         try:
-            index_series = _read_index_csv(idx_file)
+            index_series = _read_index_csv(idx_file) if idx_file is not None else session_index
+            if index_series is None:
+                raise ValueError("Provide index CSV to simulate.")
 
             base_cfg = ModelConfig.model_validate(
                 {

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -119,7 +119,7 @@ def main() -> None:
         "External PA alpha fraction θ",
         min_value=0.0,
         max_value=1.0,
-        value=float(session_cfg.external_alpha_frac if session_cfg else 0.5),
+        value=float(session_cfg.theta_extpa if session_cfg else 0.5),
         step=0.05,
     )
     active_share = st.sidebar.slider(

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import MutableMapping
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -13,6 +14,66 @@ from pa_core.config import ModelConfig, normalize_share
 from pa_core.sleeve_suggestor import generate_sleeve_frontier, suggest_sleeve_sizes
 
 # Keep dashboard normalization aligned with core config behavior.
+
+CURRENT_SCENARIO_CONFIG_KEY = "dashboard_current_scenario_config"
+CURRENT_RESULTS_PATH_KEY = "dashboard_current_results_path"
+CURRENT_INDEX_RETURNS_KEY = "dashboard_current_index_returns"
+
+
+def remember_current_scenario(
+    state: MutableMapping[str, Any],
+    *,
+    config: ModelConfig,
+    results_path: str | Path | None = None,
+    index_returns: pd.Series | None = None,
+) -> None:
+    """Persist the latest runnable scenario in session state for other pages."""
+    state[CURRENT_SCENARIO_CONFIG_KEY] = config
+    if results_path is not None:
+        state[CURRENT_RESULTS_PATH_KEY] = str(results_path)
+    if index_returns is not None:
+        state[CURRENT_INDEX_RETURNS_KEY] = index_returns.copy()
+
+
+def current_scenario_config(state: MutableMapping[str, Any]) -> ModelConfig | None:
+    """Return the latest in-session scenario config when available."""
+    config = state.get(CURRENT_SCENARIO_CONFIG_KEY)
+    return config if isinstance(config, ModelConfig) else None
+
+
+def current_results_path(state: MutableMapping[str, Any]) -> str | None:
+    """Return the latest results workbook path remembered by the wizard."""
+    raw_path = state.get(CURRENT_RESULTS_PATH_KEY)
+    if isinstance(raw_path, Path):
+        return str(raw_path)
+    if isinstance(raw_path, str) and raw_path.strip():
+        return raw_path
+    return None
+
+
+def current_index_returns(state: MutableMapping[str, Any]) -> pd.Series | None:
+    """Return a copy of the latest uploaded index returns from session state."""
+    series = state.get(CURRENT_INDEX_RETURNS_KEY)
+    if isinstance(series, pd.Series):
+        return series.copy()
+    return None
+
+
+def config_capital_defaults(config: ModelConfig | None) -> dict[str, float]:
+    """Return Stress Lab-compatible capital defaults from a stored config."""
+    if config is None:
+        return {
+            "total_fund_capital": 1000.0,
+            "external_pa_capital": 200.0,
+            "active_ext_capital": 200.0,
+            "internal_pa_capital": 200.0,
+        }
+    return {
+        "total_fund_capital": float(config.total_fund_capital),
+        "external_pa_capital": float(config.external_pa_capital),
+        "active_ext_capital": float(config.active_ext_capital),
+        "internal_pa_capital": float(config.internal_pa_capital),
+    }
 
 
 def build_alpha_shares_payload(
@@ -149,6 +210,14 @@ def run_sleeve_frontier(
 
 __all__ = [
     "normalize_share",
+    "CURRENT_SCENARIO_CONFIG_KEY",
+    "CURRENT_RESULTS_PATH_KEY",
+    "CURRENT_INDEX_RETURNS_KEY",
+    "remember_current_scenario",
+    "current_scenario_config",
+    "current_results_path",
+    "current_index_returns",
+    "config_capital_defaults",
     "build_alpha_shares_payload",
     "make_grid_cache_key",
     "bump_session_token",

--- a/tests/test_dashboard_session_handoff.py
+++ b/tests/test_dashboard_session_handoff.py
@@ -26,7 +26,7 @@ def _model_config() -> ModelConfig:
             "active_ext_capital": 175.0,
             "internal_pa_capital": 500.0,
             "financing_mode": "broadcast",
-            "external_alpha_frac": 0.35,
+            "theta_extpa": 0.35,
             "active_share": 0.65,
             "risk_metrics": ["Return", "Risk", "terminal_ShortfallProb"],
         }
@@ -77,9 +77,11 @@ def test_results_default_path_uses_wizard_session_path() -> None:
         st.session_state.clear()
 
 
-def test_wizard_index_upload_bytes_select_first_numeric_column() -> None:
+def test_wizard_index_upload_bytes_uses_core_monthly_tr_loader() -> None:
     module = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
 
-    series = module["_read_index_csv_bytes"](b"date,returns,other\n2026-01,0.01,5\n2026-02,-0.02,6\n")
+    series = module["_read_index_csv_bytes"](
+        b"Date,Other,Monthly_TR\n2026-02-28,5,-0.02\n2026-01-31,6,0.01\n"
+    )
 
     assert series.tolist() == [0.01, -0.02]

--- a/tests/test_dashboard_session_handoff.py
+++ b/tests/test_dashboard_session_handoff.py
@@ -1,0 +1,85 @@
+import runpy
+
+import pandas as pd
+import streamlit as st
+
+from dashboard.utils import (
+    CURRENT_INDEX_RETURNS_KEY,
+    CURRENT_RESULTS_PATH_KEY,
+    CURRENT_SCENARIO_CONFIG_KEY,
+    config_capital_defaults,
+    current_index_returns,
+    current_results_path,
+    current_scenario_config,
+    remember_current_scenario,
+)
+from pa_core.config import ModelConfig
+
+
+def _model_config() -> ModelConfig:
+    return ModelConfig.model_validate(
+        {
+            "N_SIMULATIONS": 321,
+            "N_MONTHS": 18,
+            "total_fund_capital": 900.0,
+            "external_pa_capital": 225.0,
+            "active_ext_capital": 175.0,
+            "internal_pa_capital": 500.0,
+            "financing_mode": "broadcast",
+            "external_alpha_frac": 0.35,
+            "active_share": 0.65,
+            "risk_metrics": ["Return", "Risk", "terminal_ShortfallProb"],
+        }
+    )
+
+
+def test_remember_current_scenario_round_trips_session_values() -> None:
+    state = {}
+    config = _model_config()
+    index_returns = pd.Series([0.01, -0.02, 0.03])
+
+    remember_current_scenario(
+        state,
+        config=config,
+        results_path="runs/current/Outputs.xlsx",
+        index_returns=index_returns,
+    )
+
+    assert state[CURRENT_SCENARIO_CONFIG_KEY] is config
+    assert state[CURRENT_RESULTS_PATH_KEY] == "runs/current/Outputs.xlsx"
+    assert current_scenario_config(state) is config
+    assert current_results_path(state) == "runs/current/Outputs.xlsx"
+    assert current_index_returns(state).tolist() == [0.01, -0.02, 0.03]
+
+    state[CURRENT_INDEX_RETURNS_KEY].iloc[0] = 99.0
+    assert index_returns.iloc[0] == 0.01
+
+
+def test_capital_defaults_follow_current_config() -> None:
+    defaults = config_capital_defaults(_model_config())
+
+    assert defaults == {
+        "total_fund_capital": 900.0,
+        "external_pa_capital": 225.0,
+        "active_ext_capital": 175.0,
+        "internal_pa_capital": 500.0,
+    }
+
+
+def test_results_default_path_uses_wizard_session_path() -> None:
+    st.session_state.clear()
+    try:
+        module = runpy.run_path("dashboard/pages/4_Results.py")
+        st.session_state[CURRENT_RESULTS_PATH_KEY] = "/tmp/wizard-results.xlsx"
+
+        assert module["_default_results_path"]() == "/tmp/wizard-results.xlsx"
+    finally:
+        st.session_state.clear()
+
+
+def test_wizard_index_upload_bytes_select_first_numeric_column() -> None:
+    module = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
+
+    series = module["_read_index_csv_bytes"](b"date,returns,other\n2026-01,0.01,5\n2026-02,-0.02,6\n")
+
+    assert series.tolist() == [0.01, -0.02]


### PR DESCRIPTION
Closes #1901

## Summary
- Add a shared dashboard session-state contract for the latest runnable wizard scenario, results workbook path, and uploaded index returns.
- Record the current scenario after a successful wizard simulation so Results defaults to the generated workbook.
- Let Stress Lab reuse the current wizard config and index series as defaults while preserving upload/manual overrides.

## Tasks
- [x] Persist the wizard scenario configuration, uploaded index data, and latest simulation result in shared Streamlit session state.
- [x] Let downstream dashboard pages consume the in-session scenario/result before falling back to file-path handoff.
- [x] Keep explicit file import/export behavior available as a fallback instead of removing it.
- [x] Cover the wizard-to-results and wizard-to-stress-lab handoff with focused tests.

## Acceptance Criteria
- [x] A user can run the Scenario Wizard and continue to the Results page in the same browser session without downloading and re-uploading an intermediate workbook.
- [x] Stress Lab can reuse wizard-entered model configuration and uploaded index data when no new file is supplied.
- [x] Existing file-based workflows remain available as explicit fallback paths.
- [x] PR #1935 passed required Gate checks and review-thread disposition before merge.

## Validation
- `python -m pytest tests/test_dashboard_session_handoff.py tests/test_wizard_config_wiring.py tests/test_dashboard_explain_results.py tests/test_stress_lab.py -q`
- `python -m ruff check dashboard/utils.py dashboard/pages/3_Scenario_Wizard.py dashboard/pages/4_Results.py dashboard/pages/6_Stress_Lab.py tests/test_dashboard_session_handoff.py`