### PR TITLE
lint: ignore E402 in notebooks (repair red main ruff check)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,13 @@ extend-exclude = ["archive/*", "build/*", "dist/*"]
 [tool.ruff.lint]
 extend-ignore = ["E501"]
 
+[tool.ruff.lint.per-file-ignores]
+# Tutorial notebooks deliberately run setup code (repo-root discovery,
+# sys.path.insert, os.chdir, matplotlib/warnings configuration) before the
+# bulk of their imports in the bootstrap cell, so the later module-level
+# imports legitimately trip E402. Suppress it for notebooks only.
+"*.ipynb" = ["E402"]
+
 [tool.black]
 line-length = 100
 target-version = ['py312']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ extend-ignore = ["E501"]
 # sys.path.insert, os.chdir, matplotlib/warnings configuration) before the
 # bulk of their imports in the bootstrap cell, so the later module-level
 # imports legitimately trip E402. Suppress it for notebooks only.
-"*.ipynb" = ["E402"]
+"**/*.ipynb" = ["E402"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## Repair red \`main\` (lint-ruff / `ruff check .`)

The repo-wide `ruff check --extend-exclude .workflows-lib .` that backs the **Python CI / lint-ruff** Gate job went red on `main` after the tutorial notebook merged:

```
docs/tutorial/PortableAlpha_Tutorial.ipynb:cell 3:38-44: E402 Module level import not at top of cell  (×6)
```

Cell 3 is a bootstrap cell: it discovers the repo root, does `sys.path.insert(0, ROOT)` + `os.chdir(ROOT)`, configures the matplotlib cache dir / warnings / an ipykernel patch, and only **then** imports `pa_core`, `numpy`, `pandas`, etc. Those imports must run after the path/cwd setup, so E402 is a legitimate false-positive here.

### Fix
Add a ruff per-file-ignore for notebooks:

```toml
[tool.ruff.lint.per-file-ignores]
"*.ipynb" = ["E402"]
```

`pyproject.toml`-only; the notebook is left untouched (avoids JSON churn / conflicts with any in-flight notebook work).

### Validation
`ruff check --extend-exclude .workflows-lib .` (Python 3.12, matching CI) → **All checks passed!** TOML parses clean.

### Impact
Unblocks the **lint-ruff Gate for every open PAEM PR** (e.g. #1938, #1939), which were inheriting this red-main failure on rebase.

Opened by the closer lane (broken-main completion-debt repair).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only lint exception scoped to notebooks; Python modules still enforce E402.
> 
> **Overview**
> Restores a green **lint-ruff** CI run by adding `[tool.ruff.lint.per-file-ignores]` so `**/*.ipynb` files skip **E402** (module-level import not at top of file).
> 
> Tutorial notebooks use a bootstrap cell (`sys.path`, `os.chdir`, matplotlib/warnings setup) before importing `pa_core` and other libraries, which ruff flags even though that order is intentional. **Only** `pyproject.toml` changes; notebooks are not edited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b7c34894f2d2ce8f4259af288db1ce401922a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->