### PR TITLE
test(dashboard): fix FakeStreamlit.expander context manager (repair red main CI)

### DIFF
--- a/tests/test_dashboard_advanced_settings.py
+++ b/tests/test_dashboard_advanced_settings.py
@@ -63,6 +63,14 @@ class FakeStreamlit:
     def set_page_config(self, **kwargs: Any) -> None:
         self.events.append(("set_page_config", kwargs))
 
+    def expander(self, label: str, expanded: bool = False) -> _FakeExpander:
+        # Top-level ``st.expander`` is a context manager (e.g. the getting-started
+        # block in ``main`` via ``_render_getting_started``). Without this the
+        # catch-all ``__getattr__`` below returns a no-op that yields ``None``,
+        # which is not a context manager and breaks ``with st.expander(...)``.
+        self.events.append(("expander", label, expanded))
+        return _FakeExpander(self, label)
+
     def __getattr__(self, _name: str):  # no-op for title/write/page_link/etc.
         def _noop(*args: Any, **kwargs: Any) -> None:
             return None


### PR DESCRIPTION
## Summary
`main` CI was red: `tests/test_dashboard_advanced_settings.py::test_home_page_sets_real_title` failed with `TypeError: 'NoneType' object does not support the context manager protocol`.

**Root cause (test-only):** the test calls `app.main()` → `_render_getting_started()`, which uses a **top-level** `with st.expander(...)` ([dashboard/app.py:211](../blob/main/dashboard/app.py#L211)). The `FakeStreamlit` mock only defined `expander` on the *sidebar*; the top-level call fell through to the catch-all `__getattr__` no-op (returns `None`), so `with None:` raised. The dashboard code is correct.

**Fix:** add a top-level `FakeStreamlit.expander` returning the existing `_FakeExpander` context manager.

**Tests:** the 3 dashboard test files now pass (10 passed, was 9 passed / 1 failed); `ruff` clean.

Context: this test shipped with the auto-pilot work for issue #1902 (advanced-settings expander + real home-page title); the mock was just incomplete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock change; no production dashboard or runtime behavior is modified.
> 
> **Overview**
> Fixes failing dashboard tests by teaching the **`FakeStreamlit`** test double to handle **top-level** `st.expander(...)`, not only `st.sidebar.expander`.
> 
> `app.main()` runs `_render_getting_started()`, which uses `with st.expander(...)`. The mock’s catch-all `__getattr__` returned `None`, so `test_home_page_sets_real_title` crashed with a context-manager `TypeError`. The new method records expander events and returns the existing **`_FakeExpander`** context manager, matching real Streamlit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40c28e75b9fc5ff4203589745b51552bec5c2fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->