### PR TITLE
refactor: consolidate the two PPTX exporters (#1906)

### DIFF
--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -2001,6 +2001,14 @@ def main(
                 logger.error(f"PPTX export failed due to data issue: {e}")
                 print(f"❌ PPTX export failed: Invalid data - {e}")
                 print("💡 Check your visualization data and parameters")
+            except RuntimeError as e:
+                # Raised by pptx_export when a static renderer (Kaleido/Chromium)
+                # is unavailable; surface it instead of dropping chart slides.
+                logger.error(f"PPTX export failed: {e}")
+                print("❌ PPTX export failed: Kaleido or Chrome/Chromium required")
+                print(
+                    "💡 Install with: pip install kaleido (preferred) or sudo apt-get install chromium-browser"
+                )
         if flags.html:
             viz.html_export.save(
                 fig,

--- a/pa_core/reporting/export_packet.py
+++ b/pa_core/reporting/export_packet.py
@@ -7,9 +7,6 @@ errors when static chart export is unavailable.
 
 from __future__ import annotations
 
-import base64
-import io
-import os
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence, Tuple
 
@@ -19,14 +16,12 @@ from pptx.dml.color import RGBColor
 from pptx.enum.text import PP_ALIGN
 from pptx.util import Inches, Pt
 
+from ..viz.pptx_export import add_chart_slide
 from .disclaimers import LIMITATIONS_TITLE, MODEL_LIMITATIONS
 from .excel import export_to_excel, finalize_excel_workbook
 
 __all__ = ["create_export_packet"]
 
-_ONE_PX_PNG = base64.b64decode(
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
-)
 RGBColorAny: Any = RGBColor  # python-pptx lacks typing for RGBColor
 
 
@@ -92,30 +87,10 @@ def _add_summary_table_slide(prs: Any, df: pd.DataFrame, title: str = "Executive
 
 
 def _add_chart_slide(prs: Any, fig: Any, alt: str | None = None) -> None:
-    slide = prs.slides.add_slide(prs.slide_layouts[5])
-    if os.environ.get("CI") or os.environ.get("PYTEST_CURRENT_TEST"):
-        # Avoid hanging kaleido subprocesses in CI/pytest by using a tiny placeholder image.
-        img = _ONE_PX_PNG
-    else:
-        try:
-            img = fig.to_image(format="png", engine="kaleido")
-        except Exception as e:
-            raise RuntimeError(
-                "PPTX export requires a static image renderer (Kaleido/Chromium). "
-                "Install Plotly Kaleido or Chrome/Chromium. For Debian/Ubuntu: "
-                "pip install 'plotly[kaleido]' or sudo apt-get install -y chromium-browser. "
-                f"Original error: {e}"
-            ) from e
-
-    pic = slide.shapes.add_picture(io.BytesIO(img), Inches(0), Inches(0))
-    if not alt:
-        layout = getattr(fig, "layout", None)
-        title = getattr(layout, "title", None) if layout is not None else None
-        text = getattr(title, "text", None) if title is not None else None
-        alt = str(text) if text else ""
-    if alt:
-        el = pic._element.xpath("./p:nvPicPr/p:cNvPr")[0]
-        el.set("descr", alt)
+    # Delegate to the shared viz exporter so chart rendering and kaleido error
+    # handling stay consistent between the standalone PPTX export and this
+    # committee packet (see pa_core/viz/pptx_export.add_chart_slide).
+    add_chart_slide(prs, fig, alt=alt)
 
 
 def _add_table_slide(prs: Any, df: pd.DataFrame, title: str = "Table") -> None:

--- a/pa_core/viz/pptx_export.py
+++ b/pa_core/viz/pptx_export.py
@@ -4,7 +4,7 @@ import base64
 import io
 import os
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Sequence, cast
 
 import plotly.graph_objects as go
 from pptx import Presentation
@@ -32,7 +32,7 @@ def render_chart_png(fig: Any) -> bytes:
     if os.environ.get("CI") or os.environ.get("PYTEST_CURRENT_TEST"):
         return _ONE_PX_PNG
     try:
-        return fig.to_image(format="png", engine="kaleido")
+        return cast(bytes, fig.to_image(format="png", engine="kaleido"))
     except Exception as e:  # pragma: no cover - exercised only without kaleido
         raise RuntimeError(
             "PPTX export requires a static image renderer (Kaleido/Chromium). "

--- a/pa_core/viz/pptx_export.py
+++ b/pa_core/viz/pptx_export.py
@@ -4,11 +4,67 @@ import base64
 import io
 import os
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Sequence
 
 import plotly.graph_objects as go
 from pptx import Presentation
 from pptx.util import Inches
+
+__all__ = ["render_chart_png", "add_chart_slide", "save"]
+
+# Tiny 1x1 PNG used as a placeholder in CI/pytest so chart slides never spawn a
+# (potentially hanging) kaleido/Chromium subprocess during automated runs.
+_ONE_PX_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMA"
+    "ASsJTYQAAAAASUVORK5CYII="
+)
+
+
+def render_chart_png(fig: Any) -> bytes:
+    """Render a Plotly figure to PNG bytes for embedding in a PPTX slide.
+
+    In CI/pytest a tiny placeholder image is returned to avoid hanging kaleido
+    subprocesses. Outside CI a real static render is attempted via Kaleido; if
+    that renderer is unavailable the failure is surfaced as an actionable
+    ``RuntimeError`` rather than being silently swallowed (a silently-skipped
+    chart produces a divergent, incomplete board pack).
+    """
+    if os.environ.get("CI") or os.environ.get("PYTEST_CURRENT_TEST"):
+        return _ONE_PX_PNG
+    try:
+        return fig.to_image(format="png", engine="kaleido")
+    except Exception as e:  # pragma: no cover - exercised only without kaleido
+        raise RuntimeError(
+            "PPTX export requires a static image renderer (Kaleido/Chromium). "
+            "Install Plotly Kaleido or Chrome/Chromium. For Debian/Ubuntu: "
+            "pip install 'plotly[kaleido]' or sudo apt-get install -y chromium-browser. "
+            f"Original error: {e}"
+        ) from e
+
+
+def add_chart_slide(
+    prs: Any,
+    fig: Any,
+    *,
+    alt: str | None = None,
+    layout_index: int = 5,
+) -> None:
+    """Add a single full-bleed chart slide to ``prs`` for ``fig``.
+
+    The image is rendered via :func:`render_chart_png` (shared error handling)
+    and accessibility alt text is set from ``alt`` or the figure's layout title.
+    """
+    slide = prs.slides.add_slide(prs.slide_layouts[layout_index])
+    img_bytes = render_chart_png(fig)
+    pic = slide.shapes.add_picture(io.BytesIO(img_bytes), Inches(0), Inches(0))
+    if not alt:
+        layout = getattr(fig, "layout", None)
+        title = getattr(layout, "title", None) if layout is not None else None
+        text = getattr(title, "text", None) if title is not None else None
+        alt = str(text) if text else ""
+    if alt:
+        el = pic._element.xpath("./p:nvPicPr/p:cNvPr")[0]
+        el.set("descr", alt)
 
 
 def save(
@@ -28,28 +84,16 @@ def save(
     alt_texts:
         Optional sequence of alt text strings for accessibility. If omitted,
         each figure's layout title is used when present.
+
+    Raises
+    ------
+    RuntimeError
+        If a static image renderer (Kaleido/Chromium) is required but
+        unavailable. This matches the committee export-packet behaviour so a
+        missing renderer can never silently drop chart slides.
     """
-    one_px_png = base64.b64decode(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMA"
-        "ASsJTYQAAAAASUVORK5CYII="
-    )
     pres = Presentation()
     alt_iter = iter(alt_texts) if alt_texts is not None else None
     for fig in figs:
-        slide = pres.slides.add_slide(pres.slide_layouts[5])
-        try:
-            if os.environ.get("CI") or os.environ.get("PYTEST_CURRENT_TEST"):
-                img_bytes = one_px_png
-            else:
-                img_bytes = fig.to_image(format="png", engine="kaleido")
-            pic = slide.shapes.add_picture(io.BytesIO(img_bytes), Inches(0), Inches(0))
-            alt = next(alt_iter, None) if alt_iter else None
-            if not alt:
-                alt = str(fig.layout.title.text) if fig.layout.title.text else ""
-            if alt:
-                el = pic._element.xpath("./p:nvPicPr/p:cNvPr")[0]
-                el.set("descr", alt)
-        except Exception:
-            # Fallback: ignore export errors
-            pass
+        add_chart_slide(pres, fig, alt=next(alt_iter, None) if alt_iter else None)
     pres.save(str(path))

--- a/pa_core/viz/pptx_export.py
+++ b/pa_core/viz/pptx_export.py
@@ -12,28 +12,36 @@ from pptx.util import Inches
 
 __all__ = ["render_chart_png", "add_chart_slide", "save"]
 
-# Tiny 1x1 PNG used as a placeholder in CI/pytest so chart slides never spawn a
-# (potentially hanging) kaleido/Chromium subprocess during automated runs.
+# Tiny 1x1 PNG used as a placeholder in pytest or explicit placeholder mode so
+# chart slides never spawn a potentially hanging kaleido/Chromium subprocess.
 _ONE_PX_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMA"
     "ASsJTYQAAAAASUVORK5CYII="
 )
+_RENDERER_ERROR_TERMS = ("kaleido", "chrome", "chromium")
+
+
+def _is_static_renderer_error(exc: BaseException) -> bool:
+    return any(term in str(exc).lower() for term in _RENDERER_ERROR_TERMS)
 
 
 def render_chart_png(fig: Any) -> bytes:
     """Render a Plotly figure to PNG bytes for embedding in a PPTX slide.
 
-    In CI/pytest a tiny placeholder image is returned to avoid hanging kaleido
-    subprocesses. Outside CI a real static render is attempted via Kaleido; if
-    that renderer is unavailable the failure is surfaced as an actionable
-    ``RuntimeError`` rather than being silently swallowed (a silently-skipped
-    chart produces a divergent, incomplete board pack).
+    In pytest or explicit placeholder mode a tiny placeholder image is returned
+    to avoid hanging kaleido subprocesses. Otherwise a real static render is
+    attempted via Kaleido; if that renderer is unavailable the failure is
+    surfaced as an actionable ``RuntimeError`` rather than being silently
+    swallowed (a silently-skipped chart produces a divergent, incomplete board
+    pack).
     """
-    if os.environ.get("CI") or os.environ.get("PYTEST_CURRENT_TEST"):
+    if os.environ.get("PYTEST_CURRENT_TEST") or os.environ.get("PA_PPTX_PLACEHOLDER") == "1":
         return _ONE_PX_PNG
     try:
         return cast(bytes, fig.to_image(format="png", engine="kaleido"))
     except Exception as e:  # pragma: no cover - exercised only without kaleido
+        if not _is_static_renderer_error(e):
+            raise
         raise RuntimeError(
             "PPTX export requires a static image renderer (Kaleido/Chromium). "
             "Install Plotly Kaleido or Chrome/Chromium. For Debian/Ubuntu: "
@@ -56,7 +64,13 @@ def add_chart_slide(
     """
     slide = prs.slides.add_slide(prs.slide_layouts[layout_index])
     img_bytes = render_chart_png(fig)
-    pic = slide.shapes.add_picture(io.BytesIO(img_bytes), Inches(0), Inches(0))
+    pic = slide.shapes.add_picture(
+        io.BytesIO(img_bytes),
+        Inches(0),
+        Inches(0),
+        width=prs.slide_width,
+        height=prs.slide_height,
+    )
     if not alt:
         layout = getattr(fig, "layout", None)
         title = getattr(layout, "title", None) if layout is not None else None

--- a/scripts/visualise.py
+++ b/scripts/visualise.py
@@ -90,9 +90,12 @@ def main(argv: list[str] | None = None) -> None:
         except Exception as e:
             logging.warning("PDF export failed: %s", e)
     if args.pptx:
-        pptx_export.save(
-            [fig], f"{stem}.pptx", alt_texts=[args.alt_text] if args.alt_text else None
-        )
+        try:
+            pptx_export.save(
+                [fig], f"{stem}.pptx", alt_texts=[args.alt_text] if args.alt_text else None
+            )
+        except RuntimeError as e:
+            logging.warning("PPTX export failed: %s", e)
     if args.gif:
         if df_paths is None:
             raise FileNotFoundError(parquet_path)

--- a/tests/test_pptx_export_consolidation_1906.py
+++ b/tests/test_pptx_export_consolidation_1906.py
@@ -1,0 +1,78 @@
+"""Regression tests for issue #1906: consolidate the two PPTX exporters.
+
+`pa_core/viz/pptx_export.py` and `pa_core/reporting/export_packet.py` used to be
+near-duplicate PPTX implementations with divergent kaleido error handling (one
+silently swallowed render failures, the other raised). Both must now share a
+single render/slide code path with consistent, actionable error handling so a
+missing renderer can never silently drop chart slides from a board pack.
+"""
+
+from __future__ import annotations
+
+import plotly.graph_objects as go
+import pytest
+from pptx import Presentation
+
+from pa_core.reporting import export_packet
+from pa_core.viz import pptx_export
+
+
+class _BoomFig:
+    """Stand-in figure whose static render always fails (no kaleido)."""
+
+    layout = None
+
+    def to_image(self, *args: object, **kwargs: object) -> bytes:
+        raise ValueError("Kaleido/Chromium not installed")
+
+
+def _without_ci_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force the real-render branch (CI/pytest normally short-circuit to a
+    # placeholder image to avoid spawning kaleido).
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+
+def test_export_packet_delegates_to_shared_helper() -> None:
+    # Guard against re-divergence: the committee packet must reuse the viz
+    # exporter rather than reimplementing chart rendering.
+    assert export_packet.add_chart_slide is pptx_export.add_chart_slide
+
+
+def test_render_chart_png_uses_placeholder_under_pytest() -> None:
+    # Under pytest PYTEST_CURRENT_TEST is set, so no kaleido subprocess runs.
+    assert pptx_export.render_chart_png(_BoomFig()) == pptx_export._ONE_PX_PNG
+
+
+def test_save_raises_actionable_error_without_renderer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    # `save` no longer silently swallows render failures.
+    _without_ci_placeholder(monkeypatch)
+    with pytest.raises(RuntimeError, match="static image renderer"):
+        pptx_export.save([_BoomFig()], tmp_path / "out.pptx")  # type: ignore[operator]
+
+
+def test_packet_chart_slide_raises_same_error_without_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The packet path raises the identical actionable error (shared code path).
+    _without_ci_placeholder(monkeypatch)
+    prs = Presentation()
+    with pytest.raises(RuntimeError, match="static image renderer"):
+        export_packet._add_chart_slide(prs, _BoomFig())
+
+
+def test_save_writes_slides_with_alt_text(tmp_path: object) -> None:
+    fig = go.Figure()
+    out = tmp_path / "out.pptx"  # type: ignore[operator]
+    pptx_export.save([fig], out, alt_texts=["my chart"])
+    assert out.exists()
+    pres = Presentation(out)
+    # Layout 5 carries a title placeholder, so scan all shapes for the picture.
+    descrs = [
+        node.get("descr")
+        for shape in pres.slides[0].shapes
+        for node in shape._element.xpath("./p:nvPicPr/p:cNvPr")
+    ]
+    assert "my chart" in descrs

--- a/tests/test_pptx_export_consolidation_1906.py
+++ b/tests/test_pptx_export_consolidation_1906.py
@@ -9,6 +9,8 @@ missing renderer can never silently drop chart slides from a board pack.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import plotly.graph_objects as go
 import pytest
 from pptx import Presentation
@@ -26,11 +28,21 @@ class _BoomFig:
         raise ValueError("Kaleido/Chromium not installed")
 
 
+class _BadFig:
+    """Stand-in figure whose render fails for a non-renderer data reason."""
+
+    layout = None
+
+    def to_image(self, *args: object, **kwargs: object) -> bytes:
+        raise ValueError("bad figure data")
+
+
 def _without_ci_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Force the real-render branch (CI/pytest normally short-circuit to a
+    # Force the real-render branch (pytest normally short-circuits to a
     # placeholder image to avoid spawning kaleido).
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("PA_PPTX_PLACEHOLDER", raising=False)
 
 
 def test_export_packet_delegates_to_shared_helper() -> None:
@@ -44,13 +56,32 @@ def test_render_chart_png_uses_placeholder_under_pytest() -> None:
     assert pptx_export.render_chart_png(_BoomFig()) == pptx_export._ONE_PX_PNG
 
 
+def test_render_chart_png_does_not_mask_renderer_failure_in_generic_ci(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("PA_PPTX_PLACEHOLDER", raising=False)
+
+    with pytest.raises(RuntimeError, match="static image renderer"):
+        pptx_export.render_chart_png(_BoomFig())
+
+
+def test_render_chart_png_preserves_non_renderer_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _without_ci_placeholder(monkeypatch)
+    with pytest.raises(ValueError, match="bad figure data"):
+        pptx_export.render_chart_png(_BadFig())
+
+
 def test_save_raises_actionable_error_without_renderer(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     # `save` no longer silently swallows render failures.
     _without_ci_placeholder(monkeypatch)
     with pytest.raises(RuntimeError, match="static image renderer"):
-        pptx_export.save([_BoomFig()], tmp_path / "out.pptx")  # type: ignore[operator]
+        pptx_export.save([_BoomFig()], tmp_path / "out.pptx")
 
 
 def test_packet_chart_slide_raises_same_error_without_renderer(
@@ -63,9 +94,9 @@ def test_packet_chart_slide_raises_same_error_without_renderer(
         export_packet._add_chart_slide(prs, _BoomFig())
 
 
-def test_save_writes_slides_with_alt_text(tmp_path: object) -> None:
+def test_save_writes_slides_with_alt_text(tmp_path: Path) -> None:
     fig = go.Figure()
-    out = tmp_path / "out.pptx"  # type: ignore[operator]
+    out = tmp_path / "out.pptx"
     pptx_export.save([fig], out, alt_texts=["my chart"])
     assert out.exists()
     pres = Presentation(out)


### PR DESCRIPTION
## Summary
`pa_core/viz/pptx_export.py` and `pa_core/reporting/export_packet.py` were near-duplicate PPTX implementations with **divergent kaleido error handling** — `viz.save()` silently swallowed render failures (producing incomplete board packs with no warning) while `export_packet` raised an actionable error. This consolidates both onto one shared code path.

## Changes
- `pa_core/viz/pptx_export.py`: add shared `render_chart_png(fig)` and `add_chart_slide(prs, fig, *, alt=...)` helpers using the **actionable-raise** behaviour (CI/pytest still short-circuit to the 1px placeholder). `save()` now uses them, so it no longer silently drops chart slides.
- `pa_core/reporting/export_packet.py`: `_add_chart_slide` now delegates to the shared `add_chart_slide`; removed the duplicated render/placeholder/error logic and now-unused imports.
- `pa_core/cli.py`: handle the `RuntimeError` from a missing static renderer so the CLI pptx path stays graceful instead of crashing.
- `tests/test_pptx_export_consolidation_1906.py`: regression tests asserting both paths share the helper and raise the same actionable error.

## Validation
- `tests/test_pptx_export_consolidation_1906.py tests/test_viz.py tests/test_export_packet.py tests/test_reporting_exports.py tests/test_cli_packet_diff.py tests/test_model_limitations_1923.py` → 53 passed
- `ruff check` on all touched files → clean

Closes #1906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PPTX chart export now provides clear, actionable guidance when the required static image renderer (Kaleido or Chrome/Chromium) isn’t available, instead of silently failing or producing incomplete output.
  * PPTX export failures are handled more consistently across export entry points (with warning behavior in the visualisation script).
* **New Features**
  * PPTX chart slides now include accessibility descriptions (alt-text), which are propagated into the exported slide metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->