### PR TITLE
Wire dashboard validation UI

### DIFF
--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -17,6 +17,7 @@ import streamlit as st
 import yaml
 
 from dashboard import cli as dashboard_cli
+from dashboard import validation_ui
 from dashboard.app import _DEF_XLSX, apply_theme, render_settings_sidebar
 from dashboard.components.config_chat import render_config_chat_panel
 from dashboard.components.llm_settings import (
@@ -1757,9 +1758,43 @@ def _render_step_4_correlations(config: Any) -> Any:
         )
     else:
         st.success("✅ Correlation matrix is valid")
+
+    _render_validation_panel(config)
     return config
 
-    return config
+
+def _config_validation_payload(config: Any) -> dict[str, Any]:
+    """Return the legacy validator input shape from the wizard config view."""
+
+    payload: dict[str, Any] = {
+        "rho_idx_H": config.rho_idx_h,
+        "rho_idx_E": config.rho_idx_e,
+        "rho_idx_M": config.rho_idx_m,
+        "rho_H_E": config.rho_h_e,
+        "rho_H_M": config.rho_h_m,
+        "rho_E_M": config.rho_e_m,
+        "external_pa_capital": config.external_pa_capital,
+        "active_ext_capital": config.active_ext_capital,
+        "internal_pa_capital": config.internal_pa_capital,
+        "total_fund_capital": config.total_fund_capital,
+        "reference_sigma": config.reference_sigma,
+        "volatility_multiple": config.volatility_multiple,
+        "financing_model": config.financing_model,
+        "financing_term_months": config.financing_term_months,
+        "N_SIMULATIONS": config.n_simulations,
+    }
+    if config.financing_schedule_path:
+        payload["financing_schedule_path"] = config.financing_schedule_path
+    return payload
+
+
+def _render_validation_panel(config: Any) -> list[Any]:
+    """Render real-time wizard validation and return the computed results."""
+
+    settings = validation_ui.create_validation_sidebar()
+    results = validation_ui.validate_scenario_config(_config_validation_payload(config), settings)
+    validation_ui.display_validation_results(results, title="Wizard Validation")
+    return results
 
 
 def _render_step_5_review(config: DefaultConfigView) -> bool:

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -1766,6 +1766,7 @@ def _render_step_4_correlations(config: Any) -> Any:
 def _config_validation_payload(config: Any) -> dict[str, Any]:
     """Return the legacy validator input shape from the wizard config view."""
 
+    financing_settings = st.session_state.get("financing_settings", {})
     payload: dict[str, Any] = {
         "rho_idx_H": config.rho_idx_h,
         "rho_idx_E": config.rho_idx_e,
@@ -1777,14 +1778,15 @@ def _config_validation_payload(config: Any) -> dict[str, Any]:
         "active_ext_capital": config.active_ext_capital,
         "internal_pa_capital": config.internal_pa_capital,
         "total_fund_capital": config.total_fund_capital,
-        "reference_sigma": config.reference_sigma,
-        "volatility_multiple": config.volatility_multiple,
-        "financing_model": config.financing_model,
-        "financing_term_months": config.financing_term_months,
+        "reference_sigma": float(financing_settings.get("reference_sigma", 0.01)),
+        "volatility_multiple": float(financing_settings.get("volatility_multiple", 3.0)),
+        "financing_model": financing_settings.get("financing_model", "simple_proxy"),
+        "financing_term_months": float(financing_settings.get("term_months", 1.0)),
         "N_SIMULATIONS": config.n_simulations,
     }
-    if config.financing_schedule_path:
-        payload["financing_schedule_path"] = config.financing_schedule_path
+    schedule_path = financing_settings.get("schedule_path")
+    if schedule_path:
+        payload["financing_schedule_path"] = str(schedule_path)
     return payload
 
 

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -409,7 +409,7 @@ def main() -> None:
 
     if auto:
         time.sleep(interval)
-        st.experimental_rerun()
+        st.rerun()
 
 
 if __name__ == "__main__":

--- a/tests/test_dashboard_dead_ux_1907.py
+++ b/tests/test_dashboard_dead_ux_1907.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import runpy
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
+
+import streamlit as st
+
+from pa_core.wizard_schema import AnalysisMode, get_default_config
 
 
 def _wizard_module() -> dict[str, Any]:
@@ -20,7 +23,7 @@ def test_wizard_validation_panel_uses_existing_validation_ui(monkeypatch) -> Non
         "show_details": False,
         "show_warnings": True,
     }
-    results = [SimpleNamespace(is_valid=True, severity="info")]
+    results = [object()]
 
     def fake_validate(payload: dict[str, Any], received_settings: dict[str, Any]) -> list[Any]:
         calls["payload"] = payload
@@ -34,31 +37,41 @@ def test_wizard_validation_panel_uses_existing_validation_ui(monkeypatch) -> Non
     monkeypatch.setattr(validation_ui, "validate_scenario_config", fake_validate)
     monkeypatch.setattr(validation_ui, "display_validation_results", fake_display)
 
-    config = SimpleNamespace(
-        rho_idx_h=0.1,
-        rho_idx_e=0.2,
-        rho_idx_m=0.3,
-        rho_h_e=0.4,
-        rho_h_m=0.5,
-        rho_e_m=0.6,
-        external_pa_capital=10.0,
-        active_ext_capital=20.0,
-        internal_pa_capital=30.0,
-        total_fund_capital=100.0,
-        reference_sigma=0.01,
-        volatility_multiple=3.0,
-        financing_model="simple_proxy",
-        financing_term_months=12.0,
-        financing_schedule_path=None,
-        n_simulations=5000,
-    )
+    st.session_state.clear()
+    try:
+        config = get_default_config(AnalysisMode.RETURNS)
+        config.rho_idx_h = 0.1
+        config.rho_idx_e = 0.2
+        config.rho_idx_m = 0.3
+        config.rho_h_e = 0.4
+        config.rho_h_m = 0.5
+        config.rho_e_m = 0.6
+        config.external_pa_capital = 10.0
+        config.active_ext_capital = 20.0
+        config.internal_pa_capital = 30.0
+        config.total_fund_capital = 100.0
+        config.n_simulations = 5000
+        st.session_state["financing_settings"] = {
+            "financing_model": "schedule",
+            "reference_sigma": 0.02,
+            "volatility_multiple": 4.0,
+            "term_months": 12.0,
+            "schedule_path": "margin.csv",
+        }
 
