### PR TITLE
fix(viz): distinguish headline risk-return sleeves (#1903)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -45,9 +45,7 @@ def render_settings_sidebar(results_default: str | None = None) -> tuple[str | N
     """
     with st.sidebar.expander(ADVANCED_SETTINGS_LABEL, expanded=False):
         results_path = (
-            st.text_input("Results file", results_default)
-            if results_default is not None
-            else None
+            st.text_input("Results file", results_default) if results_default is not None else None
         )
         theme_path = st.text_input("Theme file", _DEF_THEME)
     return results_path, theme_path

--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -214,16 +214,16 @@ def main() -> None:
 
         run_sweep = st.button("Run sweep")
         if idx_file is None and not use_sample:
-            st.info("Upload an index returns CSV or tick 'Use bundled sample data' to run the sweep.")
+            st.info(
+                "Upload an index returns CSV or tick 'Use bundled sample data' to run the sweep."
+            )
             return
 
         try:
             if idx_file is not None:
                 idx_df = _read_csv(idx_file)
                 # Use first numeric column as index series
-                num_cols = [
-                    c for c in idx_df.columns if pd.api.types.is_numeric_dtype(idx_df[c])
-                ]
+                num_cols = [c for c in idx_df.columns if pd.api.types.is_numeric_dtype(idx_df[c])]
                 if not num_cols:
                     st.error("No numeric column found in index CSV")
                     return

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from importlib import resources
 from collections.abc import MutableMapping
+from importlib import resources
 from pathlib import Path
 from typing import Any
 

--- a/docs/tutorial/PortableAlpha_Tutorial.ipynb
+++ b/docs/tutorial/PortableAlpha_Tutorial.ipynb
@@ -41,7 +41,6 @@
    },
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
     "import copy\n",
     "import logging\n",
     "import math\n",
@@ -49,6 +48,7 @@
     "import sys\n",
     "import tempfile\n",
     "import warnings\n",
+    "from pathlib import Path\n",
     "\n",
     "start = Path.cwd().resolve()\n",
     "for candidate in (start, *start.parents):\n",

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -258,9 +258,7 @@ class ModelConfig(BaseModel):
     external_pa_capital: float = Field(default=0.0, alias="External PA capital (mm)")
     active_ext_capital: float = Field(default=0.0, alias="Active Extension capital (mm)")
     internal_pa_capital: float = Field(default=0.0, alias="Internal PA capital (mm)")
-    total_fund_capital: float = Field(
-        default=1000.0, gt=0, alias="Total fund capital (mm)"
-    )
+    total_fund_capital: float = Field(default=1000.0, gt=0, alias="Total fund capital (mm)")
     agents: List[AgentConfig] = Field(default_factory=list)
 
     w_beta_H: float = Field(default=0.5, alias="In-House beta share")
@@ -336,9 +334,7 @@ class ModelConfig(BaseModel):
     internal_financing_sigma_month: float = Field(
         default=0.0, ge=0, alias="Internal financing vol (monthly %)"
     )
-    internal_spike_prob: float = Field(
-        default=0.0, ge=0, le=1, alias="Internal monthly spike prob"
-    )
+    internal_spike_prob: float = Field(default=0.0, ge=0, le=1, alias="Internal monthly spike prob")
     internal_spike_factor: float = Field(default=0.0, alias="Internal spike multiplier")
 
     # Internal-PA financing cost (issue #1849). Distinct from the margin

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -346,9 +346,7 @@ def _derive_regime_rng(rng_returns: GeneratorLike) -> GeneratorLike:
     ``rng_returns`` reproduce identical regime paths, while remaining an
     independent stream from the return draws.
     """
-    state_repr = json.dumps(
-        rng_returns.bit_generator.state, sort_keys=True, default=str
-    )
+    state_repr = json.dumps(rng_returns.bit_generator.state, sort_keys=True, default=str)
     digest = hashlib.sha256(("pa_core.regime:" + state_repr).encode("utf-8")).digest()
     entropy = int.from_bytes(digest, "big")
     return spawn_rngs(entropy, 1)[0]

--- a/pa_core/viz/moments_panel.py
+++ b/pa_core/viz/moments_panel.py
@@ -12,8 +12,9 @@ def make(df_paths: pd.DataFrame | np.ndarray, *, window: int = 12) -> go.Figure:
     """Return rolling skewness and kurtosis panel."""
     arr = np.asarray(df_paths)
     df = pd.DataFrame(arr)
-    roll_skew = df.rolling(window, axis=1, min_periods=1).skew().mean(axis=0)
-    roll_kurt = df.rolling(window, axis=1, min_periods=1).kurt().mean(axis=0)
+    rolling = df.T.rolling(window, min_periods=1)
+    roll_skew = rolling.skew().mean(axis=1)
+    roll_kurt = rolling.kurt().mean(axis=1)
     months = np.arange(arr.shape[1])
     fig = make_subplots(rows=2, cols=1, shared_xaxes=True, subplot_titles=("Skewness", "Kurtosis"))
     fig.add_trace(go.Scatter(x=months, y=roll_skew, name="Skew"), row=1, col=1)

--- a/pa_core/viz/risk_return.py
+++ b/pa_core/viz/risk_return.py
@@ -5,6 +5,32 @@ import plotly.graph_objects as go
 
 from . import theme
 
+_DEFAULT_COLORWAY = [
+    "#377eb8",
+    "#ff7f00",
+    "#4daf4a",
+    "#f781bf",
+    "#a65628",
+    "#984ea3",
+]
+_AGENT_SYMBOLS = [
+    "circle",
+    "square",
+    "triangle-up",
+    "cross",
+    "x",
+    "triangle-down",
+]
+_FIXED_AGENT_STYLES = {
+    "Total": {"color": "#111827", "symbol": "star", "size": 18},
+    "Base": {"color": "#6b7280", "symbol": "diamond", "size": 16},
+}
+_SHORTFALL_COLORS = {
+    "green": "#2ca02c",
+    "orange": "#ff7f0e",
+    "red": "#d62728",
+}
+
 
 def make(df_summary: pd.DataFrame) -> go.Figure:
     """Return tracking-error or volatility vs return scatter plot.
@@ -20,7 +46,6 @@ def make(df_summary: pd.DataFrame) -> go.Figure:
     """
     df = df_summary.copy()
     df["terminal_ShortfallProb"] = df.get("terminal_ShortfallProb", theme.DEFAULT_SHORTFALL_PROB)
-    color = []
     thr = theme.THRESHOLDS
 
     def has_data(col: str) -> bool:
@@ -52,27 +77,46 @@ def make(df_summary: pd.DataFrame) -> go.Figure:
         y_label = "Annualized Return"
         y_hover = "Annualized Return"
 
-    for prob in df["terminal_ShortfallProb"].fillna(theme.DEFAULT_SHORTFALL_PROB):
-        if prob <= thr.get("shortfall_green", 0.05):
-            color.append("green")
-        elif prob <= thr.get("shortfall_amber", theme.LOW_BUFFER_THRESHOLD):
-            color.append("orange")
-        else:
-            color.append("red")
-
     fig = go.Figure(layout_template=theme.TEMPLATE)
-    fig.add_trace(
-        go.Scatter(
-            x=df[x_col],
-            y=df[y_col],
-            mode="markers",
-            marker=dict(size=12, color=color),
-            text=df["Agent"],
-            hovertemplate=(
-                f"%{{text}}<br>{x_hover}=%{{x:.2%}}<br>{y_hover}=%{{y:.2%}}<extra></extra>"
-            ),
+    agents = _ordered_agents(df["Agent"])
+    color_map = _agent_colors(agents)
+    symbol_map = _agent_symbols(agents)
+    for agent in agents:
+        agent_rows = df[df["Agent"].astype(str) == agent]
+        probs = pd.to_numeric(
+            agent_rows["terminal_ShortfallProb"],
+            errors="coerce",
+        ).fillna(theme.DEFAULT_SHORTFALL_PROB)
+        marker_line_colors = [_shortfall_color(prob, thr) for prob in probs]
+        fixed_style = _FIXED_AGENT_STYLES.get(agent, {})
+        marker_size = fixed_style.get("size", 12)
+        text = agent_rows["Agent"] if agent in _FIXED_AGENT_STYLES else None
+        mode = "markers+text" if text is not None else "markers"
+        fig.add_trace(
+            go.Scatter(
+                x=agent_rows[x_col],
+                y=agent_rows[y_col],
+                mode=mode,
+                name=agent,
+                legendgroup=agent,
+                marker=dict(
+                    size=marker_size,
+                    color=color_map[agent],
+                    symbol=symbol_map[agent],
+                    line=dict(
+                        color=marker_line_colors,
+                        width=3 if agent in _FIXED_AGENT_STYLES else 1.5,
+                    ),
+                ),
+                text=text if text is not None else agent_rows["Agent"],
+                textposition="top center",
+                customdata=[[float(prob)] for prob in probs],
+                hovertemplate=(
+                    f"%{{text}}<br>{x_hover}=%{{x:.2%}}<br>{y_hover}=%{{y:.2%}}"
+                    "<br>Shortfall=%{customdata[0]:.2%}<extra></extra>"
+                ),
+            )
         )
-    )
 
     # sweet-spot rectangle
     rect = dict(
@@ -93,6 +137,46 @@ def make(df_summary: pd.DataFrame) -> go.Figure:
         shapes=[rect],
         xaxis_title=x_label,
         yaxis_title=y_label,
+        legend_title_text="Sleeve / Scenario",
         template=theme.TEMPLATE,
     )
     return fig
+
+
+def _ordered_agents(agent_series: pd.Series) -> list[str]:
+    agents = list(dict.fromkeys(agent_series.astype(str)))
+    highlighted = [agent for agent in ("Base", "Total") if agent in agents]
+    return [agent for agent in agents if agent not in _FIXED_AGENT_STYLES] + highlighted
+
+
+def _agent_colors(agents: list[str]) -> dict[str, str]:
+    colorway = list(theme.TEMPLATE.layout.colorway or _DEFAULT_COLORWAY)
+    dynamic_agents = [agent for agent in agents if agent not in _FIXED_AGENT_STYLES]
+    colors = {
+        agent: colorway[idx % len(colorway)]
+        for idx, agent in enumerate(dynamic_agents)
+    }
+    for agent, style in _FIXED_AGENT_STYLES.items():
+        if agent in agents:
+            colors[agent] = str(style["color"])
+    return colors
+
+
+def _agent_symbols(agents: list[str]) -> dict[str, str]:
+    dynamic_agents = [agent for agent in agents if agent not in _FIXED_AGENT_STYLES]
+    symbols = {
+        agent: _AGENT_SYMBOLS[idx % len(_AGENT_SYMBOLS)]
+        for idx, agent in enumerate(dynamic_agents)
+    }
+    for agent, style in _FIXED_AGENT_STYLES.items():
+        if agent in agents:
+            symbols[agent] = str(style["symbol"])
+    return symbols
+
+
+def _shortfall_color(prob: float, thresholds: dict[str, float]) -> str:
+    if prob <= thresholds.get("shortfall_green", 0.05):
+        return _SHORTFALL_COLORS["green"]
+    if prob <= thresholds.get("shortfall_amber", theme.LOW_BUFFER_THRESHOLD):
+        return _SHORTFALL_COLORS["orange"]
+    return _SHORTFALL_COLORS["red"]

--- a/pa_core/viz/risk_return.py
+++ b/pa_core/viz/risk_return.py
@@ -56,12 +56,14 @@ def make(df_summary: pd.DataFrame) -> go.Figure:
         x_label = "Tracking Error"
         x_hover = "Tracking Error"
         cap = thr.get("te_cap", 0.03)
+        _fill_benchmark_tracking_error(df, x_col)
     elif has_data("TrackingErr"):
         df["monthly_TE"] = df["TrackingErr"]
         x_col = "monthly_TE"
         x_label = "Tracking Error"
         x_hover = "Tracking Error"
         cap = thr.get("te_cap", 0.03)
+        _fill_benchmark_tracking_error(df, x_col)
     else:
         x_col = "monthly_AnnVol"
         x_label = "Annualized Volatility"
@@ -145,8 +147,20 @@ def make(df_summary: pd.DataFrame) -> go.Figure:
 
 def _ordered_agents(agent_series: pd.Series) -> list[str]:
     agents = list(dict.fromkeys(agent_series.astype(str)))
-    highlighted = [agent for agent in ("Base", "Total") if agent in agents]
+    highlighted = [agent for agent in _fixed_agent_order() if agent in agents]
     return [agent for agent in agents if agent not in _FIXED_AGENT_STYLES] + highlighted
+
+
+def _fixed_agent_order() -> list[str]:
+    preferred_order = ["Base", "Total"]
+    preferred = [agent for agent in preferred_order if agent in _FIXED_AGENT_STYLES]
+    extras = [agent for agent in _FIXED_AGENT_STYLES if agent not in preferred]
+    return preferred + extras
+
+
+def _fill_benchmark_tracking_error(df: pd.DataFrame, x_col: str) -> None:
+    benchmark_mask = df["Agent"].astype(str) == "Base"
+    df.loc[benchmark_mask, x_col] = df.loc[benchmark_mask, x_col].fillna(0.0)
 
 
 def _agent_colors(agents: list[str]) -> dict[str, str]:

--- a/pa_core/viz/risk_return.py
+++ b/pa_core/viz/risk_return.py
@@ -166,10 +166,7 @@ def _fill_benchmark_tracking_error(df: pd.DataFrame, x_col: str) -> None:
 def _agent_colors(agents: list[str]) -> dict[str, str]:
     colorway = list(theme.TEMPLATE.layout.colorway or _DEFAULT_COLORWAY)
     dynamic_agents = [agent for agent in agents if agent not in _FIXED_AGENT_STYLES]
-    colors = {
-        agent: colorway[idx % len(colorway)]
-        for idx, agent in enumerate(dynamic_agents)
-    }
+    colors = {agent: colorway[idx % len(colorway)] for idx, agent in enumerate(dynamic_agents)}
     for agent, style in _FIXED_AGENT_STYLES.items():
         if agent in agents:
             colors[agent] = str(style["color"])
@@ -179,8 +176,7 @@ def _agent_colors(agents: list[str]) -> dict[str, str]:
 def _agent_symbols(agents: list[str]) -> dict[str, str]:
     dynamic_agents = [agent for agent in agents if agent not in _FIXED_AGENT_STYLES]
     symbols = {
-        agent: _AGENT_SYMBOLS[idx % len(_AGENT_SYMBOLS)]
-        for idx, agent in enumerate(dynamic_agents)
+        agent: _AGENT_SYMBOLS[idx % len(_AGENT_SYMBOLS)] for idx, agent in enumerate(dynamic_agents)
     }
     for agent, style in _FIXED_AGENT_STYLES.items():
         if agent in agents:

--- a/pa_core/viz/rolling_panel.py
+++ b/pa_core/viz/rolling_panel.py
@@ -33,8 +33,9 @@ def _rolling_te(paths: np.ndarray, window: int) -> np.ndarray:
 
 def _rolling_sharpe(paths: np.ndarray, window: int) -> np.ndarray:
     returns = pd.DataFrame(paths)
-    roll_mean = returns.rolling(window, axis=1, min_periods=1).mean()
-    roll_std = returns.rolling(window, axis=1, min_periods=1).std()
+    rolling = returns.T.rolling(window, min_periods=1)
+    roll_mean = rolling.mean().T
+    roll_std = rolling.std().T
     sharpe = roll_mean / roll_std
 
     sharpe_series = sharpe.mean(axis=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,27 @@ def socket_connect_guard(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(socket.socket, "connect", _blocked_connect)
     return attempts, _blocked_connect
+
+
+@pytest.fixture(autouse=True)
+def _restore_viz_theme_globals():
+    """Isolate the shared plotly theme so tests cannot leak palette state.
+
+    ``pa_core.viz.theme`` keeps module-level globals (``TEMPLATE``, the colorway,
+    fonts, backgrounds and thresholds) that ``reload_theme``/``reload_thresholds``
+    -- and ``dashboard.app.apply_theme`` -- reassign in place. Tests such as
+    ``test_apply_theme`` and ``test_theme_reload`` rewrite the colorway to a short
+    custom palette and never restore it, which silently leaks into later tests that
+    assert on colour assignment (e.g. the risk-return sleeve legend, which expects
+    one distinct colour per sleeve). Snapshot the globals before each test and
+    restore them afterwards so theme state stays isolated regardless of test order.
+    """
+    from pa_core.viz import theme
+
+    attrs = ("TEMPLATE", "_COLORWAY", "_FONT", "_PAPER_BG", "_PLOT_BG", "THRESHOLDS")
+    saved = {name: getattr(theme, name) for name in attrs if hasattr(theme, name)}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            setattr(theme, name, value)

--- a/tests/test_active_share_transfer_coefficient.py
+++ b/tests/test_active_share_transfer_coefficient.py
@@ -5,6 +5,7 @@ bit-for-bit. With kappa > 0 the expected alpha is concave in the lever (declinin
 information ratio) while active risk still scales linearly, and an optional
 per-share extension cost yields a closed-form interior optimum.
 """
+
 from pathlib import Path
 
 import numpy as np
@@ -71,7 +72,9 @@ def test_active_risk_grows_even_as_alpha_saturates():
             ActiveExtensionAgent,
             1.0,
             {"active_share": s, "alpha_mu": 0.01, "tc_decay": 1.0, "cost_per_share": 0.0},
-        ).monthly_returns(z, alpha, z).std()
+        )
+        .monthly_returns(z, alpha, z)
+        .std()
         for s in (0.2, 0.5, 0.9)
     ]
     assert stds[0] < stds[1] < stds[2]
@@ -89,7 +92,9 @@ def test_interior_optimum_matches_closed_form():
             ActiveExtensionAgent,
             1.0,
             {"active_share": s, "alpha_mu": mu, "tc_decay": kappa, "cost_per_share": c},
-        ).monthly_returns(z, alpha, z).mean()
+        )
+        .monthly_returns(z, alpha, z)
+        .mean()
         for s in grid
     ]
     s_opt = grid[int(np.argmax(means))]

--- a/tests/test_low_buffer_threshold.py
+++ b/tests/test_low_buffer_threshold.py
@@ -58,7 +58,7 @@ def test_risk_return_uses_constant(cleared_thresholds):
     fig = risk_return.make(df)
     # Check that the function doesn't crash and returns a figure
     assert fig is not None
-    assert len(fig.data) == 1
+    assert len(fig.data) == 3
 
 
 def test_beta_scatter_uses_constant(cleared_thresholds):

--- a/tests/test_portfolio_builder_page.py
+++ b/tests/test_portfolio_builder_page.py
@@ -99,9 +99,7 @@ class _FakeApp(ModuleType):
     def apply_theme(self, path: str) -> None:
         self.applied_theme = path
 
-    def render_settings_sidebar(
-        self, results_default: str | None = None
-    ) -> tuple[str | None, str]:
+    def render_settings_sidebar(self, results_default: str | None = None) -> tuple[str | None, str]:
         return results_default, self._DEF_THEME
 
 

--- a/tests/test_scenario_fleet.py
+++ b/tests/test_scenario_fleet.py
@@ -16,7 +16,7 @@ import pytest
 
 from pa_core.config import load_config
 from pa_core.facade import RunOptions, run_sweep
-from pa_core.llm.langsmith_fleet import FLEET_REPO, FLEET_SCHEMA, FLEET_SURFACE
+from pa_core.llm.langsmith_fleet import FLEET_REPO, FLEET_SCHEMA, FLEET_SURFACE, config_fingerprint
 from pa_core.llm.scenario_fleet import (
     SCENARIO_DASHBOARD_SURFACE,
     SCENARIO_RUN_OPERATION,
@@ -25,7 +25,6 @@ from pa_core.llm.scenario_fleet import (
     _summary_metric_delta,
     record_scenario_run,
 )
-from pa_core.llm.langsmith_fleet import config_fingerprint
 from pa_core.orchestrator import SimulatorOrchestrator
 
 _BASIC_CONFIG = {

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -101,8 +101,11 @@ def test_risk_return_axis_labels_match_data():
         }
     )
     fig = risk_return.make(df)
-    assert list(fig.data[0].x) == df["monthly_TE"].tolist()
-    assert list(fig.data[0].y) == df["terminal_ExcessReturn"].tolist()
+    points = {trace.name: (list(trace.x), list(trace.y)) for trace in fig.data}
+    assert points == {
+        "A": ([0.12], [0.02]),
+        "B": ([0.18], [0.01]),
+    }
     assert fig.layout.xaxis.title.text == "Tracking Error"
     assert fig.layout.yaxis.title.text == "Annualized Excess Return"
 
@@ -117,8 +120,11 @@ def test_risk_return_axis_labels_match_vol_and_return():
         }
     )
     fig = risk_return.make(df)
-    assert list(fig.data[0].x) == df["monthly_AnnVol"].tolist()
-    assert list(fig.data[0].y) == df["terminal_AnnReturn"].tolist()
+    points = {trace.name: (list(trace.x), list(trace.y)) for trace in fig.data}
+    assert points == {
+        "A": ([0.12], [0.06]),
+        "B": ([0.18], [0.03]),
+    }
     assert fig.layout.xaxis.title.text == "Annualized Volatility"
     assert fig.layout.yaxis.title.text == "Annualized Return"
 
@@ -134,8 +140,38 @@ def test_risk_return_falls_back_to_vol_when_te_empty():
         }
     )
     fig = risk_return.make(df)
-    assert list(fig.data[0].x) == df["monthly_AnnVol"].tolist()
+    points = {trace.name: list(trace.x) for trace in fig.data}
+    assert points == {
+        "A": [0.12],
+        "B": [0.18],
+    }
     assert fig.layout.xaxis.title.text == "Annualized Volatility"
+
+
+def test_risk_return_uses_sleeve_legend_and_highlights_total_base():
+    df = pd.DataFrame(
+        {
+            "terminal_AnnReturn": [0.04, 0.06, 0.02, 0.07],
+            "terminal_ExcessReturn": [0.0, 0.025, -0.01, 0.03],
+            "monthly_TE": [0.0, 0.04, 0.03, 0.05],
+            "Agent": ["Base", "Total", "ExternalPA", "ActiveExt"],
+            "terminal_ShortfallProb": [0.01, 0.04, 0.12, 0.08],
+        }
+    )
+
+    fig = risk_return.make(df)
+
+    assert {trace.name for trace in fig.data} == {"Base", "Total", "ExternalPA", "ActiveExt"}
+    traces = {trace.name: trace for trace in fig.data}
+    assert traces["Total"].marker.symbol == "star"
+    assert traces["Total"].marker.size == 18
+    assert traces["Base"].marker.symbol == "diamond"
+    assert traces["Base"].marker.size == 16
+    assert traces["Total"].mode == "markers+text"
+    assert traces["Base"].mode == "markers+text"
+    assert fig.layout.legend.title.text == "Sleeve / Scenario"
+    assert len({trace.marker.color for trace in fig.data}) == 4
+    assert "Shortfall" in traces["ExternalPA"].hovertemplate
 
 
 def test_fan_and_dist():

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -153,7 +153,7 @@ def test_risk_return_uses_sleeve_legend_and_highlights_total_base():
         {
             "terminal_AnnReturn": [0.04, 0.06, 0.02, 0.07],
             "terminal_ExcessReturn": [0.0, 0.025, -0.01, 0.03],
-            "monthly_TE": [0.0, 0.04, 0.03, 0.05],
+            "monthly_TE": [pd.NA, 0.04, 0.03, 0.05],
             "Agent": ["Base", "Total", "ExternalPA", "ActiveExt"],
             "terminal_ShortfallProb": [0.01, 0.04, 0.12, 0.08],
         }
@@ -167,6 +167,7 @@ def test_risk_return_uses_sleeve_legend_and_highlights_total_base():
     assert traces["Total"].marker.size == 18
     assert traces["Base"].marker.symbol == "diamond"
     assert traces["Base"].marker.size == 16
+    assert list(traces["Base"].x) == [0.0]
     assert traces["Total"].mode == "markers+text"
     assert traces["Base"].mode == "markers+text"
     assert fig.layout.legend.title.text == "Sleeve / Scenario"


### PR DESCRIPTION
Closes #1903

## Summary
- split the risk-return scatter into one trace per sleeve/scenario so the legend identifies each point family
- highlight Base and Total with larger labeled markers while preserving shortfall probability in hover and marker outlines
- update rolling visualization helpers for pandas 3 compatibility exposed by the visualization test slice

## Validation
- UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_viz.py tests/test_low_buffer_threshold.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check pa_core/viz/risk_return.py pa_core/viz/rolling_panel.py pa_core/viz/moments_panel.py tests/test_viz.py tests/test_low_buffer_threshold.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Plotly presentation, pandas rolling compatibility, and test fixtures; simulation and config behavior are unchanged.
> 
> **Overview**
> The **risk-return** headline chart no longer plots every sleeve in one trace with fill color driven only by shortfall. It now emits **one Plotly trace per agent/sleeve**, with a **“Sleeve / Scenario”** legend, stable per-sleeve colors and marker shapes, and **shortfall probability** shown in hover plus **marker outline** color (green / orange / red). **Base** and **Total** get larger **star/diamond** markers with on-chart labels; missing **Base** tracking error is treated as **0** on the TE axis.
> 
> Rolling **skew/kurtosis** (`moments_panel`) and **Sharpe** (`rolling_panel`) no longer use `DataFrame.rolling(..., axis=1)`; they roll along the time axis via transpose so the viz tests stay valid on **pandas 3**.
> 
> Tests add an **autouse** fixture that snapshots and restores shared **`pa_core.viz.theme`** globals so theme-mutating tests cannot leak palette state into risk-return color assertions. Remaining diff hunks are formatting, import order, and expectation updates for the multi-trace chart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abce06f22ab7d6a4225e87dd3ae633282a7d48e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->