### PR TITLE
fix(config): recompile agents after convenience edits (#1915)

### DIFF
--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -694,12 +694,58 @@ class ModelConfig(BaseModel):
         if agents_provided:
             normalized_existing = cls._normalize_agents(existing_agents)
             existing_names = {agent["name"] for agent in normalized_existing}
+            recompiled_names = cls._agent_names_recompiled_by_convenience(data)
             compiled = [
-                agent for agent in compiled if agent["name"] not in existing_names
-            ] + normalized_existing
+                agent
+                for agent in compiled
+                if agent["name"] in recompiled_names or agent["name"] not in existing_names
+            ]
+            compiled_names = {agent["name"] for agent in compiled}
+            compiled = compiled + [
+                agent for agent in normalized_existing if agent["name"] not in compiled_names
+            ]
         normalized = cls._normalize_agents(compiled)
         data["agents"] = normalized
         return data
+
+    @classmethod
+    def _agent_names_recompiled_by_convenience(cls, data: Mapping[str, Any]) -> set[str]:
+        """Return derived agent names controlled by supplied convenience fields."""
+
+        groups = {
+            "Base": {
+                "total_fund_capital",
+                "Total fund capital (mm)",
+                "w_beta_H",
+                "w_alpha_H",
+                "In-House beta share",
+                "In-House alpha share",
+            },
+            "ExternalPA": {
+                "total_fund_capital",
+                "Total fund capital (mm)",
+                "external_pa_capital",
+                "External PA capital (mm)",
+                "theta_extpa",
+                "External PA alpha fraction",
+            },
+            "ActiveExt": {
+                "total_fund_capital",
+                "Total fund capital (mm)",
+                "active_ext_capital",
+                "Active Extension capital (mm)",
+                "active_share",
+                "Active share (%)",
+                "Active share",
+            },
+            "InternalPA": {
+                "total_fund_capital",
+                "Total fund capital (mm)",
+                "internal_pa_capital",
+                "Internal PA capital (mm)",
+            },
+        }
+        return {agent_name for agent_name, keys in groups.items() if any(key in data for key in keys)}
 
     @classmethod
     def normalize_share_inputs(cls, data: Any) -> Any:

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -702,7 +702,9 @@ class ModelConfig(BaseModel):
             ]
             compiled_names = {agent["name"] for agent in compiled}
             compiled = compiled + [
-                agent for agent in normalized_existing if agent["name"] not in compiled_names
+                agent
+                for agent in normalized_existing
+                if agent["name"] not in compiled_names and agent["name"] not in recompiled_names
             ]
         normalized = cls._normalize_agents(compiled)
         data["agents"] = normalized

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,6 +99,48 @@ def test_load_yaml_with_mixed_agents(tmp_path):
     assert {"Base", "ExternalPA", "ActiveExt", "InternalPA", "CustomSleeve"} <= names
 
 
+def test_model_dump_convenience_edits_recompile_standard_agents() -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=1,
+        financing_mode="broadcast",
+        total_fund_capital=1000.0,
+        external_pa_capital=100.0,
+        active_ext_capital=200.0,
+        internal_pa_capital=300.0,
+        w_beta_H=0.6,
+        w_alpha_H=0.4,
+        theta_extpa=0.3,
+        active_share=0.5,
+    )
+    dumped = cfg.model_dump()
+    dumped.update(
+        {
+            "external_pa_capital": 120.0,
+            "active_ext_capital": 180.0,
+            "internal_pa_capital": 240.0,
+            "w_beta_H": 0.7,
+            "w_alpha_H": 0.3,
+            "theta_extpa": 0.8,
+            "active_share": 0.25,
+        }
+    )
+
+    reloaded = ModelConfig(**dumped)
+    agents = {agent.name: agent for agent in reloaded.agents}
+
+    assert agents["Base"].beta_share == pytest.approx(0.7)
+    assert agents["Base"].alpha_share == pytest.approx(0.3)
+    assert agents["ExternalPA"].capital == pytest.approx(120.0)
+    assert agents["ExternalPA"].beta_share == pytest.approx(0.12)
+    assert agents["ExternalPA"].extra["theta_extpa"] == pytest.approx(0.8)
+    assert agents["ActiveExt"].capital == pytest.approx(180.0)
+    assert agents["ActiveExt"].beta_share == pytest.approx(0.18)
+    assert agents["ActiveExt"].extra["active_share"] == pytest.approx(0.25)
+    assert agents["InternalPA"].capital == pytest.approx(240.0)
+    assert agents["InternalPA"].alpha_share == pytest.approx(0.24)
+
+
 def test_load_dict():
     data = {
         "N_SIMULATIONS": 1000,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,6 +141,34 @@ def test_model_dump_convenience_edits_recompile_standard_agents() -> None:
     assert agents["InternalPA"].alpha_share == pytest.approx(0.24)
 
 
+def test_model_dump_zero_capital_convenience_edits_drop_standard_agents() -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=1,
+        financing_mode="broadcast",
+        total_fund_capital=1000.0,
+        external_pa_capital=100.0,
+        active_ext_capital=200.0,
+        internal_pa_capital=300.0,
+    )
+    dumped = cfg.model_dump()
+    dumped.update(
+        {
+            "external_pa_capital": 0.0,
+            "active_ext_capital": 0.0,
+            "internal_pa_capital": 0.0,
+        }
+    )
+
+    reloaded = ModelConfig(**dumped)
+
+    agent_names = {agent.name for agent in reloaded.agents}
+    assert "Base" in agent_names
+    assert "ExternalPA" not in agent_names
+    assert "ActiveExt" not in agent_names
+    assert "InternalPA" not in agent_names
+
+
 def test_load_dict():
     data = {
         "N_SIMULATIONS": 1000,


### PR DESCRIPTION
Closes #1915

## Summary
- Recompile standard generated agent entries when serialized configs are reloaded with edited convenience fields
- Preserve non-standard custom agent entries while replacing stale Base/ExternalPA/ActiveExt/InternalPA generated entries
- Add a model_dump round-trip regression covering active_share, theta_extpa, w_beta_H, and w_alpha_H edits

## Validation
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen pytest tests/test_config.py::test_model_dump_convenience_edits_recompile_standard_agents tests/test_config.py::test_load_yaml_with_mixed_agents tests/test_config.py::test_agents_duplicate_base_in_mixed_config -q
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen pytest tests/test_config.py tests/test_agents.py tests/test_wizard_config_wiring.py tests/test_dashboard_session_handoff.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen ruff check pa_core/config.py tests/test_config.py
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen mypy pa_core/config.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `agents` are built when both `agents` and convenience fields are present; incorrect merge logic could misallocate capital or shares in simulations, but the change aligns behavior with edited top-level fields and is covered by new round-trip tests.
> 
> **Overview**
> Reloading a serialized `ModelConfig` after changing **convenience fields** (capital, in-house shares, `theta_extpa`, `active_share`, etc.) now **replaces stale generated** `Base` / `ExternalPA` / `ActiveExt` / `InternalPA` entries instead of keeping the old `agents` list from `model_dump()`.
> 
> `compile_agent_config` uses a new `_agent_names_recompiled_by_convenience` helper to decide which standard sleeves are driven by the incoming payload, merges freshly compiled agents for those names, and still **keeps custom** agent rows that are not in that set.
> 
> Regression tests cover a `model_dump()` round-trip with edited convenience values and zeroing sleeve capital so optional standard agents are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55775804c96ae9ab75e5e5973b09409a6276251a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->