### PR TITLE
Document overlay total semantics

### DIFF
--- a/dashboard/glossary.py
+++ b/dashboard/glossary.py
@@ -1,9 +1,13 @@
 """Glossary of finance terms for dashboard tooltips."""
 
+from pa_core.portfolio import OVERLAY_TOTAL_DESCRIPTION
+
 GLOSSARY = {
     "active share": "Portion of a portfolio that differs from its benchmark; 0% means identical holdings, 100% fully independent.",
     "buffer multiple": "Multiplier applied to volatility to set the cash buffer threshold for drawdowns.",
     "breach probability": "Share of simulated months across all paths that fall below the breach threshold.",
+    "overlay total": OVERLAY_TOTAL_DESCRIPTION,
+    "total": OVERLAY_TOTAL_DESCRIPTION,
     "monthly_TE": "Tracking error — annualised volatility of active returns (portfolio minus benchmark).",
     "monthly_CVaR": "Conditional Value at Risk — expected loss given that losses exceed the VaR cutoff.",
     "monthly_MaxDD": "Worst peak-to-trough decline of the compounded wealth path.",

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -25,6 +25,8 @@ from dashboard.components.explain_results import render_explain_results_panel
 from dashboard.glossary import tooltip
 from dashboard.utils import current_results_path
 from pa_core.contracts import (
+    SUMMARY_AGENT_COLUMN,
+    SUMMARY_ANN_RETURN_COLUMN,
     SUMMARY_BREACH_PROB_COLUMN,
     SUMMARY_CVAR_COLUMN,
     SUMMARY_SHEET_NAME,
@@ -206,7 +208,7 @@ def main() -> None:
     months = st.sidebar.slider("Months", 1, summary.shape[0], summary.shape[0])
 
     st.subheader("Key Metrics")
-    col1, col2, col3 = st.columns(3)
+    col1, col2, col3, col4 = st.columns(4)
     te_column = None
     if SUMMARY_TE_COLUMN in summary:
         te_column = SUMMARY_TE_COLUMN
@@ -228,6 +230,15 @@ def main() -> None:
             f"{summary[SUMMARY_BREACH_PROB_COLUMN].mean():.2%}",
             help=tooltip("breach probability"),
         )
+    if {SUMMARY_AGENT_COLUMN, SUMMARY_ANN_RETURN_COLUMN} <= set(summary.columns):
+        total_rows = summary[summary[SUMMARY_AGENT_COLUMN] == "Total"]
+        if not total_rows.empty:
+            total_return = float(total_rows[SUMMARY_ANN_RETURN_COLUMN].iloc[0])
+            col4.metric(
+                "Overlay Total",
+                f"{total_return:.2%}",
+                help=tooltip("overlay total"),
+            )
 
     _render_explain_results(summary=summary, manifest_data=manifest_data, xlsx=xlsx)
     _render_comparison_panel(summary=summary, manifest_data=manifest_data, xlsx=xlsx)

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -184,6 +184,14 @@ def _default_results_path() -> str:
     return current_results_path(st.session_state) or _DEF_XLSX
 
 
+def _overlay_total_return(summary: pd.DataFrame) -> float | None:
+    if {SUMMARY_AGENT_COLUMN, SUMMARY_ANN_RETURN_COLUMN} <= set(summary.columns):
+        total_rows = summary[summary[SUMMARY_AGENT_COLUMN] == "Total"]
+        if not total_rows.empty:
+            return float(total_rows[SUMMARY_ANN_RETURN_COLUMN].mean())
+    return None
+
+
 def main() -> None:
     st.title("Results")
     xlsx, theme_path = render_settings_sidebar(_default_results_path())
@@ -230,15 +238,13 @@ def main() -> None:
             f"{summary[SUMMARY_BREACH_PROB_COLUMN].mean():.2%}",
             help=tooltip("breach probability"),
         )
