### PR TITLE
fix(config): reject inert financing spike settings

### DIFF
--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -229,6 +229,11 @@ class ModelConfig(BaseModel):
             "monthly": ("sigma_M_monthly",),
         },
     }
+    _FINANCING_SPIKE_FIELDS: ClassVar[tuple[tuple[str, str, str], ...]] = (
+        ("internal_financing_sigma_month", "internal_spike_prob", "internal_spike_factor"),
+        ("ext_pa_financing_sigma_month", "ext_pa_spike_prob", "ext_pa_spike_factor"),
+        ("act_ext_financing_sigma_month", "act_ext_spike_prob", "act_ext_spike_factor"),
+    )
 
     backend: str = Field(default="numpy")
     N_SIMULATIONS: int = Field(gt=0, alias="Number of simulations")
@@ -806,6 +811,23 @@ class ModelConfig(BaseModel):
             raise ValueError(f"financing_model must be one of: {sorted(valid)}")
         if self.financing_model == "schedule" and self.financing_schedule_path is None:
             raise ValueError("financing_schedule_path required for schedule financing model")
+        return self
+
+    @model_validator(mode="after")
+    def check_financing_spikes_have_volatility(self) -> "ModelConfig":
+        self._trace_transform(self, "check_financing_spikes_have_volatility")
+        inert_spikes = []
+        for sigma_field, prob_field, factor_field in self._FINANCING_SPIKE_FIELDS:
+            sigma = float(getattr(self, sigma_field))
+            spike_prob = float(getattr(self, prob_field))
+            spike_factor = float(getattr(self, factor_field))
+            if sigma == 0.0 and (spike_prob > 0.0 or spike_factor > 0.0):
+                inert_spikes.append(f"{prob_field}/{factor_field} require {sigma_field} > 0")
+        if inert_spikes:
+            raise ValueError(
+                "financing spike settings are inert when financing volatility is zero: "
+                + "; ".join(inert_spikes)
+            )
         return self
 
     @model_validator(mode="after")

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -816,18 +816,7 @@ class ModelConfig(BaseModel):
     @model_validator(mode="after")
     def check_financing_spikes_have_volatility(self) -> "ModelConfig":
         self._trace_transform(self, "check_financing_spikes_have_volatility")
-        inert_spikes = []
-        for sigma_field, prob_field, factor_field in self._FINANCING_SPIKE_FIELDS:
-            sigma = float(getattr(self, sigma_field))
-            spike_prob = float(getattr(self, prob_field))
-            spike_factor = float(getattr(self, factor_field))
-            if sigma == 0.0 and (spike_prob > 0.0 or spike_factor != 0.0):
-                inert_spikes.append(f"{prob_field}/{factor_field} require {sigma_field} > 0")
-        if inert_spikes:
-            raise ValueError(
-                "financing spike settings are inert when financing volatility is zero: "
-                + "; ".join(inert_spikes)
-            )
+        validate_financing_spikes(self)
         return self
 
     @model_validator(mode="after")
@@ -1103,6 +1092,30 @@ class ModelConfig(BaseModel):
             raise ValueError("; ".join(error_messages))
 
         return self
+
+
+def validate_financing_spikes(cfg: "ModelConfig") -> None:
+    """Raise ``ValueError`` if any financing spike is configured with zero volatility.
+
+    Shared by :meth:`ModelConfig.check_financing_spikes_have_volatility` (run at
+    construction) and the parameter sweep, which builds each case with
+    ``model_copy`` and therefore does not re-run model validators. Only the inert
+    spike check is enforced on sweep overrides; broader constraints such as the
+    capital buffer are intentionally not re-validated so the sweep can still
+    explore over-margin parameter combinations.
+    """
+    inert_spikes = []
+    for sigma_field, prob_field, factor_field in cfg._FINANCING_SPIKE_FIELDS:
+        sigma = float(getattr(cfg, sigma_field))
+        spike_prob = float(getattr(cfg, prob_field))
+        spike_factor = float(getattr(cfg, factor_field))
+        if sigma == 0.0 and (spike_prob > 0.0 or spike_factor != 0.0):
+            inert_spikes.append(f"{prob_field}/{factor_field} require {sigma_field} > 0")
+    if inert_spikes:
+        raise ValueError(
+            "financing spike settings are inert when financing volatility is zero: "
+            + "; ".join(inert_spikes)
+        )
 
 
 def load_config(path: Union[str, Path, Dict[str, Any]]) -> ModelConfig:

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -821,7 +821,7 @@ class ModelConfig(BaseModel):
             sigma = float(getattr(self, sigma_field))
             spike_prob = float(getattr(self, prob_field))
             spike_factor = float(getattr(self, factor_field))
