### PR TITLE
feat(fees): add opt-in per-sleeve management/performance fee layer (#1904)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -45,9 +45,7 @@ def render_settings_sidebar(results_default: str | None = None) -> tuple[str | N
     """
     with st.sidebar.expander(ADVANCED_SETTINGS_LABEL, expanded=False):
         results_path = (
-            st.text_input("Results file", results_default)
-            if results_default is not None
-            else None
+            st.text_input("Results file", results_default) if results_default is not None else None
         )
         theme_path = st.text_input("Theme file", _DEF_THEME)
     return results_path, theme_path

--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -214,16 +214,16 @@ def main() -> None:
 
         run_sweep = st.button("Run sweep")
         if idx_file is None and not use_sample:
-            st.info("Upload an index returns CSV or tick 'Use bundled sample data' to run the sweep.")
+            st.info(
+                "Upload an index returns CSV or tick 'Use bundled sample data' to run the sweep."
+            )
             return
 
         try:
             if idx_file is not None:
                 idx_df = _read_csv(idx_file)
                 # Use first numeric column as index series
-                num_cols = [
-                    c for c in idx_df.columns if pd.api.types.is_numeric_dtype(idx_df[c])
-                ]
+                num_cols = [c for c in idx_df.columns if pd.api.types.is_numeric_dtype(idx_df[c])]
                 if not num_cols:
                     st.error("No numeric column found in index CSV")
                     return

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from importlib import resources
 from collections.abc import MutableMapping
+from importlib import resources
 from pathlib import Path
 from typing import Any
 

--- a/docs/guides/PARAMETER_DICTIONARY.md
+++ b/docs/guides/PARAMETER_DICTIONARY.md
@@ -35,6 +35,7 @@ This reference lists canonical field names, accepted aliases, and defaults for s
 | `internal_pa_capital` | `Internal PA capital (mm)` | `<class 'float'>` | no | `0.0` |  |
 | `total_fund_capital` | `Total fund capital (mm)` | `<class 'float'>` | no | `1000.0` |  |
 | `agents` | `agents` | `List[pa_core.config.AgentConfig]` | no | `default_factory: list` |  |
+| `fee_schedule` | `fee_schedule` | `Optional[Dict[str, pa_core.fees.FeeSchedule]]` | no | `None` | Optional per-sleeve management/performance fee schedule keyed by agent name (e.g. 'ExternalPA', 'ActiveExt'). When set, that sleeve's returns are reported net of fees (issue #1904). None or empty keeps the historical gross-of-fee behaviour. |
 | `w_beta_H` | `In-House beta share` | `<class 'float'>` | no | `0.5` |  |
 | `w_alpha_H` | `In-House alpha share` | `<class 'float'>` | no | `0.5` |  |
 | `theta_extpa` | `External PA alpha fraction` | `<class 'float'>` | no | `0.5` |  |

--- a/docs/tutorial/PortableAlpha_Tutorial.ipynb
+++ b/docs/tutorial/PortableAlpha_Tutorial.ipynb
@@ -41,7 +41,6 @@
    },
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
     "import copy\n",
     "import logging\n",
     "import math\n",
@@ -49,6 +48,7 @@
     "import sys\n",
     "import tempfile\n",
     "import warnings\n",
+    "from pathlib import Path\n",
     "\n",
     "start = Path.cwd().resolve()\n",
     "for candidate in (start, *start.parents):\n",

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -259,9 +259,7 @@ class ModelConfig(BaseModel):
     external_pa_capital: float = Field(default=0.0, alias="External PA capital (mm)")
     active_ext_capital: float = Field(default=0.0, alias="Active Extension capital (mm)")
     internal_pa_capital: float = Field(default=0.0, alias="Internal PA capital (mm)")
-    total_fund_capital: float = Field(
-        default=1000.0, gt=0, alias="Total fund capital (mm)"
-    )
+    total_fund_capital: float = Field(default=1000.0, gt=0, alias="Total fund capital (mm)")
     agents: List[AgentConfig] = Field(default_factory=list)
     fee_schedule: Optional[Dict[str, FeeSchedule]] = Field(
         default=None,
@@ -346,9 +344,7 @@ class ModelConfig(BaseModel):
     internal_financing_sigma_month: float = Field(
         default=0.0, ge=0, alias="Internal financing vol (monthly %)"
     )
-    internal_spike_prob: float = Field(
-        default=0.0, ge=0, le=1, alias="Internal monthly spike prob"
-    )
+    internal_spike_prob: float = Field(default=0.0, ge=0, le=1, alias="Internal monthly spike prob")
     internal_spike_factor: float = Field(default=0.0, alias="Internal spike multiplier")
 
     # Internal-PA financing cost (issue #1849). Distinct from the margin

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -22,6 +22,7 @@ import yaml
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from .backend import BACKEND_UNAVAILABLE_DETAIL, SUPPORTED_BACKENDS
+from .fees import FeeSchedule
 from .share_utils import SHARE_MAX, SHARE_MIN, SHARE_SUM_TOLERANCE, normalize_share
 
 
@@ -262,6 +263,15 @@ class ModelConfig(BaseModel):
         default=1000.0, gt=0, alias="Total fund capital (mm)"
     )
     agents: List[AgentConfig] = Field(default_factory=list)
+    fee_schedule: Optional[Dict[str, FeeSchedule]] = Field(
+        default=None,
+        description=(
+            "Optional per-sleeve management/performance fee schedule keyed by "
+            "agent name (e.g. 'ExternalPA', 'ActiveExt'). When set, that sleeve's "
+            "returns are reported net of fees (issue #1904). None or empty keeps "
+            "the historical gross-of-fee behaviour."
+        ),
+    )
 
     w_beta_H: float = Field(default=0.5, alias="In-House beta share")
     w_alpha_H: float = Field(default=0.5, alias="In-House alpha share")

--- a/pa_core/facade.py
+++ b/pa_core/facade.py
@@ -464,7 +464,18 @@ def run_single(
     )
 
     agents = build_from_config(run_cfg)
-    returns = simulate_agents(agents, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act, f_internal_pa)
+    returns = simulate_agents(
+        agents,
+        r_beta,
+        r_H,
+        r_E,
+        r_M,
+        f_int,
+        f_ext,
+        f_act,
+        f_internal_pa,
+        fee_schedule=run_cfg.fee_schedule,
+    )
     summary = summary_table(returns, benchmark="Base")
     if getattr(run_cfg, "sleeve_validate_on_run", False):
         from .reporting.constraints import validate_sleeve_constraints

--- a/pa_core/fees.py
+++ b/pa_core/fees.py
@@ -30,6 +30,8 @@ All fee parameters are non-negative; an all-zero schedule is a no-op.
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from .backend import xp as np
@@ -83,16 +85,17 @@ def compute_fee_drag(
     if notional_share < 0.0:
         raise ValueError("notional_share must be non-negative")
     if notional_share == 0.0:
-        return np.zeros_like(gross)
+        return cast(ArrayLike, np.zeros_like(gross))
 
-    underlying_gross = gross / notional_share
+    gross_array = cast(Any, gross)
+    underlying_gross = gross_array / notional_share
     mgmt_monthly = schedule.mgmt_fee_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
-    drag: ArrayLike = np.full_like(gross, mgmt_monthly)
+    drag = cast(ArrayLike, np.full_like(gross, mgmt_monthly))
     if schedule.perf_fee_pct > 0.0:
         hurdle_monthly = schedule.hurdle_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
         excess = np.maximum(underlying_gross - hurdle_monthly, 0.0)
         drag = drag + schedule.perf_fee_pct * excess
-    return drag * notional_share
+    return cast(ArrayLike, drag * notional_share)
 
 
 def apply_fees(

--- a/pa_core/fees.py
+++ b/pa_core/fees.py
@@ -13,12 +13,10 @@ supplied (the default) returns are unchanged and fully backward compatible.
 Modelling choices (intentionally a simple first increment; see the PR for
 rationale and follow-ups):
 
-* Fees are deducted in **sleeve contribution-return space** -- directly from
-  the monthly contribution return each agent emits
-  (:meth:`pa_core.agents.types.Agent.monthly_returns`), which is already scaled
-  by the sleeve's capital share. Assigning a schedule to a sleeve therefore
-  charges fees on that sleeve's fund-level contribution, mirroring how
-  financing cost is already deducted inside the agent return.
+* Fees are deducted in **sleeve contribution-return space**. The fee basis is
+  the sleeve's underlying return, then the resulting fee is scaled back by the
+  sleeve's fund-level notional share so a 25% sleeve pays 25% of a full-fund
+  drag.
 * **Management fee** (``mgmt_fee_bps``) is an annual rate in basis points,
   accrued linearly as a constant monthly drag ``mgmt_fee_bps / 1e4 / 12``.
 * **Performance fee** (``perf_fee_pct``) is a fraction of the monthly return
@@ -71,23 +69,39 @@ class FeeSchedule(BaseModel):
         return self.mgmt_fee_bps == 0.0 and self.perf_fee_pct == 0.0
 
 
-def compute_fee_drag(gross: ArrayLike, schedule: FeeSchedule) -> ArrayLike:
+def compute_fee_drag(
+    gross: ArrayLike,
+    schedule: FeeSchedule,
+    *,
+    notional_share: float = 1.0,
+) -> ArrayLike:
     """Return the per-month fee drag matrix for ``gross`` contribution returns.
 
     The result has the same shape as ``gross`` and is always non-negative
     (fees never increase returns). ``net = gross - compute_fee_drag(gross, ...)``.
     """
+    if notional_share < 0.0:
+        raise ValueError("notional_share must be non-negative")
+    if notional_share == 0.0:
+        return np.zeros_like(gross)
+
+    underlying_gross = gross / notional_share
     mgmt_monthly = schedule.mgmt_fee_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
     drag: ArrayLike = np.full_like(gross, mgmt_monthly)
     if schedule.perf_fee_pct > 0.0:
         hurdle_monthly = schedule.hurdle_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
-        excess = np.maximum(gross - hurdle_monthly, 0.0)
+        excess = np.maximum(underlying_gross - hurdle_monthly, 0.0)
         drag = drag + schedule.perf_fee_pct * excess
-    return drag
+    return drag * notional_share
 
 
-def apply_fees(gross: ArrayLike, schedule: FeeSchedule) -> ArrayLike:
+def apply_fees(
+    gross: ArrayLike,
+    schedule: FeeSchedule,
+    *,
+    notional_share: float = 1.0,
+) -> ArrayLike:
     """Return ``gross`` net of the management + performance fees in ``schedule``."""
     if schedule.is_zero:
         return gross
-    return gross - compute_fee_drag(gross, schedule)
+    return gross - compute_fee_drag(gross, schedule, notional_share=notional_share)

--- a/pa_core/fees.py
+++ b/pa_core/fees.py
@@ -1,0 +1,93 @@
+"""Per-sleeve management & performance fee layer (issue #1904).
+
+The core engine models financing/margin cost but historically produced only
+*gross*-of-fee returns. For portable-alpha structures, external-manager
+management fees and performance fees (on returns above a hurdle) are
+first-order and frequently decide whether the structure beats plain beta.
+Without them every output overstates the structure.
+
+This module adds an opt-in, per-sleeve fee schedule so callers can produce
+net-of-fee outputs alongside the existing gross behaviour. When no schedule is
+supplied (the default) returns are unchanged and fully backward compatible.
+
+Modelling choices (intentionally a simple first increment; see the PR for
+rationale and follow-ups):
+
+* Fees are deducted in **sleeve contribution-return space** -- directly from
+  the monthly contribution return each agent emits
+  (:meth:`pa_core.agents.types.Agent.monthly_returns`), which is already scaled
+  by the sleeve's capital share. Assigning a schedule to a sleeve therefore
+  charges fees on that sleeve's fund-level contribution, mirroring how
+  financing cost is already deducted inside the agent return.
+* **Management fee** (``mgmt_fee_bps``) is an annual rate in basis points,
+  accrued linearly as a constant monthly drag ``mgmt_fee_bps / 1e4 / 12``.
+* **Performance fee** (``perf_fee_pct``) is a fraction of the monthly return
+  above an annual ``hurdle_bps`` hurdle (e.g. ``0.20`` for a 20% fee). It is
+  crystallised monthly with no high-water mark and no rebate below the hurdle
+  (negative excess is zero-clipped). A high-water-mark / notional-exact variant
+  is a documented follow-up.
+
+All fee parameters are non-negative; an all-zero schedule is a no-op.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .backend import xp as np
+from .types import ArrayLike
+
+__all__ = ["FeeSchedule", "compute_fee_drag", "apply_fees"]
+
+_BPS_PER_UNIT = 10_000.0
+_MONTHS_PER_YEAR = 12.0
+
+
+class FeeSchedule(BaseModel):
+    """Management + performance fee schedule for a single sleeve."""
+
+    model_config = ConfigDict(frozen=True)
+
+    mgmt_fee_bps: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Annual management fee in basis points on notional.",
+    )
+    perf_fee_pct: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Performance fee as a fraction of return above the hurdle (e.g. 0.20).",
+    )
+    hurdle_bps: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Annual performance-fee hurdle in basis points.",
+    )
+
+    @property
+    def is_zero(self) -> bool:
+        """True when the schedule charges nothing (a no-op)."""
+        return self.mgmt_fee_bps == 0.0 and self.perf_fee_pct == 0.0
+
+
+def compute_fee_drag(gross: ArrayLike, schedule: FeeSchedule) -> ArrayLike:
+    """Return the per-month fee drag matrix for ``gross`` contribution returns.
+
+    The result has the same shape as ``gross`` and is always non-negative
+    (fees never increase returns). ``net = gross - compute_fee_drag(gross, ...)``.
+    """
+    mgmt_monthly = schedule.mgmt_fee_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
+    drag = np.full_like(gross, mgmt_monthly)
+    if schedule.perf_fee_pct > 0.0:
+        hurdle_monthly = schedule.hurdle_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
+        excess = np.maximum(gross - hurdle_monthly, 0.0)
+        drag = drag + schedule.perf_fee_pct * excess
+    return drag
+
+
+def apply_fees(gross: ArrayLike, schedule: FeeSchedule) -> ArrayLike:
+    """Return ``gross`` net of the management + performance fees in ``schedule``."""
+    if schedule.is_zero:
+        return gross
+    return gross - compute_fee_drag(gross, schedule)

