### PR TITLE
style: restore Black formatting green on main (post-merge lint-format debt)

### DIFF
--- a/pa_core/config.py
+++ b/pa_core/config.py
@@ -247,8 +247,7 @@ class ModelConfig(BaseModel):
     backend: Literal["numpy"] = Field(
         default="numpy",
         description=(
-            "Computation backend. Only 'numpy' is supported; "
-            f"{BACKEND_UNAVAILABLE_DETAIL}"
+            "Computation backend. Only 'numpy' is supported; " f"{BACKEND_UNAVAILABLE_DETAIL}"
         ),
     )
     N_SIMULATIONS: int = Field(gt=0, alias="Number of simulations")
@@ -761,7 +760,9 @@ class ModelConfig(BaseModel):
                 "Internal PA capital (mm)",
             },
         }
-        return {agent_name for agent_name, keys in groups.items() if any(key in data for key in keys)}
+        return {
+            agent_name for agent_name, keys in groups.items() if any(key in data for key in keys)
+        }
 
     @classmethod
     def normalize_share_inputs(cls, data: Any) -> Any:
@@ -782,7 +783,11 @@ class ModelConfig(BaseModel):
 
     @classmethod
     def _normalize_regime_sigma_overrides(cls, regimes: Any) -> Any:
-        if regimes is None or isinstance(regimes, (str, bytes)) or not isinstance(regimes, Sequence):
+        if (
+            regimes is None
+            or isinstance(regimes, (str, bytes))
+            or not isinstance(regimes, Sequence)
+        ):
             return regimes
 
         normalized: list[Any] = []

--- a/pa_core/sim/metrics.py
+++ b/pa_core/sim/metrics.py
@@ -178,9 +178,7 @@ def annualised_return(returns: ArrayLike, periods_per_year: int = 12) -> float:
     return float(np.power(base, 1.0 / years) - 1.0)
 
 
-def annualised_return_percentile(
-    returns: ArrayLike, q: float, periods_per_year: int = 12
-) -> float:
+def annualised_return_percentile(returns: ArrayLike, q: float, periods_per_year: int = 12) -> float:
     """Return the annualised compound return at the ``q``-th percentile of paths.
 
     :func:`annualised_return` averages the terminal compounded return across

--- a/pa_core/sweep.py
+++ b/pa_core/sweep.py
@@ -21,7 +21,13 @@ except ImportError:  # pragma: no cover - fallback when tqdm is unavailable
     _HAS_TQDM = False
 
 from .agents.registry import build_from_config
-from .config import ModelConfig, SweepConfig, SweepParameter, normalize_share, validate_financing_spikes
+from .config import (
+    ModelConfig,
+    SweepConfig,
+    SweepParameter,
+    normalize_share,
+    validate_financing_spikes,
+)
 from .contracts import SUMMARY_NUMERIC_COLUMNS
 from .random import spawn_agent_rngs, spawn_rngs
 from .sim import (

--- a/tests/test_exception_handling_audit_1920.py
+++ b/tests/test_exception_handling_audit_1920.py
@@ -145,9 +145,7 @@ def test_excel_tornado_embed_logs_malformed_fallback_without_aborting(tmp_path, 
     assert any(r.exc_info is not None for r in records)
 
 
-def test_excel_sunburst_embed_logs_type_error_without_aborting(
-    monkeypatch, tmp_path, caplog
-):
+def test_excel_sunburst_embed_logs_type_error_without_aborting(monkeypatch, tmp_path, caplog):
     """Optional sunburst image failures stay non-fatal even for malformed return data."""
 
     from pa_core.reporting import excel

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -389,7 +389,11 @@ def test_summary_table_includes_terminal_return_percentiles():
     for col in ("terminal_AnnReturn_P50", "terminal_AnnReturn_P10", "terminal_AnnReturn_P90"):
         assert col in stats.columns
     row = stats.iloc[0]
-    assert row["terminal_AnnReturn_P10"] <= row["terminal_AnnReturn_P50"] <= row["terminal_AnnReturn_P90"]
+    assert (
+        row["terminal_AnnReturn_P10"]
+        <= row["terminal_AnnReturn_P50"]
+        <= row["terminal_AnnReturn_P90"]
+    )
 
 
 def test_per_path_te_lower_than_pooled_when_means_differ_across_paths():


### PR DESCRIPTION
## Problem

The reusable Python CI `lint-format` job runs **Black 26.5.1** (`--line-length 100`, per `autofix-versions.env`). It is **path-skipped on PR events** (`pr-00-gate.yml` sets `format_check: false`) but **runs on push to `main`** (`ci.yml`). So Black drift in recently-merged agent PRs never surfaces pre-merge and only fails post-merge — which floors every post-merge **verifier comparison** verdict at `CONCERNS` with the note "lint-format failing on merge commit" (observed on #1920/PR #1947 and forthcoming #1922/PR #1948).

## Fix

Apply Black 26.5.1 to the 5 files currently failing `black --check --line-length 100` on `main`:

- `pa_core/config.py` (drift from #1915)
- `pa_core/sim/metrics.py`, `tests/test_metrics.py` (drift from #1914)
- `pa_core/sweep.py`, `tests/test_exception_handling_audit_1920.py` (drift from #1920)

Pure formatting (line reflow only) — no logic changes; all 5 files compile under py3.12. After this, `black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .` reports **436 files unchanged**.

## Why closer-owned

Repeated, repo-wide completion debt caused by a CI scope inconsistency, flooring verifier verdicts across multiple source issues. Bounded mechanical fix.

> Note: the recurring root cause is the `ci.yml` (Black-on-push) vs `pr-00-gate.yml` (`format_check:false`) mismatch. Aligning those is a separate CI-policy decision left for the owner; this PR just clears the current debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)