-            if sigma == 0.0 and (spike_prob > 0.0 or spike_factor > 0.0):
+            if sigma == 0.0 and (spike_prob > 0.0 or spike_factor != 0.0):
                 inert_spikes.append(f"{prob_field}/{factor_field} require {sigma_field} > 0")
         if inert_spikes:
             raise ValueError(

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -21,7 +21,7 @@ except ImportError:  # pragma: no cover - fallback when tqdm is unavailable
     _HAS_TQDM = False
 
 from .agents.registry import build_from_config
-from .config import ModelConfig, SweepConfig, SweepParameter, normalize_share
+from .config import ModelConfig, SweepConfig, SweepParameter, normalize_share, validate_financing_spikes
 from .contracts import SUMMARY_NUMERIC_COLUMNS
 from .random import spawn_agent_rngs, spawn_rngs
 from .sim import (
@@ -589,7 +589,12 @@ def run_parameter_sweep(
             for name, rng in fin_rngs.items():
                 rng.bit_generator.state = copy.deepcopy(fin_rng_states[name])
 
-        mod_cfg = type(cfg).model_validate({**cfg.model_dump(), **overrides})
+        # Build each sweep case with ``model_copy`` (no full re-validation) so the
+        # grid can explore over-margin capital combinations as before, but re-run
+        # the inert-spike check so a sweep override cannot silently introduce a
+        # spike with zero financing volatility.
+        mod_cfg = cfg.model_copy(update=overrides)
+        validate_financing_spikes(mod_cfg)
 
         if returns_static:
             if base_params is None:

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -589,7 +589,7 @@ def run_parameter_sweep(
             for name, rng in fin_rngs.items():
                 rng.bit_generator.state = copy.deepcopy(fin_rng_states[name])
 
-        mod_cfg = cfg.model_copy(update=overrides)
+        mod_cfg = type(cfg).model_validate({**cfg.model_dump(), **overrides})
 
         if returns_static:
             if base_params is None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -260,6 +260,53 @@ def test_spike_prob_and_financing_sigma_bounds():
         ModelConfig(**base, internal_pa_financing_sigma_month=-0.01)
 
 
+@pytest.mark.parametrize(
+    ("sigma_field", "prob_field", "factor_field"),
+    [
+        (
+            "internal_financing_sigma_month",
+            "internal_spike_prob",
+            "internal_spike_factor",
+        ),
+        (
+            "ext_pa_financing_sigma_month",
+            "ext_pa_spike_prob",
+            "ext_pa_spike_factor",
+        ),
+        (
+            "act_ext_financing_sigma_month",
+            "act_ext_spike_prob",
+            "act_ext_spike_factor",
+        ),
+    ],
+)
+def test_financing_spikes_require_matching_volatility(sigma_field, prob_field, factor_field):
+    base = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
+
+    with pytest.raises(ValidationError, match=sigma_field):
+        ModelConfig(**base, **{prob_field: 0.25})
+    with pytest.raises(ValidationError, match=sigma_field):
+        ModelConfig(**base, **{factor_field: 2.0})
+
+    cfg = ModelConfig(
+        **base,
+        **{
+            sigma_field: 0.01,
+            prob_field: 0.25,
+            factor_field: 2.0,
+        },
+    )
+    assert getattr(cfg, sigma_field) == 0.01
+
+
+def test_financing_volatility_can_be_zero_when_spikes_are_disabled():
+    cfg = ModelConfig(N_SIMULATIONS=1, N_MONTHS=1, financing_mode="broadcast")
+
+    assert cfg.internal_financing_sigma_month == 0.0
+    assert cfg.ext_pa_financing_sigma_month == 0.0
+    assert cfg.act_ext_financing_sigma_month == 0.0
+
+
 def test_agents_missing_benchmark():
     data = {
         "N_SIMULATIONS": 1,
@@ -730,6 +777,7 @@ def test_model_config_logs_transform_order(caplog: pytest.LogCaptureFixture) -> 
         "normalize_share_inputs",
         "compile_agent_config",
         "check_financing_model",
+        "check_financing_spikes_have_volatility",
         "check_capital",
         "check_return_distribution",
         "check_correlations",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -287,6 +287,8 @@ def test_financing_spikes_require_matching_volatility(sigma_field, prob_field, f
         ModelConfig(**base, **{prob_field: 0.25})
     with pytest.raises(ValidationError, match=sigma_field):
         ModelConfig(**base, **{factor_field: 2.0})
+    with pytest.raises(ValidationError, match=sigma_field):
+        ModelConfig(**base, **{factor_field: -2.0})
 
     cfg = ModelConfig(
         **base,

--- a/tests/test_unit_policy_entrypoints.py
+++ b/tests/test_unit_policy_entrypoints.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 import yaml
 
 from pa_core.cli import main
@@ -276,3 +277,25 @@ def test_sweep_return_overrides_convert_to_monthly(monkeypatch) -> None:
     assert np.isclose(params["default_sigma_H"], 0.01 / np.sqrt(12.0))
     assert np.isclose(params["default_mu_E"], 0.01 / 12.0)
     assert np.isclose(params["default_sigma_E"], 0.02 / np.sqrt(12.0))
+
+
+def test_sweep_overrides_revalidate_inert_spike_settings(monkeypatch) -> None:
+    cfg = load_config(
+        {
+            "N_SIMULATIONS": 1,
+            "N_MONTHS": 2,
+            "financing_mode": "broadcast",
+            "analysis_mode": "returns",
+        }
+    )
+    idx_series = pd.Series([0.0, 0.0])
+
+    monkeypatch.setattr(
+        "pa_core.sweep.generate_parameter_combinations",
+        lambda _cfg: iter([{"internal_spike_prob": 0.25}]),
+    )
+
+    rng_returns = spawn_rngs(7, 1)[0]
+    fin_rngs = spawn_agent_rngs(7, ["internal", "external_pa", "active_ext"])
+    with pytest.raises(ValueError, match="internal_financing_sigma_month"):
+        run_parameter_sweep(cfg, idx_series, rng_returns, fin_rngs, progress=lambda x, **_: x)


### PR DESCRIPTION
## Summary
- add ModelConfig validation that rejects financing spike probability/factor settings when the matching financing volatility is zero
- cover internal, external PA, and active extension financing spike fields
- preserve zero-volatility configs when spike settings are disabled

## Tests
- .venv/bin/pytest tests/test_config.py tests/test_simulations.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen ruff check pa_core/config.py tests/test_config.py
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen --extra dev python -m mypy pa_core/config.py --config-file pyproject.toml

Closes #1911

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-time validation only; prevents silent no-op spike parameters in simulations and sweeps without changing financing draw logic.
> 
> **Overview**
> **`ModelConfig` now rejects misleading financing spike settings** where spike probability or multiplier is non-default but the paired monthly financing volatility (`internal`, external PA, or active extension) is zero—those knobs have no effect without stochastic financing.
> 
> A shared **`validate_financing_spikes`** helper backs a new after-validator on config load and is **called again in `run_parameter_sweep`** after each `model_copy(update=overrides)`, because sweep cases skip full Pydantic re-validation while still allowing over-margin capital exploration without re-running broader capital checks.
> 
> **Zero volatility remains valid** when spike prob and factor stay at their defaults. Tests cover all three spike triplets, transform order, and sweep override failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a9dc1cd76218854a6d15f1caabb4a021df89cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->