-    assert module["_render_validation_panel"](config) == results
-    assert calls["settings"] == settings
-    assert calls["payload"]["rho_idx_H"] == 0.1
-    assert calls["payload"]["rho_E_M"] == 0.6
-    assert calls["payload"]["N_SIMULATIONS"] == 5000
-    assert calls["display"] == (results, "Wizard Validation")
+        assert module["_render_validation_panel"](config) == results
+        assert calls["settings"] == settings
+        assert calls["payload"]["rho_idx_H"] == 0.1
+        assert calls["payload"]["rho_E_M"] == 0.6
+        assert calls["payload"]["reference_sigma"] == 0.02
+        assert calls["payload"]["volatility_multiple"] == 4.0
+        assert calls["payload"]["financing_model"] == "schedule"
+        assert calls["payload"]["financing_term_months"] == 12.0
+        assert calls["payload"]["financing_schedule_path"] == "margin.csv"
+        assert calls["payload"]["N_SIMULATIONS"] == 5000
+        assert calls["display"] == (results, "Wizard Validation")
+    finally:
+        st.session_state.clear()
 
 
 def test_scenario_wizard_no_unreachable_double_return_after_correlations() -> None:

--- a/tests/test_dashboard_dead_ux_1907.py
+++ b/tests/test_dashboard_dead_ux_1907.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+def _wizard_module() -> dict[str, Any]:
+    return runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
+
+
+def test_wizard_validation_panel_uses_existing_validation_ui(monkeypatch) -> None:
+    module = _wizard_module()
+    validation_ui = module["validation_ui"]
+    calls: dict[str, Any] = {}
+
+    settings = {
+        "validate_on_change": True,
+        "show_details": False,
+        "show_warnings": True,
+    }
+    results = [SimpleNamespace(is_valid=True, severity="info")]
+
+    def fake_validate(payload: dict[str, Any], received_settings: dict[str, Any]) -> list[Any]:
+        calls["payload"] = payload
+        calls["settings"] = received_settings
+        return results
+
+    def fake_display(received_results: list[Any], title: str) -> None:
+        calls["display"] = (received_results, title)
+
+    monkeypatch.setattr(validation_ui, "create_validation_sidebar", lambda: settings)
+    monkeypatch.setattr(validation_ui, "validate_scenario_config", fake_validate)
+    monkeypatch.setattr(validation_ui, "display_validation_results", fake_display)
+
+    config = SimpleNamespace(
+        rho_idx_h=0.1,
+        rho_idx_e=0.2,
+        rho_idx_m=0.3,
+        rho_h_e=0.4,
+        rho_h_m=0.5,
+        rho_e_m=0.6,
+        external_pa_capital=10.0,
+        active_ext_capital=20.0,
+        internal_pa_capital=30.0,
+        total_fund_capital=100.0,
+        reference_sigma=0.01,
+        volatility_multiple=3.0,
+        financing_model="simple_proxy",
+        financing_term_months=12.0,
+        financing_schedule_path=None,
+        n_simulations=5000,
+    )
+
+    assert module["_render_validation_panel"](config) == results
+    assert calls["settings"] == settings
+    assert calls["payload"]["rho_idx_H"] == 0.1
+    assert calls["payload"]["rho_E_M"] == 0.6
+    assert calls["payload"]["N_SIMULATIONS"] == 5000
+    assert calls["display"] == (results, "Wizard Validation")
+
+
+def test_scenario_wizard_no_unreachable_double_return_after_correlations() -> None:
+    source = Path("dashboard/pages/3_Scenario_Wizard.py").read_text()
+
+    assert "_render_validation_panel(config)\n    return config\n\n    return config" not in source
+
+
+def test_results_page_uses_modern_rerun_api() -> None:
+    source = Path("dashboard/pages/4_Results.py").read_text()
+
+    assert "st.experimental_rerun" not in source
+    assert "st.rerun()" in source


### PR DESCRIPTION
## Summary
- wire the existing validation_ui sidebar/results into the Scenario Wizard correlation step
- remove the unreachable duplicate return from the correlation renderer
- replace deprecated Results auto-refresh st.experimental_rerun() with st.rerun()

Closes #1907

## Validation
- python -m pytest tests/test_dashboard_dead_ux_1907.py tests/test_dashboard_validation_ui.py -q
- python -m pytest tests/test_dashboard_pages.py tests/test_wizard_helpers.py -q
- python -m ruff check dashboard/pages/3_Scenario_Wizard.py dashboard/pages/4_Results.py tests/test_dashboard_dead_ux_1907.py
- python -m ruff format --check dashboard/pages/3_Scenario_Wizard.py dashboard/pages/4_Results.py tests/test_dashboard_dead_ux_1907.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validation sidebar panel to the Scenario Wizard’s correlation step, showing configuration validation results immediately after the correlation matrix check.

* **Chores**
  * Updated the Results page auto-refresh to use the modern rerun API.

* **Tests**
  * Added tests covering the wizard validation panel behavior and verifying the Results page no longer uses the deprecated rerun method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->