### PR TITLE
feat(dashboard): persist page handoff in session

### DIFF
--- a/dashboard/pages/1_Asset_Library.py
+++ b/dashboard/pages/1_Asset_Library.py
@@ -20,6 +20,7 @@ try:
 except Exception:  # pragma: no cover - conservative fallback
     _BARE_MODE = True
 from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.utils import store_dashboard_asset_library
 from pa_core.presets import AlphaPreset, PresetLibrary
 
 # Create logger for this module
@@ -193,6 +194,12 @@ def main() -> None:
             try:
                 calib.to_yaml(result, ypath)
                 yaml_str = Path(ypath).read_text()
+                store_dashboard_asset_library(
+                    st.session_state,
+                    yaml_str,
+                    source_name=uploaded.name,
+                )
+                st.success("Asset library saved for Portfolio Builder in this session.")
                 st.download_button(
                     "Download Asset Library YAML",
                     yaml_str,

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -8,7 +8,12 @@ import streamlit as st
 import yaml
 
 from dashboard.app import _DEF_THEME, apply_theme
-from dashboard.utils import apply_promoted_alpha_shares, normalize_share
+from dashboard.utils import (
+    apply_promoted_alpha_shares,
+    get_dashboard_asset_library_yaml,
+    normalize_share,
+    store_dashboard_portfolio,
+)
 from pa_core.portfolio import PortfolioAggregator
 from pa_core.schema import Portfolio, load_scenario
 
@@ -77,12 +82,18 @@ def main() -> None:
         )
 
     uploaded = st.file_uploader("Upload Asset Library YAML", type=["yaml", "yml"])
-    if uploaded is None:
+    session_asset_yaml = get_dashboard_asset_library_yaml(st.session_state)
+    if uploaded is None and session_asset_yaml is None:
         st.info("Upload an asset library YAML to begin.")
         return
+    if uploaded is None and session_asset_yaml is not None:
+        st.info("Using the Asset Library YAML saved in this session.")
 
     with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp:
-        tmp.write(uploaded.getvalue())
+        if uploaded is not None:
+            tmp.write(uploaded.getvalue())
+        elif session_asset_yaml is not None:
+            tmp.write(session_asset_yaml.encode("utf-8"))
         tmp.flush()  # Ensure data is written to disk
         scenario = load_scenario(tmp.name)
 
@@ -119,6 +130,12 @@ def main() -> None:
                 "theta_extpa": float(theta_extpa_input),
             }
             yaml_str = yaml.safe_dump(data, sort_keys=False)