-    if {SUMMARY_AGENT_COLUMN, SUMMARY_ANN_RETURN_COLUMN} <= set(summary.columns):
-        total_rows = summary[summary[SUMMARY_AGENT_COLUMN] == "Total"]
-        if not total_rows.empty:
-            total_return = float(total_rows[SUMMARY_ANN_RETURN_COLUMN].mean())
-            col4.metric(
-                "Overlay Total",
-                f"{total_return:.2%}",
-                help=tooltip("overlay total"),
-            )
+    total_return = _overlay_total_return(summary)
+    if total_return is not None:
+        col4.metric(
+            "Overlay Total",
+            f"{total_return:.2%}",
+            help=tooltip("overlay total"),
+        )
 
     _render_explain_results(summary=summary, manifest_data=manifest_data, xlsx=xlsx)
     _render_comparison_panel(summary=summary, manifest_data=manifest_data, xlsx=xlsx)

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -233,7 +233,7 @@ def main() -> None:
     if {SUMMARY_AGENT_COLUMN, SUMMARY_ANN_RETURN_COLUMN} <= set(summary.columns):
         total_rows = summary[summary[SUMMARY_AGENT_COLUMN] == "Total"]
         if not total_rows.empty:
-            total_return = float(total_rows[SUMMARY_ANN_RETURN_COLUMN].iloc[0])
+            total_return = float(total_rows[SUMMARY_ANN_RETURN_COLUMN].mean())
             col4.metric(
                 "Overlay Total",
                 f"{total_return:.2%}",

--- a/docs/primer.md
+++ b/docs/primer.md
@@ -12,7 +12,10 @@ This brief guide explains key terms in plain English and shows how to run the mo
 - **Conditional Value at Risk (CVaR)** – Expected loss once losses exceed the usual Value‑at‑Risk cutoff.
 - **Max drawdown (MaxDD)** – Worst peak‑to‑trough decline of the compounded wealth path.
 - **Time under water (TimeUnderWater)** – Fraction of periods where the compounded return is below zero.
-- **Total (overlay contribution)** – Sum of all non-Base, non-Total contribution sleeves. Built-in overlays include ExternalPA, ActiveExt, InternalPA, and InternalBeta, and plugin-registered sleeves are included by the same rule. It excludes Base, which is the benchmark comparator, so a true no-overlay/no-margin run reports Total as zero overlay contribution rather than the index return.
+- **Total (overlay contribution)** – Sum of all non-Base, non-Total contribution sleeves.
+  - Built-in overlays include ExternalPA, ActiveExt, InternalPA, and InternalBeta.
+  - plugin-registered sleeves are included by the same rule.
+  - It excludes Base, which is the benchmark comparator, so a true no-overlay/no-margin run reports Total as zero overlay contribution rather than the index return.
 
 ## Quick CLI examples
 

--- a/docs/primer.md
+++ b/docs/primer.md
@@ -14,7 +14,7 @@ This brief guide explains key terms in plain English and shows how to run the mo
 - **Time under water (TimeUnderWater)** – Fraction of periods where the compounded return is below zero.
 - **Total (overlay contribution)** – Sum of all non-Base, non-Total contribution sleeves.
   - Built-in overlays include ExternalPA, ActiveExt, InternalPA, and InternalBeta.
-  - plugin-registered sleeves are included by the same rule.
+  - Plugin-registered sleeves are included by the same rule.
   - It excludes Base, which is the benchmark comparator, so a true no-overlay/no-margin run reports Total as zero overlay contribution rather than the index return.
 
 ## Quick CLI examples

--- a/docs/primer.md
+++ b/docs/primer.md
@@ -12,7 +12,7 @@ This brief guide explains key terms in plain English and shows how to run the mo
 - **Conditional Value at Risk (CVaR)** – Expected loss once losses exceed the usual Value‑at‑Risk cutoff.
 - **Max drawdown (MaxDD)** – Worst peak‑to‑trough decline of the compounded wealth path.
 - **Time under water (TimeUnderWater)** – Fraction of periods where the compounded return is below zero.
-- **Total (overlay contribution)** – Sum of overlay sleeves: ExternalPA, ActiveExt, InternalPA, and InternalBeta. It excludes Base, which is the benchmark comparator, so a Base-only run reports Total as zero overlay contribution rather than the index return.
+- **Total (overlay contribution)** – Sum of all non-Base, non-Total contribution sleeves. Built-in overlays include ExternalPA, ActiveExt, InternalPA, and InternalBeta, and plugin-registered sleeves are included by the same rule. It excludes Base, which is the benchmark comparator, so a true no-overlay/no-margin run reports Total as zero overlay contribution rather than the index return.
 
 ## Quick CLI examples
 

--- a/docs/primer.md
+++ b/docs/primer.md
@@ -12,6 +12,7 @@ This brief guide explains key terms in plain English and shows how to run the mo
 - **Conditional Value at Risk (CVaR)** – Expected loss once losses exceed the usual Value‑at‑Risk cutoff.
 - **Max drawdown (MaxDD)** – Worst peak‑to‑trough decline of the compounded wealth path.
 - **Time under water (TimeUnderWater)** – Fraction of periods where the compounded return is below zero.
+- **Total (overlay contribution)** – Sum of overlay sleeves: ExternalPA, ActiveExt, InternalPA, and InternalBeta. It excludes Base, which is the benchmark comparator, so a Base-only run reports Total as zero overlay contribution rather than the index return.
 
 ## Quick CLI examples
 

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1016,6 +1016,7 @@ def main(
     from .facade import run_single
     from .logging_utils import setup_json_logging
     from .manifest import ManifestWriter
+    from .portfolio import BASE_ONLY_TOTAL_WARNING, is_base_only_config
     from .reporting.attribution import (
         compute_sleeve_cvar_contribution,
         compute_sleeve_return_attribution,
@@ -1207,6 +1208,9 @@ def main(
                     "internal_pa_capital": float(row["internal_pa_capital"]),
                 }
             )
+
+    if is_base_only_config(cfg):
+        warnings.warn(BASE_ONLY_TOTAL_WARNING, UserWarning, stacklevel=2)
 
     # Capture raw params after user-driven config adjustments (mode/stress/suggestions)
     raw_params = cfg.model_dump()

--- a/pa_core/portfolio/__init__.py
+++ b/pa_core/portfolio/__init__.py
@@ -9,7 +9,14 @@ from .constraints import (
     WeightBoundsConstraint,
     suggest_constraint_fixes,
 )
-from .core import DEFAULT_PORTFOLIO_EXCLUDES, compute_total_contribution_returns
+from .core import (
+    BASE_ONLY_TOTAL_WARNING,
+    DEFAULT_PORTFOLIO_EXCLUDES,
+    OVERLAY_SLEEVE_NAMES,
+    OVERLAY_TOTAL_DESCRIPTION,
+    compute_total_contribution_returns,
+    is_base_only_config,
+)
 
 if TYPE_CHECKING:
     from .aggregator import PortfolioAggregator
@@ -31,5 +38,9 @@ __all__ = [
     "COMMON_WEIGHT_BOUNDS",
     "suggest_constraint_fixes",
     "compute_total_contribution_returns",
+    "is_base_only_config",
     "DEFAULT_PORTFOLIO_EXCLUDES",
+    "OVERLAY_SLEEVE_NAMES",
+    "OVERLAY_TOTAL_DESCRIPTION",
+    "BASE_ONLY_TOTAL_WARNING",
 ]

--- a/pa_core/portfolio/core.py
+++ b/pa_core/portfolio/core.py
@@ -63,15 +63,26 @@ def _has_positive_non_benchmark_capital(agents: Iterable[object]) -> bool:
     return False
 
 
+def _agent_tuple(value: object) -> tuple[object, ...] | None:
+    if value is None or isinstance(value, (str, bytes)):
+        return ()
+    if isinstance(value, Mapping):
+        return tuple(value.values())
+    try:
+        return tuple(value)  # type: ignore[arg-type]
+    except TypeError:
+        return None
+
+
 def is_base_only_config(config: object) -> bool:
     """Return true when the effective run has no non-benchmark sleeve capital."""
 
-    effective_agents: Iterable[object]
+    raw_agents = _agent_tuple(getattr(config, "agents", ())) or ()
     try:
         from ..agents.registry import build_from_config
 
-        effective_agents = build_from_config(config)  # type: ignore[arg-type]
+        built_agents = _agent_tuple(build_from_config(config))  # type: ignore[arg-type]
     except (AttributeError, FileNotFoundError, KeyError, OSError, TypeError, ValueError):
-        raw_agents = getattr(config, "agents", ())
-        effective_agents = raw_agents or ()
+        built_agents = None
+    effective_agents = raw_agents if built_agents is None else built_agents
     return not _has_positive_non_benchmark_capital(effective_agents)

--- a/pa_core/portfolio/core.py
+++ b/pa_core/portfolio/core.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import logging
 from typing import Iterable, Mapping, TypeAlias
 
 from ..backend import xp as np
 from ..types import ArrayLike
 
 Array: TypeAlias = ArrayLike
+logger = logging.getLogger(__name__)
 
 DEFAULT_PORTFOLIO_EXCLUDES = ("Base", "Total")
 OVERLAY_SLEEVE_NAMES = ("ExternalPA", "ActiveExt", "InternalPA", "InternalBeta")
@@ -57,6 +59,11 @@ def _has_positive_non_benchmark_capital(agents: Iterable[object]) -> bool:
         try:
             capital = float(raw_capital or 0.0)
         except (TypeError, ValueError):
+            logger.debug(
+                "Invalid capital value for agent %s: %r; treating as zero",
+                name,
+                raw_capital,
+            )
             capital = 0.0
         if capital > 0.0:
             return True
@@ -82,7 +89,8 @@ def is_base_only_config(config: object) -> bool:
         from ..agents.registry import build_from_config
 
         built_agents = _agent_tuple(build_from_config(config))  # type: ignore[arg-type]
-    except (AttributeError, FileNotFoundError, KeyError, OSError, TypeError, ValueError):
+    except (AttributeError, FileNotFoundError, KeyError, OSError, TypeError, ValueError) as exc:
+        logger.debug("build_from_config failed; using config.agents fallback: %s", exc)
         built_agents = None
     effective_agents = raw_agents if built_agents is None else built_agents
     return not _has_positive_non_benchmark_capital(effective_agents)

--- a/pa_core/portfolio/core.py
+++ b/pa_core/portfolio/core.py
@@ -71,6 +71,12 @@ def _has_positive_non_benchmark_capital(agents: Iterable[object]) -> bool:
 
 
 def _agent_tuple(value: object) -> tuple[object, ...] | None:
+    """Normalize agent collections, preserving failed conversion as ``None``.
+
+    Empty tuple means the value was valid but empty or intentionally ignored;
+    ``None`` means conversion failed and the caller should use fallback agents.
+    """
+
     if value is None or isinstance(value, (str, bytes)):
         return ()
     if isinstance(value, Mapping):

--- a/pa_core/portfolio/core.py
+++ b/pa_core/portfolio/core.py
@@ -8,6 +8,16 @@ from ..types import ArrayLike
 Array: TypeAlias = ArrayLike
 
 DEFAULT_PORTFOLIO_EXCLUDES = ("Base", "Total")
+OVERLAY_SLEEVE_NAMES = ("ExternalPA", "ActiveExt", "InternalPA", "InternalBeta")
+OVERLAY_TOTAL_DESCRIPTION = (
+    "Total is the overlay contribution from ExternalPA, ActiveExt, InternalPA, "
+    "and InternalBeta. It excludes Base, which is the benchmark comparator."
+)
+BASE_ONLY_TOTAL_WARNING = (
+    "Base-only configuration: Total excludes Base, so Total will report zero "
+    "overlay contribution rather than the index return. Use the Base row for "
+    "benchmark return."
+)
 
 
 def compute_total_contribution_returns(
@@ -29,3 +39,20 @@ def compute_total_contribution_returns(
             total = np.zeros_like(arr)
         total = total + arr
     return total
+
+
+def is_base_only_config(config: object) -> bool:
+    """Return true when the run config has no non-benchmark sleeve capital."""
+
+    agents = getattr(config, "agents", ()) or ()
+    for agent in agents:
+        name = str(getattr(agent, "name", ""))
+        if name in DEFAULT_PORTFOLIO_EXCLUDES:
+            continue
+        try:
+            capital = float(getattr(agent, "capital", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            capital = 0.0
+        if capital > 0.0:
+            return False
+    return True

--- a/pa_core/portfolio/core.py
+++ b/pa_core/portfolio/core.py
@@ -9,9 +9,11 @@ Array: TypeAlias = ArrayLike
 
 DEFAULT_PORTFOLIO_EXCLUDES = ("Base", "Total")
 OVERLAY_SLEEVE_NAMES = ("ExternalPA", "ActiveExt", "InternalPA", "InternalBeta")
+_BUILT_IN_OVERLAY_SLEEVES = ", ".join(OVERLAY_SLEEVE_NAMES)
 OVERLAY_TOTAL_DESCRIPTION = (
-    "Total is the overlay contribution from ExternalPA, ActiveExt, InternalPA, "
-    "and InternalBeta. It excludes Base, which is the benchmark comparator."
+    "Total is the overlay contribution from all non-Base, non-Total sleeves "
+    f"(built-in overlays: {_BUILT_IN_OVERLAY_SLEEVES}). It excludes Base, "
+    "which is the benchmark comparator."
 )
 BASE_ONLY_TOTAL_WARNING = (
     "Base-only configuration: Total excludes Base, so Total will report zero "
@@ -41,18 +43,35 @@ def compute_total_contribution_returns(
     return total
 
 
-def is_base_only_config(config: object) -> bool:
-    """Return true when the run config has no non-benchmark sleeve capital."""
-
-    agents = getattr(config, "agents", ()) or ()
+def _has_positive_non_benchmark_capital(agents: Iterable[object]) -> bool:
     for agent in agents:
-        name = str(getattr(agent, "name", ""))
+        params = getattr(agent, "p", None)
+        if isinstance(agent, Mapping):
+            name = str(agent.get("name", ""))
+            raw_capital = agent.get("capital", 0.0)
+        else:
+            name = str(getattr(agent, "name", getattr(params, "name", "")))
+            raw_capital = getattr(agent, "capital", getattr(params, "capital_mm", 0.0))
         if name in DEFAULT_PORTFOLIO_EXCLUDES:
             continue
         try:
-            capital = float(getattr(agent, "capital", 0.0) or 0.0)
+            capital = float(raw_capital or 0.0)
         except (TypeError, ValueError):
             capital = 0.0
         if capital > 0.0:
-            return False
-    return True
+            return True
+    return False
+
+
+def is_base_only_config(config: object) -> bool:
+    """Return true when the effective run has no non-benchmark sleeve capital."""
+
+    effective_agents: Iterable[object]
+    try:
+        from ..agents.registry import build_from_config
+
+        effective_agents = build_from_config(config)  # type: ignore[arg-type]
+    except (AttributeError, FileNotFoundError, KeyError, OSError, TypeError, ValueError):
+        raw_agents = getattr(config, "agents", ())
+        effective_agents = raw_agents or ()
+    return not _has_positive_non_benchmark_capital(effective_agents)

--- a/tests/test_overlay_semantics_1905.py
+++ b/tests/test_overlay_semantics_1905.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import runpy
 from pathlib import Path
+
+import pandas as pd
+import pytest
 
 from dashboard.glossary import tooltip
 from pa_core.config import ModelConfig
+from pa_core.contracts import SUMMARY_AGENT_COLUMN, SUMMARY_ANN_RETURN_COLUMN
 from pa_core.portfolio import (
     OVERLAY_TOTAL_DESCRIPTION,
     compute_total_contribution_returns,
@@ -22,6 +27,7 @@ def test_total_tooltip_documents_base_exclusion() -> None:
 def test_primer_documents_overlay_total_semantics() -> None:
     primer = Path("docs/primer.md").read_text()
 
+    # These phrases are deliberate wording anchors for the board-facing primer.
     assert "Total (overlay contribution)" in primer
     assert "excludes Base" in primer
     assert "all non-Base, non-Total contribution sleeves" in primer
@@ -83,7 +89,13 @@ def test_total_contribution_excludes_base() -> None:
 
 
 def test_results_page_aggregates_multiple_total_rows() -> None:
-    source = Path("dashboard/pages/4_Results.py").read_text()
+    module = runpy.run_path("dashboard/pages/4_Results.py")
+    overlay_total_return = module["_overlay_total_return"]
+    summary = pd.DataFrame(
+        {
+            SUMMARY_AGENT_COLUMN: ["Total", "Total", "Base"],
+            SUMMARY_ANN_RETURN_COLUMN: [0.02, 0.06, 0.10],
+        }
+    )
 
-    assert 'total_rows[SUMMARY_ANN_RETURN_COLUMN].mean()' in source
-    assert 'total_rows[SUMMARY_ANN_RETURN_COLUMN].iloc[0]' not in source
+    assert overlay_total_return(summary) == pytest.approx(0.04)

--- a/tests/test_overlay_semantics_1905.py
+++ b/tests/test_overlay_semantics_1905.py
@@ -16,6 +16,7 @@ def test_total_tooltip_documents_base_exclusion() -> None:
 
     assert total_tooltip == OVERLAY_TOTAL_DESCRIPTION
     assert "excludes Base" in total_tooltip
+    assert "all non-Base, non-Total sleeves" in total_tooltip
 
 
 def test_primer_documents_overlay_total_semantics() -> None:
@@ -23,11 +24,25 @@ def test_primer_documents_overlay_total_semantics() -> None:
 
     assert "Total (overlay contribution)" in primer
     assert "excludes Base" in primer
-    assert "Base-only run reports Total as zero" in primer
+    assert "all non-Base, non-Total contribution sleeves" in primer
+    assert "plugin-registered sleeves are included" in primer
+    assert "no-overlay/no-margin run reports Total as zero" in primer
 
 
-def test_base_only_config_is_flagged() -> None:
+def test_default_margin_config_is_not_base_only() -> None:
     cfg = ModelConfig(N_SIMULATIONS=1, N_MONTHS=1, financing_mode="broadcast")
+
+    assert is_base_only_config(cfg) is False
+
+
+def test_no_overlay_no_margin_config_is_flagged() -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=1,
+        financing_mode="broadcast",
+        reference_sigma=0.0,
+        volatility_multiple=0.0,
+    )
 
     assert is_base_only_config(cfg) is True
 
@@ -53,3 +68,10 @@ def test_total_contribution_excludes_base() -> None:
 
     assert total is not None
     np.testing.assert_allclose(total, overlay)
+
+
+def test_results_page_aggregates_multiple_total_rows() -> None:
+    source = Path("dashboard/pages/4_Results.py").read_text()
+
+    assert 'total_rows[SUMMARY_ANN_RETURN_COLUMN].mean()' in source
+    assert 'total_rows[SUMMARY_ANN_RETURN_COLUMN].iloc[0]' not in source

--- a/tests/test_overlay_semantics_1905.py
+++ b/tests/test_overlay_semantics_1905.py
@@ -58,6 +58,18 @@ def test_overlay_config_is_not_base_only() -> None:
     assert is_base_only_config(cfg) is False
 
 
+def test_base_only_check_tolerates_non_iterable_registry_stub(monkeypatch) -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=1,
+        financing_mode="broadcast",
+        external_pa_capital=10.0,
+    )
+    monkeypatch.setattr("pa_core.agents.registry.build_from_config", lambda _cfg: object())
+
+    assert is_base_only_config(cfg) is False
+
+
 def test_total_contribution_excludes_base() -> None:
     import numpy as np
 

--- a/tests/test_overlay_semantics_1905.py
+++ b/tests/test_overlay_semantics_1905.py
@@ -31,7 +31,7 @@ def test_primer_documents_overlay_total_semantics() -> None:
     assert "Total (overlay contribution)" in primer
     assert "excludes Base" in primer
     assert "all non-Base, non-Total contribution sleeves" in primer
-    assert "plugin-registered sleeves are included" in primer
+    assert "Plugin-registered sleeves are included" in primer
     assert "no-overlay/no-margin run reports Total as zero" in primer
 
 

--- a/tests/test_overlay_semantics_1905.py
+++ b/tests/test_overlay_semantics_1905.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dashboard.glossary import tooltip
+from pa_core.config import ModelConfig
+from pa_core.portfolio import (
+    OVERLAY_TOTAL_DESCRIPTION,
+    compute_total_contribution_returns,
+    is_base_only_config,
+)
+
+
+def test_total_tooltip_documents_base_exclusion() -> None:
+    total_tooltip = tooltip("overlay total")
+
+    assert total_tooltip == OVERLAY_TOTAL_DESCRIPTION
+    assert "excludes Base" in total_tooltip
+
+
+def test_primer_documents_overlay_total_semantics() -> None:
+    primer = Path("docs/primer.md").read_text()
+
+    assert "Total (overlay contribution)" in primer
+    assert "excludes Base" in primer
+    assert "Base-only run reports Total as zero" in primer
+
+
+def test_base_only_config_is_flagged() -> None:
+    cfg = ModelConfig(N_SIMULATIONS=1, N_MONTHS=1, financing_mode="broadcast")
+
+    assert is_base_only_config(cfg) is True
+
+
+def test_overlay_config_is_not_base_only() -> None:
+    cfg = ModelConfig(
+        N_SIMULATIONS=1,
+        N_MONTHS=1,
+        financing_mode="broadcast",
+        external_pa_capital=10.0,
+    )
+
+    assert is_base_only_config(cfg) is False
+
+
+def test_total_contribution_excludes_base() -> None:
+    import numpy as np
+
+    base = np.array([[0.03, 0.04]])
+    overlay = np.array([[0.01, -0.02]])
+
+    total = compute_total_contribution_returns({"Base": base, "ExternalPA": overlay})
+
+    assert total is not None
+    np.testing.assert_allclose(total, overlay)

--- a/tests/test_run_record_warnings.py
+++ b/tests/test_run_record_warnings.py
@@ -92,6 +92,14 @@ def test_run_record_cost_stub_present(tmp_path: Path) -> None:
     assert cost["dollars"] is None
 
 
+def test_base_only_total_warning_serialized(tmp_path: Path) -> None:
+    out_file = _run_cli(tmp_path)
+    record = json.loads(out_file.with_name("run.json").read_text())
+
+    messages = [str(w.get("message", "")) for w in record["warnings"]]
+    assert any("Base-only configuration" in m and "Total excludes Base" in m for m in messages)
+
+
 def test_run_record_bundle_path_points_to_bundle_json(tmp_path: Path) -> None:
     bundle_dir = tmp_path / "bundle"
     out_file = _run_cli(tmp_path, "--bundle", str(bundle_dir))

--- a/tests/test_run_record_warnings.py
+++ b/tests/test_run_record_warnings.py
@@ -37,8 +37,10 @@ from pa_core.contracts import (  # noqa: E402
 DATA_INDEX = Path(__file__).resolve().parents[1] / "data" / "sp500tr_fred_divyield.csv"
 
 
-def _run_cli(tmp_path: Path, *extra: str) -> Path:
+def _run_cli(tmp_path: Path, *extra: str, config_updates: dict[str, Any] | None = None) -> Path:
     cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
+    if config_updates:
+        cfg.update(config_updates)
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
     out_file = tmp_path / "out.xlsx"
@@ -93,11 +95,22 @@ def test_run_record_cost_stub_present(tmp_path: Path) -> None:
 
 
 def test_base_only_total_warning_serialized(tmp_path: Path) -> None:
-    out_file = _run_cli(tmp_path)
+    out_file = _run_cli(
+        tmp_path,
+        config_updates={"reference_sigma": 0.0, "volatility_multiple": 0.0},
+    )
     record = json.loads(out_file.with_name("run.json").read_text())
 
     messages = [str(w.get("message", "")) for w in record["warnings"]]
     assert any("Base-only configuration" in m and "Total excludes Base" in m for m in messages)
+
+
+def test_default_margin_run_does_not_emit_base_only_total_warning(tmp_path: Path) -> None:
+    out_file = _run_cli(tmp_path)
+    record = json.loads(out_file.with_name("run.json").read_text())
+
+    messages = [str(w.get("message", "")) for w in record["warnings"]]
+    assert not any("Base-only configuration" in m and "Total excludes Base" in m for m in messages)
 
 
 def test_run_record_bundle_path_points_to_bundle_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- document that Total is overlay contribution and excludes Base in the primer
- add a dashboard Overlay Total metric with tooltip explaining the convention
- emit a serialized warning for Base-only runs so run.json/manifest warnings capture the zero-Total guardrail

Closes #1905

## Validation
- .venv/bin/python -m pytest tests/test_overlay_semantics_1905.py tests/test_run_record_warnings.py tests/test_dashboard_pages.py tests/test_cli.py -q
- .venv/bin/python -m ruff check pa_core/portfolio/core.py pa_core/portfolio/__init__.py pa_core/cli.py dashboard/glossary.py dashboard/pages/4_Results.py tests/test_run_record_warnings.py tests/test_overlay_semantics_1905.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional **“Overlay Total”** metric to the Results page Key Metrics (shown when relevant summary columns are available).

* **Documentation**
  * Updated **“Total (overlay contribution)”** to clarify it **excludes Base** and reflects overlay-sleeve semantics.

* **Bug Fixes**
  * Unified **“overlay total”/“total”** tooltip text with a shared definition.
  * Fixed **Overlay Total** to compute from the **mean across all matching “Total” rows**.
  * CLI now emits a **Base-only configuration** warning when applicable.

* **Tests**
  * Added regression tests for tooltip/documentation consistency, base-only detection, warning serialization, and overlay-total aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->