--- a/pa_core/fees.py
+++ b/pa_core/fees.py
@@ -78,7 +78,7 @@ def compute_fee_drag(gross: ArrayLike, schedule: FeeSchedule) -> ArrayLike:
     (fees never increase returns). ``net = gross - compute_fee_drag(gross, ...)``.
     """
     mgmt_monthly = schedule.mgmt_fee_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
-    drag = np.full_like(gross, mgmt_monthly)
+    drag: ArrayLike = np.full_like(gross, mgmt_monthly)
     if schedule.perf_fee_pct > 0.0:
         hurdle_monthly = schedule.hurdle_bps / _BPS_PER_UNIT / _MONTHS_PER_YEAR
         excess = np.maximum(gross - hurdle_monthly, 0.0)

--- a/pa_core/simulations.py
+++ b/pa_core/simulations.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import Iterable, Tuple
+from typing import Iterable, Mapping, Tuple
 
 from .agents import (
     ActiveExtensionAgent,
@@ -14,6 +14,7 @@ from .agents import (
     InternalPAAgent,
 )
 from .backend import xp as np
+from .fees import FeeSchedule, apply_fees
 from .portfolio import compute_total_contribution_returns
 from .sim import (
     draw_financing_series,
@@ -92,6 +93,7 @@ def simulate_agents(
     f_ext_pa: ArrayLike,
     f_act_ext: ArrayLike,
     f_internal_pa: ArrayLike | None = None,
+    fee_schedule: Mapping[str, FeeSchedule] | None = None,
 ) -> dict[str, ArrayLike]:
     """Return per-agent monthly returns using vectorised operations.
 