+            store_dashboard_portfolio(
+                st.session_state,
+                yaml_str,
+                source_name=(uploaded.name if uploaded is not None else "session asset library"),
+            )
+            st.success("Portfolio YAML saved for this session.")
             st.download_button(
                 "Download Portfolio YAML",
                 yaml_str,

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -25,7 +25,12 @@ from dashboard.components.llm_settings import (
     resolve_llm_provider_config,
 )
 from dashboard.glossary import tooltip
-from dashboard.utils import run_sleeve_frontier, run_sleeve_suggestions
+from dashboard.utils import (
+    run_sleeve_frontier,
+    run_sleeve_suggestions,
+    store_dashboard_result,
+    store_dashboard_scenario,
+)
 from pa_core import cli as pa_cli
 from pa_core.backend import SUPPORTED_BACKENDS
 from pa_core.config import load_config
@@ -2111,7 +2116,21 @@ def main() -> None:
                             pass
 
                     if sim_ok:
+                        scenario_payload = store_dashboard_scenario(
+                            st.session_state,
+                            config,
+                            source="scenario_wizard",
+                            yaml_data=yaml_data,
+                        )
+                        store_dashboard_result(
+                            st.session_state,
+                            output,
+                            source="scenario_wizard",
+                            scenario=scenario_payload,
+                            seed=int(seed_value) if use_seed else None,
+                        )
                         st.success(f"✅ Simulation complete! Results written to {output}")
+                        st.page_link("pages/4_Results.py", label="Open Results")
                         st.balloons()
 
                         # Show quick margin summary using current financing settings if available

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -23,6 +23,7 @@ from dashboard.app import (
 from dashboard.components.comparison_llm import render_comparison_llm_panel
 from dashboard.components.explain_results import render_explain_results_panel
 from dashboard.glossary import tooltip
+from dashboard.utils import DASHBOARD_RESULT_KEY, get_dashboard_result_path
 from pa_core.contracts import (
     SUMMARY_BREACH_PROB_COLUMN,
     SUMMARY_CVAR_COLUMN,
@@ -178,7 +179,15 @@ def _render_comparison_panel(
 
 def main() -> None:
     st.title("Results")
-    xlsx = st.sidebar.text_input("Results file", _DEF_XLSX)
+    result_default = get_dashboard_result_path(st.session_state, _DEF_XLSX)
+    xlsx = st.sidebar.text_input("Results file", result_default)
+    active_result = st.session_state.get(DASHBOARD_RESULT_KEY)
+    if (
+        isinstance(active_result, dict)
+        and isinstance(active_result.get("output_path"), str)
+        and active_result["output_path"] == xlsx
+    ):
+        st.sidebar.caption(f"In-session result from {active_result.get('source', 'dashboard')}.")
     theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
     apply_theme(theme_path)
     if not Path(xlsx).exists():

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -15,6 +15,7 @@ import pandas as pd
 import streamlit as st
 
 from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.utils import get_dashboard_capital_defaults
 from pa_core.config import ModelConfig
 from pa_core.orchestrator import SimulatorOrchestrator
 from pa_core.reporting.constraints import build_constraint_report
@@ -78,24 +79,29 @@ def main() -> None:
     # Capital breakout (kept simple but non-zero to activate agents)
     st.sidebar.markdown("---")
     st.sidebar.markdown("**Capital ($mm)**")
-    total_cap = st.sidebar.number_input("Total fund capital", value=1000.0, step=50.0)
+    capital_defaults = get_dashboard_capital_defaults(st.session_state)
+    total_cap = st.sidebar.number_input(
+        "Total fund capital",
+        value=float(capital_defaults["total_fund_capital"]),
+        step=50.0,
+    )
     ext_cap = st.sidebar.number_input(
         "External PA capital",
-        value=200.0,
+        value=min(float(capital_defaults["external_pa_capital"]), float(total_cap)),
         step=10.0,
         min_value=0.0,
         max_value=total_cap,
     )
     act_cap = st.sidebar.number_input(
         "Active Extension capital",
-        value=200.0,
+        value=min(float(capital_defaults["active_ext_capital"]), float(total_cap)),
         step=10.0,
         min_value=0.0,
         max_value=total_cap,
     )
     int_cap = st.sidebar.number_input(
         "Internal PA capital",
-        value=200.0,
+        value=min(float(capital_defaults["internal_pa_capital"]), float(total_cap)),
         step=10.0,
         min_value=0.0,
         max_value=total_cap,

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime, timezone
 from collections.abc import MutableMapping
 from typing import Any
 
@@ -13,6 +14,187 @@ from pa_core.config import ModelConfig, normalize_share
 from pa_core.sleeve_suggestor import generate_sleeve_frontier, suggest_sleeve_sizes
 
 # Keep dashboard normalization aligned with core config behavior.
+
+DASHBOARD_ASSET_LIBRARY_KEY = "dashboard_asset_library_yaml"
+DASHBOARD_PORTFOLIO_KEY = "dashboard_portfolio_yaml"
+DASHBOARD_SCENARIO_KEY = "dashboard_active_scenario"
+DASHBOARD_RESULT_KEY = "dashboard_active_result"
+
+_CAPITAL_DEFAULTS = {
+    "total_fund_capital": 1000.0,
+    "external_pa_capital": 200.0,
+    "active_ext_capital": 200.0,
+    "internal_pa_capital": 200.0,
+}
+
+_SCENARIO_VALUE_FIELDS = (
+    "analysis_mode",
+    "n_simulations",
+    "n_months",
+    "total_fund_capital",
+    "external_pa_capital",
+    "active_ext_capital",
+    "internal_pa_capital",
+    "theta_extpa",
+    "active_share",
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _config_value(config: Any, field: str) -> Any:
+    if isinstance(config, dict):
+        if field in config:
+            return config[field]
+        upper_field = field.upper()
+        if upper_field in config:
+            return config[upper_field]
+    value = getattr(config, field, None)
+    if hasattr(value, "value"):
+        return value.value
+    return value
+
+
+def _coerce_float(value: Any, fallback: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(fallback)
+
+
+def build_dashboard_scenario_payload(
+    config: Any,
+    *,
+    source: str,
+    yaml_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the shared in-session scenario payload used by dashboard pages."""
+    values = {
+        field: _config_value(config, field)
+        for field in _SCENARIO_VALUE_FIELDS
+        if _config_value(config, field) is not None
+    }
+    return {
+        "source": source,
+        "updated_at": _now_iso(),
+        "values": values,
+        "yaml_data": dict(yaml_data or {}),
+    }
+
+
+def store_dashboard_scenario(
+    state: MutableMapping[str, Any],
+    config: Any,
+    *,
+    source: str,
+    yaml_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Store the latest scenario in Streamlit session state."""
+    payload = build_dashboard_scenario_payload(config, source=source, yaml_data=yaml_data)
+    state[DASHBOARD_SCENARIO_KEY] = payload
+    return payload
+
+
+def store_dashboard_result(
+    state: MutableMapping[str, Any],
+    output_path: str,
+    *,
+    source: str,
+    scenario: dict[str, Any] | None = None,
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Store the latest generated workbook path in Streamlit session state."""
+    payload: dict[str, Any] = {
+        "source": source,
+        "updated_at": _now_iso(),
+        "output_path": str(output_path),
+    }
+    if scenario is not None:
+        payload["scenario"] = scenario
+    if seed is not None:
+        payload["seed"] = int(seed)
+    state[DASHBOARD_RESULT_KEY] = payload
+    return payload
+
+
+def get_dashboard_result_path(state: MutableMapping[str, Any], default: str) -> str:
+    """Return the most recent in-session result workbook path, if present."""
+    result = state.get(DASHBOARD_RESULT_KEY)
+    if isinstance(result, dict):
+        output_path = result.get("output_path")
+        if isinstance(output_path, str) and output_path.strip():
+            return output_path
+    return default
+
+
+def get_dashboard_capital_defaults(
+    state: MutableMapping[str, Any],
+    fallback: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Return capital defaults from the current session scenario/result."""
+    defaults = dict(_CAPITAL_DEFAULTS)
+    if fallback:
+        defaults.update(fallback)
+
+    scenario = state.get(DASHBOARD_SCENARIO_KEY)
+    result = state.get(DASHBOARD_RESULT_KEY)
+    if not isinstance(scenario, dict) and isinstance(result, dict):
+        maybe_scenario = result.get("scenario")
+        if isinstance(maybe_scenario, dict):
+            scenario = maybe_scenario
+
+    values = scenario.get("values") if isinstance(scenario, dict) else None
+    if not isinstance(values, dict):
+        return defaults
+
+    return {
+        key: _coerce_float(values.get(key), default_value)
+        for key, default_value in defaults.items()
+    }
+
+
+def store_dashboard_asset_library(
+    state: MutableMapping[str, Any],
+    yaml_text: str,
+    *,
+    source_name: str | None = None,
+) -> dict[str, Any]:
+    """Store calibrated asset-library YAML for Portfolio Builder handoff."""
+    payload = {
+        "source": "asset_library",
+        "source_name": source_name,
+        "updated_at": _now_iso(),
+        "yaml": yaml_text,
+    }
+    state[DASHBOARD_ASSET_LIBRARY_KEY] = payload
+    return payload
+
+
+def get_dashboard_asset_library_yaml(state: MutableMapping[str, Any]) -> str | None:
+    payload = state.get(DASHBOARD_ASSET_LIBRARY_KEY)
+    if not isinstance(payload, dict):
+        return None
+    yaml_text = payload.get("yaml")
+    return yaml_text if isinstance(yaml_text, str) and yaml_text.strip() else None
+
+
+def store_dashboard_portfolio(
+    state: MutableMapping[str, Any],
+    yaml_text: str,
+    *,
+    source_name: str | None = None,
+) -> dict[str, Any]:
+    """Store generated portfolio YAML so file export is not the only handoff."""
+    payload = {
+        "source": "portfolio_builder",
+        "source_name": source_name,
+        "updated_at": _now_iso(),
+        "yaml": yaml_text,
+    }
+    state[DASHBOARD_PORTFOLIO_KEY] = payload
+    return payload
 
 
 def build_alpha_shares_payload(
@@ -149,6 +331,18 @@ def run_sleeve_frontier(
 
 __all__ = [
     "normalize_share",
+    "DASHBOARD_ASSET_LIBRARY_KEY",
+    "DASHBOARD_PORTFOLIO_KEY",
+    "DASHBOARD_SCENARIO_KEY",
+    "DASHBOARD_RESULT_KEY",
+    "build_dashboard_scenario_payload",
+    "store_dashboard_scenario",
+    "store_dashboard_result",
+    "get_dashboard_result_path",
+    "get_dashboard_capital_defaults",
+    "store_dashboard_asset_library",
+    "get_dashboard_asset_library_yaml",
+    "store_dashboard_portfolio",
     "build_alpha_shares_payload",
     "make_grid_cache_key",
     "bump_session_token",

--- a/tests/test_dashboard_session_handoff.py
+++ b/tests/test_dashboard_session_handoff.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dashboard.utils import (
+    DASHBOARD_ASSET_LIBRARY_KEY,
+    DASHBOARD_PORTFOLIO_KEY,
+    DASHBOARD_RESULT_KEY,
+    DASHBOARD_SCENARIO_KEY,
+    get_dashboard_asset_library_yaml,
+    get_dashboard_capital_defaults,
+    get_dashboard_result_path,
+    store_dashboard_asset_library,
+    store_dashboard_portfolio,
+    store_dashboard_result,
+    store_dashboard_scenario,
+)
+from pa_core.wizard_schema import AnalysisMode, get_default_config
+
+
+def test_wizard_result_path_defaults_results_page_to_latest_session_output() -> None:
+    state: dict[str, object] = {}
+    config = get_default_config(AnalysisMode.RETURNS)
+    config.total_fund_capital = 750.0
+    config.external_pa_capital = 125.0
+    config.active_ext_capital = 175.0
+    config.internal_pa_capital = 450.0
+
+    scenario = store_dashboard_scenario(
+        state,
+        config,
+        source="scenario_wizard",
+        yaml_data={"total_fund_capital": 750.0},
+    )
+    result = store_dashboard_result(
+        state,
+        "ScenarioRun.xlsx",
+        source="scenario_wizard",
+        scenario=scenario,
+        seed=123,
+    )
+
+    assert state[DASHBOARD_SCENARIO_KEY] == scenario
+    assert state[DASHBOARD_RESULT_KEY] == result
+    assert get_dashboard_result_path(state, "Outputs.xlsx") == "ScenarioRun.xlsx"
+    assert result["seed"] == 123
+
+
+def test_stress_lab_capital_defaults_reuse_latest_scenario_values() -> None:
+    state: dict[str, object] = {}
+    config = get_default_config(AnalysisMode.RETURNS)
+    config.total_fund_capital = 900.0
+    config.external_pa_capital = 100.0
+    config.active_ext_capital = 250.0
+    config.internal_pa_capital = 550.0
+
+    store_dashboard_scenario(state, config, source="scenario_wizard")
+
+    assert get_dashboard_capital_defaults(state) == {
+        "total_fund_capital": 900.0,
+        "external_pa_capital": 100.0,
+        "active_ext_capital": 250.0,
+        "internal_pa_capital": 550.0,
+    }
+
+
+def test_capital_defaults_can_fall_back_to_result_embedded_scenario() -> None:
+    state: dict[str, object] = {}
+    scenario = {
+        "values": {
+            "total_fund_capital": "600",
+            "external_pa_capital": "120",
+            "active_ext_capital": "80",
+            "internal_pa_capital": "400",
+        }
+    }
+
+    store_dashboard_result(
+        state,
+        "Results.xlsx",
+        source="scenario_wizard",
+        scenario=scenario,
+    )
+    state.pop(DASHBOARD_SCENARIO_KEY, None)
+
+    assert get_dashboard_capital_defaults(state)["total_fund_capital"] == 600.0
+    assert get_dashboard_capital_defaults(state)["internal_pa_capital"] == 400.0
+
+
+def test_asset_library_and_portfolio_yaml_are_available_without_download_roundtrip() -> None:
+    state: dict[str, object] = {}
+
+    asset_payload = store_dashboard_asset_library(
+        state,
+        "assets:\n  - id: Index\n",
+        source_name="uploaded.csv",
+    )
+    portfolio_payload = store_dashboard_portfolio(
+        state,
+        "portfolios:\n  - id: portfolio1\n",
+        source_name="session asset library",
+    )
+
+    assert state[DASHBOARD_ASSET_LIBRARY_KEY] == asset_payload
+    assert state[DASHBOARD_PORTFOLIO_KEY] == portfolio_payload
+    assert get_dashboard_asset_library_yaml(state) == "assets:\n  - id: Index\n"


### PR DESCRIPTION
Closes #1901

## Summary
- add a shared dashboard session handoff payload for asset libraries, portfolios, scenarios, and result workbooks
- let Portfolio Builder consume the Asset Library session YAML and store generated portfolio YAML without requiring a download/upload roundtrip
- record successful Scenario Wizard runs so Results opens the generated workbook by default and Stress Lab reuses the wizard capital allocation

## Validation
- UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_dashboard_session_handoff.py tests/test_dashboard_results_previous_run.py tests/test_stress_lab.py tests/test_wizard_helpers.py tests/test_dashboard_pages.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check dashboard/utils.py dashboard/pages/1_Asset_Library.py dashboard/pages/2_Portfolio_Builder.py dashboard/pages/3_Scenario_Wizard.py dashboard/pages/4_Results.py dashboard/pages/6_Stress_Lab.py tests/test_dashboard_session_handoff.py

## Notes
- File exports remain available; session state is now the primary cross-page handoff inside one Streamlit session.
- Local validation regenerated uv.lock in the worktree, but that resolver noise was intentionally left uncommitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to dashboard UX and session helpers with tests; no auth, persistence, or simulation core logic changes.
> 
> **Overview**
> Adds shared **Streamlit session-state handoff** in `dashboard/utils.py` for asset-library YAML, portfolio YAML, active scenario snapshots, and the latest results workbook path (with optional embedded scenario and seed).
> 
> **Asset Library** saves calibrated YAML into the session after calibration; **Portfolio Builder** can load that YAML without re-uploading and persists generated portfolio YAML on build. **Scenario Wizard** records scenario + result after a successful run and links to Results. **Results** defaults the workbook path from the in-session result and shows a sidebar caption when it matches. **Stress Lab** pre-fills capital fields from the wizard scenario (or scenario embedded on the stored result).
> 
> New unit tests in `tests/test_dashboard_session_handoff.py` cover result-path defaulting, capital reuse/fallback, and YAML store/retrieve. File downloads remain; session state is the primary in-session cross-page path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a8ffe02a4eff0c63fb0c8a831183f86386b00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->