### PR TITLE
fix(config): normalize regime sigma overrides (#1913)

### DIFF
--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 import logging
 import math
 import warnings
@@ -707,7 +708,7 @@ class ModelConfig(BaseModel):
 
     @classmethod
     def _normalize_regime_sigma_overrides(cls, regimes: Any) -> Any:
-        if regimes is None or not isinstance(regimes, list):
+        if regimes is None or isinstance(regimes, (str, bytes)) or not isinstance(regimes, Sequence):
             return regimes
 
         normalized: list[Any] = []

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -706,6 +706,34 @@ class ModelConfig(BaseModel):
         return data
 
     @classmethod
+    def _normalize_regime_sigma_overrides(cls, regimes: Any) -> Any:
+        if regimes is None or not isinstance(regimes, list):
+            return regimes
+
+        normalized: list[Any] = []
+        for regime in regimes:
+            if isinstance(regime, RegimeConfig):
+                updates = {
+                    field: annual_vol_to_monthly(float(value))
+                    for field in ("sigma_H", "sigma_E", "sigma_M")
+                    if (value := getattr(regime, field)) is not None
+                }
+                normalized.append(regime.model_copy(update=updates) if updates else regime)
+                continue
+
+            if isinstance(regime, Mapping):
+                regime_data = dict(regime)
+                for field in ("sigma_H", "sigma_E", "sigma_M"):
+                    value = regime_data.get(field)
+                    if value is not None:
+                        regime_data[field] = annual_vol_to_monthly(float(value))
+                normalized.append(regime_data)
+                continue
+
+            normalized.append(regime)
+        return normalized
+
+    @classmethod
     def normalize_return_units(cls, data: Any) -> Any:
         if not isinstance(data, dict):
             return data
@@ -756,6 +784,8 @@ class ModelConfig(BaseModel):
             converted = annual_vol_to_monthly(value)
             for key in keys:
                 updated[key] = converted
+        if "regimes" in updated:
+            updated["regimes"] = cls._normalize_regime_sigma_overrides(updated["regimes"])
         updated["return_unit"] = CANONICAL_RETURN_UNIT
         return updated
 

--- a/tests/test_regime_switching.py
+++ b/tests/test_regime_switching.py
@@ -171,6 +171,31 @@ def test_regime_sigma_overrides_follow_annual_return_unit() -> None:
     assert params[0]["default_sigma_H"] == pytest.approx(annual_vol_to_monthly(0.24))
 
 
+def test_regime_sigma_overrides_follow_annual_return_unit_for_tuple_input() -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=2,
+        financing_mode="broadcast",
+        return_unit="annual",
+        regimes=(
+            {
+                "name": "stress",
+                "sigma_H": 0.24,
+                "sigma_E": 0.30,
+                "sigma_M": 0.36,
+            },
+        ),
+        regime_transition=[[1.0]],
+        regime_start="stress",
+    )
+
+    assert cfg.regimes is not None
+    regime = cfg.regimes[0]
+    assert regime.sigma_H == pytest.approx(annual_vol_to_monthly(0.24))
+    assert regime.sigma_E == pytest.approx(annual_vol_to_monthly(0.30))
+    assert regime.sigma_M == pytest.approx(annual_vol_to_monthly(0.36))
+
+
 def test_regime_sigma_overrides_stay_monthly_when_return_unit_monthly() -> None:
     cfg = ModelConfig(
         N_SIMULATIONS=1,

--- a/tests/test_regime_switching.py
+++ b/tests/test_regime_switching.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pa_core.config import ModelConfig, RegimeConfig
+from pa_core.config import ModelConfig, RegimeConfig, annual_vol_to_monthly
 from pa_core.random import spawn_rngs
 from pa_core.sim.paths import draw_joint_returns
 from pa_core.sim.regimes import (
@@ -132,6 +132,71 @@ def test_simulate_regime_paths_rejects_invalid_inputs() -> None:
             transition=[[1.0]],
             start_state=True,
         )
+
+
+def test_regime_sigma_overrides_follow_annual_return_unit() -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=2,
+        financing_mode="broadcast",
+        return_unit="annual",
+        sigma_H=0.12,
+        sigma_E=0.24,
+        sigma_M=0.36,
+        regimes=[
+            {
+                "name": "stress",
+                "sigma_H": 0.24,
+                "sigma_E": 0.30,
+                "sigma_M": 0.36,
+            }
+        ],
+        regime_transition=[[1.0]],
+        regime_start="stress",
+    )
+
+    assert cfg.regimes is not None
+    regime = cfg.regimes[0]
+    assert regime.sigma_H == pytest.approx(annual_vol_to_monthly(0.24))
+    assert regime.sigma_E == pytest.approx(annual_vol_to_monthly(0.30))
+    assert regime.sigma_M == pytest.approx(annual_vol_to_monthly(0.36))
+
+    params, labels = build_regime_draw_params(
+        cfg,
+        mu_idx=0.0,
+        idx_sigma=0.01,
+        n_samples=120,
+    )
+    assert labels == ["stress"]
+    assert params[0]["default_sigma_H"] == pytest.approx(annual_vol_to_monthly(0.24))
+
+
+def test_regime_sigma_overrides_stay_monthly_when_return_unit_monthly() -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=2,
+        financing_mode="broadcast",
+        return_unit="monthly",
+        sigma_H=0.01,
+        sigma_E=0.02,
+        sigma_M=0.03,
+        regimes=[
+            RegimeConfig(
+                name="stress",
+                sigma_H=0.04,
+                sigma_E=0.05,
+                sigma_M=0.06,
+            )
+        ],
+        regime_transition=[[1.0]],
+        regime_start="stress",
+    )
+
+    assert cfg.regimes is not None
+    regime = cfg.regimes[0]
+    assert regime.sigma_H == pytest.approx(0.04)
+    assert regime.sigma_E == pytest.approx(0.05)
+    assert regime.sigma_M == pytest.approx(0.06)
 
 
 def test_simulate_regime_paths_normalizes_transition_rows() -> None:


### PR DESCRIPTION
## Summary
- normalize nested regime sigma_H/sigma_E/sigma_M overrides when raw configs use annual return units
- preserve already-monthly regime override values when return_unit is monthly
- add regression coverage for stored regime configs and regime draw params

Closes #1913

## Tests
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen pytest tests/test_regime_switching.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen pytest tests/test_facade_run_sweep.py::test_run_sweep_applies_regime_switching tests/test_facade_run_single.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen ruff check pa_core/config.py tests/test_regime_switching.py
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen --extra dev python -m mypy pa_core/config.py pa_core/sim/regimes.py --config-file pyproject.toml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes simulation inputs for annual configs with regime sigma overrides (fixes incorrect vols but alters results vs the prior bug); scope is limited to config normalization.
> 
> **Overview**
> Fixes a unit mismatch where top-level `sigma_H`/`sigma_E`/`sigma_M` were converted to monthly when `return_unit` is annual, but per-regime overrides under `regimes` were left in annual form and could skew regime-switching draws.
> 
> `ModelConfig.normalize_return_units` now runs a new `_normalize_regime_sigma_overrides` pass on nested `regimes`, applying `annual_vol_to_monthly` to any set `sigma_H`, `sigma_E`, or `sigma_M` on dict or `RegimeConfig` entries (including tuple-shaped regime lists). When `return_unit` is already monthly, that annual-conversion branch is skipped so regime overrides stay unchanged.
> 
> Regression tests cover stored regime configs, tuple input, monthly `return_unit`, and `build_regime_draw_params` seeing the converted stress sigmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70a41a157e801409b709ff138eed638b2efd8bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->