### PR TITLE
fix(dashboard): tuck file-path internals into Advanced/Settings expander (#1902)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -27,6 +27,30 @@ _DEF_XLSX = DEFAULT_OUTPUT_FILENAME
 _DEF_THEME = "config_theme.yaml"
 _PARQUET_HINT = "Parquet support missing; install pyarrow or use CSV."
 
+ADVANCED_SETTINGS_LABEL = "Advanced / Settings"
+
+
+def render_settings_sidebar(results_default: str | None = None) -> tuple[str | None, str]:
+    """Render file-path internals inside a collapsed sidebar expander.
+
+    The theme-file path (and, on the Results page, the results workbook path)
+    are configuration internals that previously sat as raw text inputs at the
+    top of every page's sidebar. Tucking them inside a collapsed
+    ``"Advanced / Settings"`` expander keeps the default sidebar focused on the
+    user's workflow while leaving the controls available for power users.
+
+    Returns ``(results_path, theme_path)``. When ``results_default`` is ``None``
+    the results input is omitted and the returned results path is ``None``.
+    """
+    with st.sidebar.expander(ADVANCED_SETTINGS_LABEL, expanded=False):
+        results_path = (
+            st.text_input("Results file", results_default)
+            if results_default is not None
+            else None
+        )
+        theme_path = st.text_input("Theme file", _DEF_THEME)
+    return results_path, theme_path
+
 
 def _cache_data(ttl: int):
     """Fallback wrapper when Streamlit cache decorators are unavailable."""
@@ -174,6 +198,16 @@ def load_history(parquet: str = "Outputs.parquet") -> pd.DataFrame | None:
 
 def main() -> None:
     """Render the dashboard home page."""
+
+    # Give the home page a real browser/page title instead of the Streamlit
+    # default derived from the entry-point filename ("app").
+    try:
+        st.set_page_config(page_title="Portable Alpha Dashboard", page_icon="📈")
+    except Exception:
+        # set_page_config raises if called more than once per session (e.g. on
+        # a Streamlit rerun) or when unavailable in bare/test mode; the title is
+        # cosmetic, so a repeat call must not break the page.
+        pass
 
     st.title("Portable Alpha Dashboard")
     st.write("Select a page from the sidebar or use the links below to begin.")

--- a/dashboard/pages/1_Asset_Library.py
+++ b/dashboard/pages/1_Asset_Library.py
@@ -19,7 +19,7 @@ try:
     _BARE_MODE = get_script_run_ctx() is None
 except Exception:  # pragma: no cover - conservative fallback
     _BARE_MODE = True
-from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.app import apply_theme, render_settings_sidebar
 from pa_core.presets import AlphaPreset, PresetLibrary
 
 # Create logger for this module
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     st.title("Asset Library")
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    _, theme_path = render_settings_sidebar()
     apply_theme(theme_path)
     st.markdown("**Upload asset return data**")
     st.caption("Drag and drop a CSV or Excel file, or click to browse.")

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -7,7 +7,7 @@ import tempfile
 import streamlit as st
 import yaml
 
-from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.app import apply_theme, render_settings_sidebar
 from dashboard.utils import apply_promoted_alpha_shares, normalize_share
 from pa_core.portfolio import PortfolioAggregator
 from pa_core.schema import Portfolio, load_scenario
@@ -15,7 +15,7 @@ from pa_core.schema import Portfolio, load_scenario
 
 def main() -> None:
     st.title("Portfolio Builder")
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    _, theme_path = render_settings_sidebar()
     apply_theme(theme_path)
 
     # Show any promoted alpha shares from Scenario Grid

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -17,7 +17,7 @@ import streamlit as st
 import yaml
 
 from dashboard import cli as dashboard_cli
-from dashboard.app import _DEF_THEME, _DEF_XLSX, apply_theme
+from dashboard.app import _DEF_XLSX, apply_theme, render_settings_sidebar
 from dashboard.components.config_chat import render_config_chat_panel
 from dashboard.components.llm_settings import (
     default_api_key,
@@ -1959,7 +1959,7 @@ def main() -> None:
         st.session_state.wizard_config = get_default_config(AnalysisMode.RETURNS)
 
     # Theme and validation settings in sidebar
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    _, theme_path = render_settings_sidebar()
     apply_theme(theme_path)
 
     st.sidebar.markdown("---")

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -13,12 +13,12 @@ import pandas as pd
 import streamlit as st
 
 from dashboard.app import (
-    _DEF_THEME,
     _DEF_XLSX,
     PLOTS,
     _get_plot_fn,
     apply_theme,
     load_data,
+    render_settings_sidebar,
 )
 from dashboard.components.comparison_llm import render_comparison_llm_panel
 from dashboard.components.explain_results import render_explain_results_panel
@@ -184,8 +184,7 @@ def _default_results_path() -> str:
 
 def main() -> None:
     st.title("Results")
-    xlsx = st.sidebar.text_input("Results file", _default_results_path())
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    xlsx, theme_path = render_settings_sidebar(_default_results_path())
     apply_theme(theme_path)
     if not Path(xlsx).exists():
         st.warning(f"File {xlsx} not found")

--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -12,7 +12,7 @@ import pandas as pd  # type: ignore[reportMissingImports]
 import streamlit as st
 import yaml
 
-from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.app import apply_theme, render_settings_sidebar
 from dashboard.utils import (
     build_alpha_shares_payload,
     bump_session_token,
@@ -125,7 +125,7 @@ def _extract_plotly_click(selection) -> tuple[float, float] | None:
 
 def main() -> None:
     st.title("Scenario Grid & Frontier (beta)")
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    _, theme_path = render_settings_sidebar()
     apply_theme(theme_path)
 
     tab1, tab2 = st.tabs(["Upload Grid CSV", "Compute from Config"])

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -14,7 +14,7 @@ from typing import cast
 import pandas as pd
 import streamlit as st
 
-from dashboard.app import _DEF_THEME, apply_theme
+from dashboard.app import apply_theme, render_settings_sidebar
 from dashboard.utils import (
     config_capital_defaults,
     current_index_returns,
@@ -61,7 +61,7 @@ def _config_diff(base: ModelConfig, stressed: ModelConfig) -> pd.DataFrame:
 
 def main() -> None:
     st.title("Stress Lab (presets)")
-    theme_path = st.sidebar.text_input("Theme file", _DEF_THEME)
+    _, theme_path = render_settings_sidebar()
     apply_theme(theme_path)
 
     st.markdown("Pick a preset, run base vs stressed with identical seeds, and review deltas.")

--- a/tests/test_dashboard_advanced_settings.py
+++ b/tests/test_dashboard_advanced_settings.py
@@ -1,0 +1,116 @@
+"""Tests for the sidebar 'Advanced / Settings' expander (issue #1902).
+
+The theme-file and results-file path inputs used to sit as bare
+``st.sidebar.text_input`` widgets at the top of every page. They are now
+tucked inside a collapsed ``"Advanced / Settings"`` sidebar expander, and the
+home page sets a real page title instead of the Streamlit default ("app").
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import dashboard.app as app
+
+
+class _FakeExpander:
+    def __init__(self, st: "FakeStreamlit", label: str) -> None:
+        self._st = st
+        self._label = label
+
+    def __enter__(self) -> "_FakeExpander":
+        self._st.container_stack.append(f"expander:{self._label}")
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        self._st.container_stack.pop()
+        return False
+
+
+class _FakeSidebar:
+    def __init__(self, st: "FakeStreamlit") -> None:
+        self._st = st
+
+    def expander(self, label: str, expanded: bool = False) -> _FakeExpander:
+        self._st.events.append(("sidebar.expander", label, expanded))
+        return _FakeExpander(self._st, label)
+
+    def text_input(self, label: str, value: str = "") -> str:
+        # A bare sidebar text input -- the regression we are guarding against.
+        self._st.events.append(("sidebar.text_input", label, tuple(self._st.container_stack)))
+        return value
+
+    def markdown(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def subheader(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class FakeStreamlit:
+    def __init__(self) -> None:
+        self.events: list[tuple[Any, ...]] = []
+        self.container_stack: list[str] = []
+        self.session_state: dict[str, Any] = {}
+        self.sidebar = _FakeSidebar(self)
+
+    def text_input(self, label: str, value: str = "") -> str:
+        self.events.append(("text_input", label, tuple(self.container_stack)))
+        return value
+
+    def set_page_config(self, **kwargs: Any) -> None:
+        self.events.append(("set_page_config", kwargs))
+
+    def __getattr__(self, _name: str):  # no-op for title/write/page_link/etc.
+        def _noop(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        return _noop
+
+
+@pytest.fixture()
+def fake_st(monkeypatch: pytest.MonkeyPatch) -> FakeStreamlit:
+    fake = FakeStreamlit()
+    monkeypatch.setattr(app, "st", fake)
+    return fake
+
+
+def test_theme_input_lives_inside_advanced_expander(fake_st: FakeStreamlit) -> None:
+    results, theme = app.render_settings_sidebar()
+
+    assert results is None
+    assert theme == app._DEF_THEME
+
+    # The expander is rendered in the sidebar, collapsed by default.
+    assert ("sidebar.expander", app.ADVANCED_SETTINGS_LABEL, False) in fake_st.events
+
+    # The theme input is a text input nested inside that expander, not a bare
+    # sidebar widget.
+    theme_inputs = [e for e in fake_st.events if e[0] == "text_input" and e[1] == "Theme file"]
+    assert len(theme_inputs) == 1
+    assert theme_inputs[0][2] == (f"expander:{app.ADVANCED_SETTINGS_LABEL}",)
+    assert not [e for e in fake_st.events if e[0] == "sidebar.text_input"]
+
+
+def test_results_input_included_when_default_given(fake_st: FakeStreamlit) -> None:
+    results, theme = app.render_settings_sidebar("Outputs.xlsx")
+
+    assert results == "Outputs.xlsx"
+    assert theme == app._DEF_THEME
+
+    labels_in_expander = [
+        e[1]
+        for e in fake_st.events
+        if e[0] == "text_input" and e[2] == (f"expander:{app.ADVANCED_SETTINGS_LABEL}",)
+    ]
+    assert labels_in_expander == ["Results file", "Theme file"]
+
+
+def test_home_page_sets_real_title(fake_st: FakeStreamlit) -> None:
+    app.main()
+
+    page_configs = [e for e in fake_st.events if e[0] == "set_page_config"]
+    assert len(page_configs) == 1
+    assert page_configs[0][1].get("page_title") == "Portable Alpha Dashboard"

--- a/tests/test_portfolio_builder_page.py
+++ b/tests/test_portfolio_builder_page.py
@@ -99,6 +99,11 @@ class _FakeApp(ModuleType):
     def apply_theme(self, path: str) -> None:
         self.applied_theme = path
 
+    def render_settings_sidebar(
+        self, results_default: str | None = None
+    ) -> tuple[str | None, str]:
+        return results_default, self._DEF_THEME
+
 
 class _Upload:
     def __init__(self, payload: bytes) -> None:


### PR DESCRIPTION
## Summary
Closes #1902.

Config/dev internals no longer dominate the user-facing sidebar:

- Added a shared `dashboard.app.render_settings_sidebar()` helper that renders the `Theme file` (and, on the Results page, `Results file`) path inputs inside a **collapsed `Advanced / Settings` sidebar expander**, returning `(results_path, theme_path)`.
- Rewired all six pages that previously showed bare `st.sidebar.text_input("Theme file", ...)` widgets — Asset Library, Portfolio Builder, Scenario Wizard, Results, Scenario Grid, Stress Lab — to use the helper. Results now sources both its workbook path and theme path from the one expander.
- Home page (`app.py`) now calls `st.set_page_config(page_title="Portable Alpha Dashboard", page_icon="📈")` so the browser/page title is a real name instead of the Streamlit default derived from the entry-point filename (`app`). The page already renders `st.title("Portable Alpha Dashboard")` in the body.

### Note on the sidebar nav label
In Streamlit's filesystem multipage app (this app's `pages/` layout), the *sidebar navigation* label for the entry page is derived purely from the script filename (`app.py` → "app") and is not overridable by `set_page_config`. Renaming the documented entry point (`streamlit run dashboard/app.py`, imported as `dashboard.app` across the codebase/tests) is out of scope for this UX fix, so this PR addresses the page/browser title; a follow-up could migrate to `st.navigation` if a custom nav label is desired.

## Tests
- New `tests/test_dashboard_advanced_settings.py`: verifies the inputs render *inside* the `Advanced / Settings` expander (not as bare sidebar widgets), that `Results file` is included only when a default is supplied, and that the home page sets a real `page_title`.
- Updated `tests/test_portfolio_builder_page.py` fake `dashboard.app` to provide `render_settings_sidebar` (mirrors how it already fakes `apply_theme`).
- `ruff check` clean on all changed files; focused dashboard/page suite green (471 passed). One unrelated pre-existing failure in `test_data_loading_validation.py::test_rolling_panel_with_malformed_data` reproduces on pristine `main` (numpy env issue), untouched by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar layout and cosmetic page title; theme/results paths and `apply_theme` behavior are unchanged aside from widget placement.
> 
> **Overview**
> Closes #1902 by decluttering the Streamlit sidebar: **theme** (and on Results, **results workbook**) path fields no longer appear as bare `st.sidebar.text_input` widgets at the top of each page.
> 
> A shared **`render_settings_sidebar()`** in `dashboard.app` renders those inputs inside a **collapsed** `Advanced / Settings` expander and returns `(results_path, theme_path)`; all six multipage routes (Asset Library through Stress Lab) call it instead of duplicating sidebar wiring. **Results** passes a default workbook path so both file inputs live in one place.
> 
> The **home** entry page now calls **`st.set_page_config`** with `page_title="Portable Alpha Dashboard"` (wrapped in try/except for reruns/tests). Tests add **`test_dashboard_advanced_settings.py`** for expander placement and page title; portfolio builder fakes were updated for the new helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 534cdca7f47009dae802e425d5dc96f96c0cfd87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->