### PR TITLE
docs: disclose model limitations in README & board-pack (#1923)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,14 @@ If you're new to the project, see the [primer](docs/primer.md) for simple defini
 Read these before relying on any output. The same caveats are printed on a slide
 in every generated board pack (see `pa_core/reporting/disclaimers.py`):
 
-- Results are **gross of fees and costs**.
-- **Total excludes Base** (overlay semantics): a Base-only fund shows `Total = 0`.
-- Monthly draws are **i.i.d.** — no volatility clustering is modelled.
-- **Regimes are ignored in parameter sweeps.**
-- Financing `broadcast` reuses a **single financing path** across simulations.
-- The model is **forward-looking and has not been backtested**.
-- `risk_metrics` is **advisory**: it selects which metrics are reported, not how
-  the simulation runs.
-- `Scenario.sleeves` is **currently unwired** and does not affect simulation
-  results.
+- By default, results are gross of fees and costs; configured `fee_schedule` entries report matching sleeves net of those fees.
+- Total excludes Base (overlay semantics): a Base-only fund shows Total = 0.
+- Monthly draws are i.i.d. — no volatility clustering is modelled.
+- Regimes are ignored in parameter sweeps.
+- Financing `broadcast` reuses a single financing path across simulations.
+- The model is forward-looking and has not been backtested.
+- `risk_metrics` is advisory: it selects which metrics are reported, not how the simulation runs.
+- `Scenario.sleeves` is currently unwired and does not affect simulation results.
 
 ## Optional LLM Features
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ The index CSV should include a `Date` column and a monthly total return column n
 
 If you're new to the project, see the [primer](docs/primer.md) for simple definitions of terms like **active share**, **active return volatility (tracking error, TE)**, and **CVaR**.
 
+## Model Limitations & Caveats
+
+Read these before relying on any output. The same caveats are printed on a slide
+in every generated board pack (see `pa_core/reporting/disclaimers.py`):
+
+- Results are **gross of fees and costs**.
+- **Total excludes Base** (overlay semantics): a Base-only fund shows `Total = 0`.
+- Monthly draws are **i.i.d.** — no volatility clustering is modelled.
+- **Regimes are ignored in parameter sweeps.**
+- Financing `broadcast` reuses a **single financing path** across simulations.
+- The model is **forward-looking and has not been backtested**.
+- `risk_metrics` is **advisory**: it selects which metrics are reported, not how
+  the simulation runs.
+- `Scenario.sleeves` is **currently unwired** and does not affect simulation
+  results.
+
 ## Optional LLM Features
 
 The Results page includes optional LLM panels for run explanations and current-vs-previous comparisons. Install them with `python -m pip install -e ".[llm]"`, then configure provider keys with `PA_STREAMLIT_API_KEY`, `OPENAI_API_KEY`, or `CLAUDE_API_STRANSKE`; Azure OpenAI also needs endpoint/version settings such as `PA_LLM_BASE_URL`, `PA_LLM_API_VERSION`, or `AZURE_OPENAI_API_VERSION`. See [Streamlit LLM Features](docs/llm_features.md) for key handling, no-secret export expectations, LangSmith tracing, and the Trend reference pack used by agent runs.

--- a/docs/guides/PARAMETER_DICTIONARY.md
+++ b/docs/guides/PARAMETER_DICTIONARY.md
@@ -113,7 +113,7 @@ This reference lists canonical field names, accepted aliases, and defaults for s
 | `regimes` | `regimes` | `Optional[List[pa_core.config.RegimeConfig]]` | no | `None` | List of regime configurations for regime-switching models. |
 | `regime_start` | `regime_start` | `Optional[str]` | no | `None` | Initial regime name for regime-switching simulations. |
 | `regime_transition` | `regime_transition` | `Optional[List[List[float]]]` | no | `None` | Markov transition matrix for regime switching (n_regimes x n_regimes). |
-| `risk_metrics` | `risk_metrics` | `List[str]` | no | `default_factory: <lambda>` |  |
+| `risk_metrics` | `risk_metrics` | `List[str]` | no | `default_factory: <lambda>` | Advisory list selecting which metrics are reported/displayed. It does not change how the simulation runs (must include 'terminal_ShortfallProb'). See README 'Model Limitations & Caveats'. |
 | `sleeve_max_te` | `sleeve_max_te` | `Optional[float]` | no | `None` | Maximum tracking error constraint for sleeves (monthly). |
 | `sleeve_max_breach` | `sleeve_max_breach` | `Optional[float]` | no | `None` | Maximum breach probability constraint for sleeves (monthly). |
 | `sleeve_max_cvar` | `sleeve_max_cvar` | `Optional[float]` | no | `None` | Maximum CVaR constraint for sleeves (monthly). |

--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -500,6 +500,11 @@ class ModelConfig(BaseModel):
             "terminal_ShortfallProb",
         ],
         alias="risk_metrics",