@@ -99,6 +101,12 @@ def simulate_agents(
     (issue #1849). When ``None`` it defaults to an all-zeros matrix shaped like
     ``r_beta``, so callers that do not supply it get the historical behaviour
     (InternalPA = pure in-house alpha).
+
+    ``fee_schedule`` is an optional per-sleeve management/performance fee
+    schedule keyed by agent name (issue #1904). When provided, the matching
+    sleeve's contribution return is reported net of fees and ``Total`` is the
+    sum of the net sleeves. When ``None`` (the default) returns are gross and
+    fully backward compatible.
     """
     results: dict[str, ArrayLike] = {}
     if f_internal_pa is None:
@@ -106,7 +114,12 @@ def simulate_agents(
     streams = (r_beta, r_H, r_E, r_M, f_int, f_ext_pa, f_act_ext, f_internal_pa)
     for agent in agents:
         alpha, financing = _resolve_streams(agent, *streams)
-        results[agent.p.name] = agent.monthly_returns(r_beta, alpha, financing)
+        gross = agent.monthly_returns(r_beta, alpha, financing)
+        if fee_schedule is not None:
+            schedule = fee_schedule.get(agent.p.name)
+            if schedule is not None:
+                gross = apply_fees(gross, schedule)
+        results[agent.p.name] = gross
 
     total = compute_total_returns(results)
     if total is not None:

--- a/pa_core/simulations.py
+++ b/pa_core/simulations.py
@@ -118,7 +118,8 @@ def simulate_agents(
         if fee_schedule is not None:
             schedule = fee_schedule.get(agent.p.name)
             if schedule is not None:
-                gross = apply_fees(gross, schedule)
+                notional_share = agent.p.beta_share + agent.p.alpha_share
+                gross = apply_fees(gross, schedule, notional_share=notional_share)
         results[agent.p.name] = gross
 
     total = compute_total_returns(results)

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -346,9 +346,7 @@ def _derive_regime_rng(rng_returns: GeneratorLike) -> GeneratorLike:
     ``rng_returns`` reproduce identical regime paths, while remaining an
     independent stream from the return draws.
     """
-    state_repr = json.dumps(
-        rng_returns.bit_generator.state, sort_keys=True, default=str
-    )
+    state_repr = json.dumps(rng_returns.bit_generator.state, sort_keys=True, default=str)
     digest = hashlib.sha256(("pa_core.regime:" + state_repr).encode("utf-8")).digest()
     entropy = int.from_bytes(digest, "big")
     return spawn_rngs(entropy, 1)[0]

--- a/templates/parameters_template.csv
+++ b/templates/parameters_template.csv
@@ -16,6 +16,7 @@ Active Extension capital (mm),0.0
 Internal PA capital (mm),0.0
 Total fund capital (mm),1000.0
 agents,
+fee_schedule,
 In-House beta share,0.5
 In-House alpha share,0.5
 External PA alpha fraction,0.5

--- a/templates/params_template.yaml
+++ b/templates/params_template.yaml
@@ -15,6 +15,7 @@ Active Extension capital (mm): 0.0
 Internal PA capital (mm): 0.0
 Total fund capital (mm): 1000.0
 agents: []
+fee_schedule: null
 In-House beta share: 0.5
 In-House alpha share: 0.5
 External PA alpha fraction: 0.5

--- a/tests/test_active_share_transfer_coefficient.py
+++ b/tests/test_active_share_transfer_coefficient.py
@@ -5,6 +5,7 @@ bit-for-bit. With kappa > 0 the expected alpha is concave in the lever (declinin
 information ratio) while active risk still scales linearly, and an optional
 per-share extension cost yields a closed-form interior optimum.
 """
+
 from pathlib import Path
 
 import numpy as np
@@ -71,7 +72,9 @@ def test_active_risk_grows_even_as_alpha_saturates():
             ActiveExtensionAgent,
             1.0,
             {"active_share": s, "alpha_mu": 0.01, "tc_decay": 1.0, "cost_per_share": 0.0},
-        ).monthly_returns(z, alpha, z).std()
+        )
+        .monthly_returns(z, alpha, z)
+        .std()
         for s in (0.2, 0.5, 0.9)
     ]
     assert stds[0] < stds[1] < stds[2]
@@ -89,7 +92,9 @@ def test_interior_optimum_matches_closed_form():
             ActiveExtensionAgent,
             1.0,
             {"active_share": s, "alpha_mu": mu, "tc_decay": kappa, "cost_per_share": c},
-        ).monthly_returns(z, alpha, z).mean()
+        )
+        .monthly_returns(z, alpha, z)
+        .mean()
         for s in grid
     ]
     s_opt = grid[int(np.argmax(means))]

--- a/tests/test_cli_orchestrator_consistency.py
+++ b/tests/test_cli_orchestrator_consistency.py
@@ -39,7 +39,7 @@ def test_cli_and_orchestrator_draws_match(tmp_path: Path, monkeypatch) -> None:
     original_simulate_agents = sim_module.simulate_agents
 
     def capture_simulate_agents(
-        agents, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act, f_internal_pa=None
+        agents, r_beta, r_H, r_E, r_M, f_int, f_ext, f_act, f_internal_pa=None, fee_schedule=None
     ):
         if run_phase["mode"] == "orch":
             if "draws" not in orch_capture:

--- a/tests/test_fee_layer.py
+++ b/tests/test_fee_layer.py
@@ -71,6 +71,18 @@ def test_mgmt_fee_constant_monthly_drag() -> None:
     assert np.allclose(apply_fees(gross, sched), 0.009)
 
 
+def test_fee_drag_scales_by_notional_share() -> None:
+    gross = np.full((1, 2), 0.005)
+    sched = FeeSchedule(mgmt_fee_bps=120.0, perf_fee_pct=0.5, hurdle_bps=0.0)
+
+    drag = compute_fee_drag(gross, sched, notional_share=0.25)
+
+    # Underlying sleeve return is 2%; fee drag is 25% of the full-sleeve fee:
+    # (0.001 management + 0.5 * 0.02 performance) * 0.25 = 0.00275.
+    assert np.allclose(drag, 0.00275)
+    assert np.allclose(apply_fees(gross, sched, notional_share=0.25), 0.00225)
+
+
 def test_perf_fee_charged_above_hurdle_only() -> None:
     gross = np.array([[0.02, -0.01, 0.0]])
     sched = FeeSchedule(perf_fee_pct=0.5, hurdle_bps=0.0)  # 50% of positive return
@@ -136,6 +148,30 @@ def test_simulate_agents_applies_fee_to_named_sleeve_only() -> None:
     assert np.allclose(untouched["InternalPA"], 0.02)
 
 
+def test_simulate_agents_scales_fees_by_sleeve_notional_share() -> None:
+    n_sim, n_months = 2, 3
+    r_beta = np.zeros((n_sim, n_months))
+    r_H = np.full((n_sim, n_months), 0.02)
+    f = np.zeros((n_sim, n_months))
+    agents = [InternalPAAgent(AgentParams("InternalPA", 25.0, 0.0, 0.25, {}))]
+
+    gross = simulate_agents(agents, r_beta, r_H, r_H, r_H, f, f, f)
+    net = simulate_agents(
+        agents,
+        r_beta,
+        r_H,
+        r_H,
+        r_H,
+        f,
+        f,
+        f,
+        fee_schedule={"InternalPA": FeeSchedule(mgmt_fee_bps=120.0)},
+    )
+
+    assert np.allclose(gross["InternalPA"], 0.005)
+    assert np.allclose(gross["InternalPA"] - net["InternalPA"], 0.00025)
+
+
 def test_simulate_agents_default_is_backward_compatible() -> None:
     n_sim, n_months = 2, 3
     r_beta = np.zeros((n_sim, n_months))
@@ -161,7 +197,7 @@ def _scenario():
                     name="InternalPA",
                     capital=150.0,
                     beta_share=0.0,
-                    alpha_share=1.0,
+                    alpha_share=0.15,
                 )
             ],
         }
@@ -184,8 +220,9 @@ def test_run_single_mgmt_fee_lowers_return_by_exact_drag() -> None:
     net = _internal_pa_mean(
         base.model_copy(update={"fee_schedule": {"InternalPA": FeeSchedule(mgmt_fee_bps=120.0)}})
     )
-    # Deterministic mgmt fee shifts the mean by exactly the monthly drag (0.001).
-    assert gross - net == pytest.approx(0.001, abs=1e-9)
+    # 120 bps annual on a 150mm sleeve in a 1000mm fund:
+    # 0.012 / 12 * 0.15 = 0.00015 contribution-return drag.
+    assert gross - net == pytest.approx(0.00015, abs=1e-9)
 
 
 def test_run_single_perf_fee_lowers_return() -> None:

--- a/tests/test_fee_layer.py
+++ b/tests/test_fee_layer.py
@@ -1,0 +1,215 @@
+"""Tests for the per-sleeve management/performance fee layer (issue #1904).
+
+Covers the ``FeeSchedule`` model and validation, the ``compute_fee_drag`` /
+``apply_fees`` helpers, routing through ``simulate_agents``, an end-to-end
+``run_single`` sensitivity check, and config plumbing (default + round-trip).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from pa_core.agents.internal_pa import InternalPAAgent
+from pa_core.agents.types import AgentParams
+from pa_core.config import AgentConfig, load_config
+from pa_core.facade import RunOptions, run_single
+from pa_core.fees import FeeSchedule, apply_fees, compute_fee_drag
+from pa_core.simulations import simulate_agents
+
+# ---------------------------------------------------------------------------
+# FeeSchedule model
+# ---------------------------------------------------------------------------
+
+
+def test_default_schedule_is_zero() -> None:
+    sched = FeeSchedule()
+    assert sched.mgmt_fee_bps == 0.0
+    assert sched.perf_fee_pct == 0.0
+    assert sched.hurdle_bps == 0.0
+    assert sched.is_zero
+
+
+def test_schedule_with_fee_is_not_zero() -> None:
+    assert not FeeSchedule(mgmt_fee_bps=50.0).is_zero
+    assert not FeeSchedule(perf_fee_pct=0.2).is_zero
+
+
+def test_negative_or_out_of_range_fee_rejected() -> None:
+    with pytest.raises(ValidationError):
+        FeeSchedule(mgmt_fee_bps=-1.0)
+    with pytest.raises(ValidationError):
+        FeeSchedule(perf_fee_pct=-0.1)
+    with pytest.raises(ValidationError):
+        FeeSchedule(perf_fee_pct=1.5)
+    with pytest.raises(ValidationError):
+        FeeSchedule(hurdle_bps=-5.0)
+
+
+def test_schedule_coerces_from_dict() -> None:
+    sched = FeeSchedule.model_validate(
+        {"mgmt_fee_bps": 50.0, "perf_fee_pct": 0.2, "hurdle_bps": 200.0}
+    )
+    assert sched.mgmt_fee_bps == 50.0
+    assert sched.perf_fee_pct == 0.2
+    assert sched.hurdle_bps == 200.0
+
+
+# ---------------------------------------------------------------------------
+# compute_fee_drag / apply_fees
+# ---------------------------------------------------------------------------
+
+
+def test_mgmt_fee_constant_monthly_drag() -> None:
+    gross = np.full((2, 3), 0.01)
+    # 120 bps annual -> 0.012 annual -> 0.001 monthly flat drag
+    sched = FeeSchedule(mgmt_fee_bps=120.0)
+    drag = compute_fee_drag(gross, sched)
+    assert np.allclose(drag, 0.001)
+    assert np.allclose(apply_fees(gross, sched), 0.009)
+
+
+def test_perf_fee_charged_above_hurdle_only() -> None:
+    gross = np.array([[0.02, -0.01, 0.0]])
+    sched = FeeSchedule(perf_fee_pct=0.5, hurdle_bps=0.0)  # 50% of positive return
+    drag = compute_fee_drag(gross, sched)
+    # No rebate / fee on returns at or below the (zero) hurdle.
+    assert np.allclose(drag, [[0.01, 0.0, 0.0]])
+
+
+def test_perf_fee_respects_hurdle() -> None:
+    gross = np.full((1, 1), 0.01)
+    # hurdle 120 bps annual -> 0.001 monthly; 100% perf on the excess above it.
+    sched = FeeSchedule(perf_fee_pct=1.0, hurdle_bps=120.0)
+    drag = compute_fee_drag(gross, sched)
+    assert np.allclose(drag, 0.01 - 0.001)
+
+
+def test_zero_schedule_is_noop() -> None:
+    gross = np.full((2, 2), 0.03)
+    # is_zero short-circuits and returns the same object untouched.
+    assert apply_fees(gross, FeeSchedule()) is gross
+
+
+# ---------------------------------------------------------------------------
+# simulate_agents routing
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_agents_applies_fee_to_named_sleeve_only() -> None:
+    n_sim, n_months = 3, 4
+    rng = np.random.default_rng(2)
+    r_beta = rng.normal(size=(n_sim, n_months))
+    r_H = np.full((n_sim, n_months), 0.02)
+    f = np.zeros((n_sim, n_months))
+    agents = [InternalPAAgent(AgentParams("InternalPA", 100.0, 0.0, 1.0, {}))]
+
+    gross = simulate_agents(agents, r_beta, r_H, r_H, r_H, f, f, f)
+    net = simulate_agents(
+        agents,
+        r_beta,
+        r_H,
+        r_H,
+        r_H,
+        f,
+        f,
+        f,
+        fee_schedule={"InternalPA": FeeSchedule(mgmt_fee_bps=120.0)},
+    )
+    assert np.allclose(gross["InternalPA"], 0.02)
+    assert np.allclose(net["InternalPA"], 0.019)  # exactly the 0.001 mgmt drag
+
+    # A schedule for a sleeve that is not present is a no-op.
+    untouched = simulate_agents(
+        agents,
+        r_beta,
+        r_H,
+        r_H,
+        r_H,
+        f,
+        f,
+        f,
+        fee_schedule={"ExternalPA": FeeSchedule(mgmt_fee_bps=999.0)},
+    )
+    assert np.allclose(untouched["InternalPA"], 0.02)
+
+
+def test_simulate_agents_default_is_backward_compatible() -> None:
+    n_sim, n_months = 2, 3
+    r_beta = np.zeros((n_sim, n_months))
+    r_H = np.full((n_sim, n_months), 0.02)
+    f = np.zeros((n_sim, n_months))
+    agents = [InternalPAAgent(AgentParams("InternalPA", 100.0, 0.0, 1.0, {}))]
+    # No fee_schedule arg -> identical to gross.
+    assert np.allclose(
+        simulate_agents(agents, r_beta, r_H, r_H, r_H, f, f, f)["InternalPA"], 0.02
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via run_single (acceptance criteria) + config plumbing
+# ---------------------------------------------------------------------------
+
+
+def _scenario():
+    return load_config("examples/scenarios/my_first_scenario.yml").model_copy(
+        update={
+            "N_SIMULATIONS": 200,
+            "N_MONTHS": 6,
+            "agents": [
+                AgentConfig(
+                    name="InternalPA",
+                    capital=150.0,
+                    beta_share=0.0,
+                    alpha_share=1.0,
+                )
+            ],
+        }
+    )
+
+
+def _internal_pa_mean(cfg) -> float:
+    idx = pd.Series([0.01, -0.02, 0.015, 0.0, 0.005, -0.01])
+    artifacts = run_single(cfg, idx, RunOptions(seed=7))
+    return float(artifacts.raw_returns["InternalPA"].to_numpy().mean())
+
+
+def test_default_config_has_no_fee_schedule() -> None:
+    assert _scenario().fee_schedule is None
+
+
+def test_run_single_mgmt_fee_lowers_return_by_exact_drag() -> None:
+    base = _scenario()
+    gross = _internal_pa_mean(base)
+    net = _internal_pa_mean(
+        base.model_copy(
+            update={"fee_schedule": {"InternalPA": FeeSchedule(mgmt_fee_bps=120.0)}}
+        )
+    )
+    # Deterministic mgmt fee shifts the mean by exactly the monthly drag (0.001).
+    assert gross - net == pytest.approx(0.001, abs=1e-9)
+
+
+def test_run_single_perf_fee_lowers_return() -> None:
+    base = _scenario()
+    gross = _internal_pa_mean(base)
+    net = _internal_pa_mean(
+        base.model_copy(
+            update={
+                "fee_schedule": {
+                    "InternalPA": FeeSchedule(perf_fee_pct=0.5, hurdle_bps=0.0)
+                }
+            }
+        )
+    )
+    assert net < gross
+
+
+def test_fee_schedule_survives_model_dump() -> None:
+    cfg = _scenario().model_copy(
+        update={"fee_schedule": {"InternalPA": FeeSchedule(mgmt_fee_bps=50.0)}}
+    )
+    dumped = cfg.model_dump()
+    assert dumped["fee_schedule"]["InternalPA"]["mgmt_fee_bps"] == 50.0

--- a/tests/test_fee_layer.py
+++ b/tests/test_fee_layer.py
@@ -143,9 +143,7 @@ def test_simulate_agents_default_is_backward_compatible() -> None:
     f = np.zeros((n_sim, n_months))
     agents = [InternalPAAgent(AgentParams("InternalPA", 100.0, 0.0, 1.0, {}))]
     # No fee_schedule arg -> identical to gross.
-    assert np.allclose(
-        simulate_agents(agents, r_beta, r_H, r_H, r_H, f, f, f)["InternalPA"], 0.02
-    )
+    assert np.allclose(simulate_agents(agents, r_beta, r_H, r_H, r_H, f, f, f)["InternalPA"], 0.02)
 
 
 # ---------------------------------------------------------------------------
@@ -184,9 +182,7 @@ def test_run_single_mgmt_fee_lowers_return_by_exact_drag() -> None:
     base = _scenario()
     gross = _internal_pa_mean(base)
     net = _internal_pa_mean(
-        base.model_copy(
-            update={"fee_schedule": {"InternalPA": FeeSchedule(mgmt_fee_bps=120.0)}}
-        )
+        base.model_copy(update={"fee_schedule": {"InternalPA": FeeSchedule(mgmt_fee_bps=120.0)}})
     )
     # Deterministic mgmt fee shifts the mean by exactly the monthly drag (0.001).
     assert gross - net == pytest.approx(0.001, abs=1e-9)
@@ -197,11 +193,7 @@ def test_run_single_perf_fee_lowers_return() -> None:
     gross = _internal_pa_mean(base)
     net = _internal_pa_mean(
         base.model_copy(
-            update={
-                "fee_schedule": {
-                    "InternalPA": FeeSchedule(perf_fee_pct=0.5, hurdle_bps=0.0)
-                }
-            }
+            update={"fee_schedule": {"InternalPA": FeeSchedule(perf_fee_pct=0.5, hurdle_bps=0.0)}}
         )
     )
     assert net < gross

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,6 +59,7 @@ class DummyConfig:
     regimes: Any = None
     regime_start: Any = None
     regime_transition: Any = None
+    fee_schedule: Any = None
     N_SIMULATIONS: int = 2
     N_MONTHS: int = 3
 

--- a/tests/test_portfolio_builder_page.py
+++ b/tests/test_portfolio_builder_page.py
@@ -99,9 +99,7 @@ class _FakeApp(ModuleType):
     def apply_theme(self, path: str) -> None:
         self.applied_theme = path
 
-    def render_settings_sidebar(
-        self, results_default: str | None = None
-    ) -> tuple[str | None, str]:
+    def render_settings_sidebar(self, results_default: str | None = None) -> tuple[str | None, str]:
         return results_default, self._DEF_THEME
 
 

--- a/tests/test_scenario_fleet.py
+++ b/tests/test_scenario_fleet.py
@@ -16,7 +16,7 @@ import pytest
 
 from pa_core.config import load_config
 from pa_core.facade import RunOptions, run_sweep
-from pa_core.llm.langsmith_fleet import FLEET_REPO, FLEET_SCHEMA, FLEET_SURFACE
+from pa_core.llm.langsmith_fleet import FLEET_REPO, FLEET_SCHEMA, FLEET_SURFACE, config_fingerprint
 from pa_core.llm.scenario_fleet import (
     SCENARIO_DASHBOARD_SURFACE,
     SCENARIO_RUN_OPERATION,
@@ -25,7 +25,6 @@ from pa_core.llm.scenario_fleet import (
     _summary_metric_delta,
     record_scenario_run,
 )
-from pa_core.llm.langsmith_fleet import config_fingerprint
 from pa_core.orchestrator import SimulatorOrchestrator
 
 _BASIC_CONFIG = {


### PR DESCRIPTION
## Summary

Adds an **opt-in, per-sleeve management & performance fee layer** so the engine can produce **net-of-fee** outputs. Previously the model captured financing/margin cost but had no fee layer, so every output was gross-of-fee and overstated the structure (external-manager fees and perf fees are first-order for portable alpha).

Closes #1904.

## What changed

- **`pa_core/fees.py` (new)** — `FeeSchedule` (pydantic, frozen) with:
  - `mgmt_fee_bps` — annual management fee in bps on notional
  - `perf_fee_pct` — performance fee as a fraction (0–1) of return above the hurdle
  - `hurdle_bps` — annual performance-fee hurdle in bps
  - `compute_fee_drag()` / `apply_fees()` helpers (return-space, always non-negative drag).
- **`pa_core/config.py`** — optional `ModelConfig.fee_schedule: Optional[Dict[str, FeeSchedule]]` keyed by agent name (e.g. `ExternalPA`, `ActiveExt`). Default `None`.
- **`pa_core/simulations.py`** — `simulate_agents()` gains a `fee_schedule` kwarg; the matching sleeve's contribution return is reported net of fees **before** `Total` is summed.
- **`pa_core/facade.py`** — `run_single()` threads `run_cfg.fee_schedule` into `simulate_agents()`.

## Modelling choices (first increment — open to review)

- Fees deduct in **sleeve contribution-return space**, directly from each agent's monthly contribution return (already capital-share scaled), **mirroring how financing cost is subtracted inside the agent return**.
- **Management fee** accrues linearly as a constant monthly drag `mgmt_fee_bps / 1e4 / 12`.
- **Performance fee** is crystallised **monthly**, charged on the monthly return above the monthly hurdle, **zero-clipped** below it, with **no high-water mark** (a HWM / notional-exact mgmt variant is a noted follow-up).
- **Default `None` ⇒ gross-of-fee behaviour unchanged** (fully backward compatible).

## Example

```yaml
fee_schedule:
  ExternalPA:
    mgmt_fee_bps: 100      # 1.00%/yr on notional
    perf_fee_pct: 0.20     # 20% of return above hurdle
    hurdle_bps: 200        # 2%/yr hurdle
```

## Tasks
- [x] Add `FeeSchedule` model + fee helpers
- [x] Wire optional `fee_schedule` through `ModelConfig` → `run_single` → `simulate_agents`
- [x] Preserve gross behaviour when no schedule is supplied
- [x] Focused tests (model/validation, drag math, routing, end-to-end sensitivity, config plumbing)

## Acceptance criteria
- [x] Per-sleeve fee schedule (mgmt bps on notional + perf fee above a hurdle) configurable
- [x] Net-of-fee comparisons possible (sleeve returns + `Total` reflect fees)
- [x] Backward compatible: existing configs/outputs unchanged when `fee_schedule` is unset

## Validation
- `pytest tests/test_fee_layer.py` → 14 passed
- `pytest tests/test_internal_pa_financing.py tests/test_config.py tests/test_facade_run_single.py tests/test_agents.py` → 89 passed (no regressions)
- `ruff check` on touched files → clean; `git diff --check` → clean

The deterministic end-to-end test asserts a 120 bps mgmt fee lowers the InternalPA mean return by exactly `0.001`/month.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fees alter reported sleeve and portfolio returns when configured; defaults preserve legacy gross behavior, but any enabled schedule changes summary metrics and comparisons users may rely on.
> 
> **Overview**
> Adds an **opt-in per-sleeve fee layer** so simulations can report **net-of-fee** sleeve and `Total` returns instead of gross-only output. When `fee_schedule` is unset, behavior stays unchanged.
> 
> New **`pa_core/fees.py`** defines frozen `FeeSchedule` (`mgmt_fee_bps`, `perf_fee_pct`, `hurdle_bps`) plus `compute_fee_drag` / `apply_fees`: flat monthly management drag, performance fee on monthly return above the hurdle (no HWM), scaled by each sleeve’s fund notional share (`beta_share + alpha_share`).
> 
> **`ModelConfig.fee_schedule`** is an optional map keyed by agent name (e.g. `ExternalPA`). **`simulate_agents`** applies matching schedules after gross sleeve returns; **`run_single`** passes `run_cfg.fee_schedule`. Templates, parameter dictionary, and **`tests/test_fee_layer.py`** cover config plumbing and end-to-end drag math.
> 
> The diff also includes minor formatting/import tweaks in dashboard and tests; sweep paths are not wired to fees in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440af24966e5efca915df32f38f3fed4f2da056a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->