+        description=(
+            "Advisory list selecting which metrics are reported/displayed. It "
+            "does not change how the simulation runs (must include "
+            "'terminal_ShortfallProb'). See README 'Model Limitations & Caveats'."
+        ),
     )
 
     sleeve_max_te: Optional[float] = Field(

--- a/pa_core/reporting/disclaimers.py
+++ b/pa_core/reporting/disclaimers.py
@@ -13,7 +13,8 @@ LIMITATIONS_TITLE = "Model Limitations & Caveats"
 #: Ordered list of model caveats. Each entry is a single, self-contained
 #: statement suitable for a README bullet or a slide line.
 MODEL_LIMITATIONS: tuple[str, ...] = (
-    "Results are gross of fees and costs.",
+    "By default, results are gross of fees and costs; configured `fee_schedule` "
+    "entries report matching sleeves net of those fees.",
     "Total excludes Base (overlay semantics): a Base-only fund shows Total = 0.",
     "Monthly draws are i.i.d. — no volatility clustering is modelled.",
     "Regimes are ignored in parameter sweeps.",

--- a/pa_core/reporting/disclaimers.py
+++ b/pa_core/reporting/disclaimers.py
@@ -1,0 +1,31 @@
+"""Shared model-limitation disclaimers.
+
+Single source of truth for the caveats that must accompany any committee-facing
+output (the README, the PPTX board pack, and exported packets). Keeping the text
+in one place ensures the documentation and the generated board pack cannot drift
+apart. See issue #1923.
+"""
+
+from __future__ import annotations
+
+LIMITATIONS_TITLE = "Model Limitations & Caveats"
+
+#: Ordered list of model caveats. Each entry is a single, self-contained
+#: statement suitable for a README bullet or a slide line.
+MODEL_LIMITATIONS: tuple[str, ...] = (
+    "Results are gross of fees and costs.",
+    "Total excludes Base (overlay semantics): a Base-only fund shows Total = 0.",
+    "Monthly draws are i.i.d. — no volatility clustering is modelled.",
+    "Regimes are ignored in parameter sweeps.",
+    "Financing `broadcast` reuses a single financing path across simulations.",
+    "The model is forward-looking and has not been backtested.",
+    "`risk_metrics` is advisory: it selects which metrics are reported, "
+    "not how the simulation runs.",
+    "`Scenario.sleeves` is currently unwired and does not affect simulation "
+    "results.",
+)
+
+
+def limitations_markdown() -> str:
+    """Return the limitations as a Markdown bullet list."""
+    return "\n".join(f"- {item}" for item in MODEL_LIMITATIONS)

--- a/pa_core/reporting/export_packet.py
+++ b/pa_core/reporting/export_packet.py
@@ -19,6 +19,7 @@ from pptx.dml.color import RGBColor
 from pptx.enum.text import PP_ALIGN
 from pptx.util import Inches, Pt
 
+from .disclaimers import LIMITATIONS_TITLE, MODEL_LIMITATIONS
 from .excel import export_to_excel, finalize_excel_workbook
 
 __all__ = ["create_export_packet"]
@@ -34,6 +35,24 @@ def _add_title_slide(prs: Any, title: str, subtitle: str | None = None) -> None:
     slide.shapes.title.text = title
     if subtitle and len(slide.placeholders) > 1:
         slide.placeholders[1].text = subtitle
+
+
+def _add_limitations_slide(prs: Any) -> None:
+    """Add a committee-facing slide listing model limitations and caveats."""
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    tx_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.5), Inches(9), Inches(6))
+    tf = tx_box.text_frame
+    tf.word_wrap = True
+    tf.clear()
+    title_run = tf.paragraphs[0].add_run()
+    title_run.text = LIMITATIONS_TITLE
+    title_run.font.size = Pt(22)
+    title_run.font.bold = True
+    for item in MODEL_LIMITATIONS:
+        p = tf.add_paragraph()
+        run = p.add_run()
+        run.text = f"• {item}"
+        run.font.size = Pt(12)
 
 
 def _add_summary_table_slide(prs: Any, df: pd.DataFrame, title: str = "Executive Summary") -> None:
@@ -196,6 +215,7 @@ def create_export_packet(
         title="Portfolio Analysis Packet",
         subtitle=f"Generated: {pd.Timestamp.now():%Y-%m-%d %H:%M}",
     )
+    _add_limitations_slide(prs)
     if not summary_df.empty:
         _add_summary_table_slide(prs, summary_df)
 

--- a/pa_core/schema.py
+++ b/pa_core/schema.py
@@ -152,7 +152,15 @@ class Scenario(BaseModel):
     correlations: List[Correlation] = Field(default_factory=list)
     portfolios: List[Portfolio] = Field(default_factory=list)
     constraints: PortfolioConstraints = Field(default_factory=PortfolioConstraints)
-    sleeves: Dict[str, Sleeve] | None = None
+    # NOTE: ``sleeves`` is currently unwired — it is validated (capital_share must
+    # sum to 1) but does not affect simulation results. See README
+    # 'Model Limitations & Caveats'.
+    sleeves: Dict[str, Sleeve] | None = Field(
+        default=None,
+        description=(
+            "Currently unwired: validated but does not affect simulation results."
+        ),
+    )
 
     @model_validator(mode="after")
     def _check_assets_and_portfolios(self) -> "Scenario":

--- a/tests/test_model_limitations_1923.py
+++ b/tests/test_model_limitations_1923.py
@@ -1,0 +1,87 @@
+"""Tests for issue #1923 — disclose model limitations in docs & board-pack.
+
+Verifies the single source of truth (``pa_core.reporting.disclaimers``) is wired
+into both the README and the generated PPTX board pack so the two cannot drift.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+from pptx import Presentation
+
+from pa_core.reporting.disclaimers import (
+    LIMITATIONS_TITLE,
+    MODEL_LIMITATIONS,
+    limitations_markdown,
+)
+from pa_core.reporting.export_packet import create_export_packet
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_limitations_cover_required_caveats():
+    """Every caveat named in the audit issue must be present."""
+    blob = " ".join(MODEL_LIMITATIONS).lower()
+    for phrase in (
+        "gross of fees",
+        "total excludes base",
+        "i.i.d",
+        "regimes are ignored",
+        "broadcast",
+        "not been backtested",
+        "risk_metrics",
+        "scenario.sleeves",
+    ):
+        assert phrase in blob, f"missing caveat: {phrase}"
+
+
+def test_limitations_markdown_is_a_bullet_list():
+    md = limitations_markdown()
+    assert md.count("- ") == len(MODEL_LIMITATIONS)
+    assert MODEL_LIMITATIONS[0] in md
+
+
+def test_readme_documents_limitations():
+    readme = (_REPO_ROOT / "README.md").read_text().lower()
+    assert "model limitations & caveats" in readme
+    for phrase in (
+        "gross of fees",
+        "total excludes base",
+        "i.i.d",
+        "regimes are ignored",
+        "broadcast",
+        "backtested",
+        "advisory",
+        "unwired",
+    ):
+        assert phrase in readme, f"README missing caveat: {phrase}"
+
+
+def test_board_pack_includes_limitations_slide():
+    """The generated PPTX must carry a limitations slide with every caveat."""
+    summary_df = pd.DataFrame(
+        {
+            "terminal_AnnReturn": [0.05],
+            "monthly_AnnVol": [0.12],
+            "terminal_ShortfallProb": [0.1],
+        }
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pptx_path, _ = create_export_packet(
+            figs=[],
+            summary_df=summary_df,
+            raw_returns_dict={"Summary": summary_df},
+            inputs_dict={"N_SIMULATIONS": 10, "N_MONTHS": 12},
+            base_filename=str(Path(tmpdir) / "packet"),
+        )
+        prs = Presentation(pptx_path)
+        texts = []
+        for slide in prs.slides:
+            for shape in slide.shapes:
+                if shape.has_text_frame:
+                    texts.append(shape.text_frame.text)
+        blob = "\n".join(texts)
+        assert LIMITATIONS_TITLE in blob
+        for item in MODEL_LIMITATIONS:
+            assert item in blob, f"slide missing caveat: {item}"

--- a/tests/test_model_limitations_1923.py
+++ b/tests/test_model_limitations_1923.py
@@ -43,19 +43,11 @@ def test_limitations_markdown_is_a_bullet_list():
 
 
 def test_readme_documents_limitations():
-    readme = (_REPO_ROOT / "README.md").read_text().lower()
-    assert "model limitations & caveats" in readme
-    for phrase in (
-        "gross of fees",
-        "total excludes base",
-        "i.i.d",
-        "regimes are ignored",
-        "broadcast",
-        "backtested",
-        "advisory",
-        "unwired",
-    ):
-        assert phrase in readme, f"README missing caveat: {phrase}"
+    readme = (_REPO_ROOT / "README.md").read_text()
+    section_start = readme.index(f"## {LIMITATIONS_TITLE}")
+    next_section = readme.index("\n## ", section_start + 1)
+    section = readme[section_start:next_section]
+    assert limitations_markdown() in section
 
 
 def test_board_pack_includes_limitations_slide():

--- a/tests/test_reporting_exports.py
+++ b/tests/test_reporting_exports.py
@@ -16,6 +16,15 @@ ONE_PX_PNG = base64.b64decode(
 )
 
 
+def _presentation_text(presentation) -> str:
+    texts: list[str] = []
+    for slide in presentation.slides:
+        for shape in slide.shapes:
+            if shape.has_text_frame:
+                texts.append(shape.text_frame.text)
+    return "\n".join(texts)
+
+
 def test_export_sweep_results_writes_summary_and_run_sheet(tmp_path: Path, monkeypatch) -> None:
     from pa_core.reporting import sweep_excel
 
@@ -58,6 +67,7 @@ def test_export_sweep_results_writes_summary_when_empty(tmp_path: Path) -> None:
 
 
 def test_create_export_packet_writes_files_and_manifest_slide(tmp_path: Path) -> None:
+    from pa_core.reporting.disclaimers import LIMITATIONS_TITLE
     from pa_core.reporting.export_packet import create_export_packet
 
     summary = pd.DataFrame({"Agent": ["Base"], "terminal_AnnReturn": [0.05]})
@@ -91,10 +101,12 @@ def test_create_export_packet_writes_files_and_manifest_slide(tmp_path: Path) ->
     assert Path(excel_path).exists()
 
     presentation = pptx.Presentation(pptx_path)
-    assert len(presentation.slides) == 5
+    assert len(presentation.slides) == 6
+    assert LIMITATIONS_TITLE in _presentation_text(presentation)
 
 
 def test_create_export_packet_adds_tornado_slide(tmp_path: Path) -> None:
+    from pa_core.reporting.disclaimers import LIMITATIONS_TITLE
     from pa_core.reporting.export_packet import create_export_packet
 
     summary = pd.DataFrame({"Agent": ["Base"], "terminal_AnnReturn": [0.05]})
@@ -125,7 +137,8 @@ def test_create_export_packet_adds_tornado_slide(tmp_path: Path) -> None:
     )
 
     presentation = pptx.Presentation(pptx_path)
-    assert len(presentation.slides) == 5
+    assert len(presentation.slides) == 6
+    assert LIMITATIONS_TITLE in _presentation_text(presentation)
 
 
 def test_export_to_excel_includes_tornado_snapshot(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Discloses model limitations in the docs and the committee board-pack, per the 2026-06 whole-repo audit (#1923).

Introduces a single source of truth — `pa_core/reporting/disclaimers.py` (`MODEL_LIMITATIONS`) — so the README and the generated PPTX cannot drift apart.

## Changes
- **README**: new "Model Limitations & Caveats" section.
- **Board pack**: `export_packet.py` now adds a limitations slide right after the title slide of every generated deck.
- **Field docs**: `risk_metrics` documented as advisory (config.py); `Scenario.sleeves` documented as currently unwired (schema.py).
- **Regenerated** `docs/guides/PARAMETER_DICTIONARY.md` to reflect the new `risk_metrics` description.

Caveats disclosed: gross of fees/costs; Total excludes Base; i.i.d. monthly draws (no vol clustering); regimes ignored in sweeps; financing `broadcast` reuses one path; forward-looking/not backtested; `risk_metrics` advisory; `Scenario.sleeves` unwired.

## Tests
- `tests/test_model_limitations_1923.py` (4 tests): caveat coverage, README content, board-pack slide content.
- Existing `tests/test_export_packet.py` (8) and schema/scenario slice (95) pass; ruff + mypy clean on touched files.

Closes #1923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Model Limitations & Caveats" section to README outlining computation assumptions, handling of fees, draw mechanics, and other important caveats
  * Updated parameter documentation to clarify that risk metrics are advisory and do not affect simulation behavior

* **New Features**
  * Board pack exports now include a dedicated slide listing model limitations and caveats immediately after the title slide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->