### PR TITLE
Generalize alpha stream draws for manager universe

### DIFF
--- a/pa_core/sim/__init__.py
+++ b/pa_core/sim/__init__.py
@@ -1,6 +1,6 @@
 """Vectorised Monte-Carlo helpers."""
 
-from .covariance import build_cov_matrix
+from .covariance import build_cov_matrix, build_generic_cov_matrix
 from .financing import (
     broadcast_dispersion_warning,
     draw_financing_series,
@@ -9,7 +9,9 @@ from .financing import (
 from .internal_pa_financing import resolve_internal_pa_financing_series
 from .paths import (
     draw_joint_returns,
+    draw_named_returns,
     draw_returns,
+    map_sleeve_alpha_streams,
     prepare_mc_universe,
     prepare_return_shocks,
     simulate_alpha_streams,
@@ -29,11 +31,14 @@ __all__ = [
     "broadcast_dispersion_warning",
     "prepare_mc_universe",
     "build_cov_matrix",
+    "build_generic_cov_matrix",
     "prepare_return_shocks",
+    "draw_named_returns",
     "draw_returns",
     "draw_financing",
     "draw_joint_returns",
     "draw_financing_series",
+    "map_sleeve_alpha_streams",
     "resolve_internal_pa_financing_series",
     "simulate_alpha_streams",
     "apply_regime_labels",

--- a/pa_core/sim/covariance.py
+++ b/pa_core/sim/covariance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import warnings
 from typing import Literal
 
@@ -9,7 +10,12 @@ from numpy.typing import NDArray
 from ..backend import xp
 from ..schema import CORRELATION_LOWER_BOUND, CORRELATION_UPPER_BOUND
 
-__all__ = ["build_cov_matrix", "nearest_psd", "build_cov_matrix_with_validation"]
+__all__ = [
+    "build_cov_matrix",
+    "build_generic_cov_matrix",
+    "nearest_psd",
+    "build_cov_matrix_with_validation",
+]
 
 
 def _boost_shrinkage_for_short_samples(
@@ -133,6 +139,87 @@ def build_cov_matrix(
         ]
     )
     cov = xp.outer(sds, sds) * rho
+    cov = 0.5 * (cov + cov.T)
+    if covariance_shrinkage == "ledoit_wolf" and n_samples is not None:
+        cov, _ = _ledoit_wolf_shrinkage_from_cov(cov, int(n_samples))
+        cov = xp.asarray(cov)
+    if _is_psd(cov):
+        return np.asarray(cov, dtype=np.float64)
+    adjusted = nearest_psd(cov)
+    max_delta = float(xp.max(xp.abs(adjusted - cov)))
+    warnings.warn(
+        f"Covariance matrix was not PSD; projected with max|Δ|={max_delta:.2e}",
+        RuntimeWarning,
+    )
+    return np.asarray(adjusted, dtype=np.float64)
+
+
+def _correlation_lookup(
+    correlations: Mapping[object, float], left: str, right: str
+) -> tuple[str, float]:
+    """Resolve a pairwise correlation from tuple or string-keyed mappings."""
+
+    candidates: tuple[object, ...] = (
+        (left, right),
+        (right, left),
+        tuple(sorted((left, right))),
+        f"{left}:{right}",
+        f"{right}:{left}",
+        f"{left},{right}",
+        f"{right},{left}",
+        f"rho_{left}_{right}",
+        f"rho_{right}_{left}",
+    )
+    for key in candidates:
+        if key in correlations:
+            return str(key), float(correlations[key])
+    raise ValueError(f"missing correlation for pair ({left}, {right})")
+
+
+def build_generic_cov_matrix(
+    stream_names: Sequence[str],
+    sigmas: Sequence[float] | Mapping[str, float],
+    correlations: Mapping[object, float],
+    covariance_shrinkage: Literal["none", "ledoit_wolf"] = "none",
+    n_samples: int | None = None,
+) -> NDArray[np.float64]:
+    """Return a PSD covariance matrix for index plus any number of alpha streams.
+
+    ``stream_names`` defines the matrix order, typically ``("idx", *alpha_names)``.
+    ``correlations`` must provide each off-diagonal pair using tuple keys,
+    ``"left:right"`` keys, or legacy-style ``"rho_left_right"`` keys.
+    """
+
+    names = tuple(str(name) for name in stream_names)
+    if len(names) < 2:
+        raise ValueError("stream_names must include index plus at least one alpha stream")
+    if len(set(names)) != len(names):
+        raise ValueError("stream_names must be unique")
+
+    if isinstance(sigmas, Mapping):
+        missing_sigmas = [name for name in names if name not in sigmas]
+        if missing_sigmas:
+            raise ValueError(f"missing sigma values for streams: {missing_sigmas}")
+        sigma_values = [float(sigmas[name]) for name in names]
+    else:
+        sigma_values = [float(value) for value in sigmas]
+        if len(sigma_values) != len(names):
+            raise ValueError("sigmas must have the same length as stream_names")
+
+    corr = xp.eye(len(names), dtype=float)
+    for i, left in enumerate(names):
+        for j in range(i + 1, len(names)):
+            right = names[j]
+            key, rho_value = _correlation_lookup(correlations, left, right)
+            if not (CORRELATION_LOWER_BOUND <= rho_value <= CORRELATION_UPPER_BOUND):
+                raise ValueError(
+                    f"{key} must be between {CORRELATION_LOWER_BOUND} and {CORRELATION_UPPER_BOUND}"
+                )
+            corr[i, j] = rho_value
+            corr[j, i] = rho_value
+
+    sds = xp.clip(xp.array(sigma_values, dtype=float), 0.0, None)
+    cov = xp.outer(sds, sds) * corr
     cov = 0.5 * (cov + cov.T)
     if covariance_shrinkage == "ledoit_wolf" and n_samples is not None:
         cov, _ = _ledoit_wolf_shrinkage_from_cov(cov, int(n_samples))

--- a/pa_core/sim/paths.py
+++ b/pa_core/sim/paths.py
@@ -18,9 +18,11 @@ __all__ = [
     "simulate_financing",
     "prepare_mc_universe",
     "prepare_return_shocks",
+    "draw_named_returns",
     "draw_returns",
     "draw_joint_returns",
     "draw_financing_series",
+    "map_sleeve_alpha_streams",
     "simulate_alpha_streams",
 ]
 
@@ -63,6 +65,20 @@ def _resolve_return_distributions(
         overrides[2] or base,
         overrides[3] or base,
     )
+
+
+def _resolve_stream_return_distributions(
+    base: str,
+    stream_names: Sequence[str],
+    overrides: Mapping[str, Optional[str]] | Sequence[Optional[str]] | None = None,
+) -> tuple[str, ...]:
+    if overrides is None:
+        return tuple(base for _ in stream_names)
+    if isinstance(overrides, Mapping):
+        return tuple(overrides.get(name) or base for name in stream_names)
+    if len(overrides) != len(stream_names):
+        raise ValueError("return_distributions must have the same length as stream_names")
+    return tuple(dist or base for dist in overrides)
 
 
 def _validate_correlation_matrix(corr: NDArray[Any]) -> None:
@@ -131,9 +147,7 @@ def _resolve_correlation_matrix(params: Dict[str, Any]) -> tuple[NDArray[Any], d
     repaired = corr_work
     if min_eig_work < -_CORR_VALIDATION_TOL:
         if repair_mode == "error":
-            raise ValueError(
-                "Correlation matrix is not PSD; " f"min eigenvalue {min_eig_work:.3e}."
-            )
+            raise ValueError(f"Correlation matrix is not PSD; min eigenvalue {min_eig_work:.3e}.")
         repaired = _project_to_near_psd_correlation(corr_work)
         applied_steps.append("eigen_clip")
     eigvals_after = np.linalg.eigvalsh(repaired)
@@ -485,6 +499,127 @@ def draw_returns(
     r_E = sims[:, :, 2]
     r_M = sims[:, :, 3]
     return r_beta, r_H, r_E, r_M
+
+
+def draw_named_returns(
+    *,
+    n_months: int,
+    n_sim: int,
+    stream_names: Sequence[str],
+    means: Sequence[float] | Mapping[str, float],
+    cov: npt.NDArray[Any],
+    return_distribution: str = "normal",
+    return_t_df: float = 5.0,
+    return_copula: str = "gaussian",
+    return_distributions: Mapping[str, Optional[str]] | Sequence[Optional[str]] | None = None,
+    seed: Optional[int] = None,
+    rng: Optional[GeneratorLike] = None,
+) -> dict[str, npt.NDArray[Any]]:
+    """Draw monthly returns for index plus an arbitrary named alpha universe.
+
+    This is the generic N-stream counterpart to ``draw_returns``. It preserves
+    the same distribution and copula semantics while returning a name-keyed
+    mapping, so callers can map Scenario sleeves to any calibrated manager
+    stream instead of only the legacy H/E/M streams.
+    """
+
+    names = tuple(str(name) for name in stream_names)
+    if n_months <= 0 or n_sim <= 0:
+        raise ValueError("n_months and n_sim must be positive")
+    if len(names) < 2:
+        raise ValueError("stream_names must include index plus at least one alpha stream")
+    if len(set(names)) != len(names):
+        raise ValueError("stream_names must be unique")
+    if cov.shape != (len(names), len(names)):
+        raise ValueError("cov shape must match stream_names")
+
+    if isinstance(means, Mapping):
+        missing_means = [name for name in names if name not in means]
+        if missing_means:
+            raise ValueError(f"missing mean values for streams: {missing_means}")
+        mean_vec = np.array([float(means[name]) for name in names])
+    else:
+        mean_vec = np.array([float(value) for value in means])
+        if mean_vec.size != len(names):
+            raise ValueError("means must have the same length as stream_names")
+
+    distributions = _resolve_stream_return_distributions(
+        return_distribution, names, return_distributions
+    )
+    _validate_return_draw_settings(distributions, return_copula, return_t_df)
+    rng = ensure_rng(seed, rng)
+    if all(dist == "normal" for dist in distributions):
+        sims = _safe_multivariate_normal(rng, mean_vec, cov, (n_sim, n_months))
+    else:
+        sigma = np.sqrt(np.clip(np.diag(cov), 0.0, None))
+        denom = np.outer(sigma, sigma)
+        corr = np.divide(
+            cov,
+            denom,
+            out=np.eye(cov.shape[0]),
+            where=denom != 0.0,
+        )
+        if all(dist == "student_t" for dist in distributions):
+            sims = _draw_student_t(
+                rng=rng,
+                mean=mean_vec,
+                sigma=sigma,
+                corr=corr,
+                size=(n_sim, n_months),
+                df=return_t_df,
+                copula=return_copula,
+            )
+        else:
+            sims = _draw_mixed_returns(
+                rng=rng,
+                mean=mean_vec,
+                sigma=sigma,
+                corr=corr,
+                size=(n_sim, n_months),
+                df=return_t_df,
+                copula=return_copula,
+                distributions=distributions,
+            )
+    return {name: sims[:, :, idx] for idx, name in enumerate(names)}
+
+
+def _normalize_alpha_source(source: str) -> tuple[str, ...]:
+    raw = str(source).strip()
+    if not raw:
+        raise ValueError("alpha_source must not be empty")
+    candidates = [raw]
+    if ":" in raw:
+        _, suffix = raw.split(":", 1)
+        candidates.append(suffix)
+    for prefix in ("stream:", "alpha:", "portfolio:", "manager:"):
+        if not raw.startswith(prefix):
+            candidates.append(f"{prefix}{raw}")
+    return tuple(dict.fromkeys(candidates))
+
+
+def map_sleeve_alpha_streams(
+    sleeve_alpha_sources: Mapping[str, str],
+    return_streams: Mapping[str, npt.NDArray[Any]],
+) -> dict[str, npt.NDArray[Any]]:
+    """Map sleeve names to drawn alpha streams using their configured source.
+
+    Source values may be plain stream names or prefixed values such as
+    ``stream:manager_a`` and ``portfolio:trend_123``. The latter is important
+    for Scenario sleeves that already express Trend-selected manager sources.
+    """
+
+    mapped: dict[str, npt.NDArray[Any]] = {}
+    for sleeve_name, source in sleeve_alpha_sources.items():
+        for candidate in _normalize_alpha_source(source):
+            if candidate in return_streams:
+                mapped[str(sleeve_name)] = return_streams[candidate]
+                break
+        else:
+            raise KeyError(
+                f"alpha source {source!r} for sleeve {sleeve_name!r} "
+                "does not match any drawn return stream"
+            )
+    return mapped
 
 
 def _distribution_signature(params: Dict[str, Any]) -> tuple[Any, ...]:

--- a/pa_core/sim/paths.py
+++ b/pa_core/sim/paths.py
@@ -588,12 +588,15 @@ def _normalize_alpha_source(source: str) -> tuple[str, ...]:
     if not raw:
         raise ValueError("alpha_source must not be empty")
     candidates = [raw]
+    suffix = raw
     if ":" in raw:
         _, suffix = raw.split(":", 1)
         candidates.append(suffix)
     for prefix in ("stream:", "alpha:", "portfolio:", "manager:"):
         if not raw.startswith(prefix):
             candidates.append(f"{prefix}{raw}")
+        if suffix != raw:
+            candidates.append(f"{prefix}{suffix}")
     return tuple(dict.fromkeys(candidates))
 
 

--- a/tests/test_n_manager_streams_1908.py
+++ b/tests/test_n_manager_streams_1908.py
@@ -38,7 +38,15 @@ def test_generic_covariance_supports_manager_universe_shape() -> None:
 
 
 def test_named_return_draws_map_sleeves_to_alpha_sources() -> None:
-    stream_names = ("idx", "H", "E", "M", "portfolio:trend_growth", "portfolio:trend_value")
+    stream_names = (
+        "idx",
+        "H",
+        "E",
+        "M",
+        "portfolio:trend_growth",
+        "portfolio:trend_value",
+        "stream:trend_core",
+    )
     correlations = {
         (left, right): 0.0 for i, left in enumerate(stream_names) for right in stream_names[i + 1 :]
     }
@@ -51,6 +59,7 @@ def test_named_return_draws_map_sleeves_to_alpha_sources() -> None:
             "M": 0.04,
             "portfolio:trend_growth": 0.05,
             "portfolio:trend_value": 0.06,
+            "stream:trend_core": 0.07,
         },
         correlations,
     )
@@ -67,6 +76,7 @@ def test_named_return_draws_map_sleeves_to_alpha_sources() -> None:
         {
             "growth_manager": "portfolio:trend_growth",
             "value_manager": "trend_value",
+            "prefixed_stream_manager": "portfolio:trend_core",
         },
         draws,
     )
@@ -75,6 +85,9 @@ def test_named_return_draws_map_sleeves_to_alpha_sources() -> None:
     assert draws["portfolio:trend_growth"].shape == (4, 3)
     np.testing.assert_array_equal(sleeve_streams["growth_manager"], draws["portfolio:trend_growth"])
     np.testing.assert_array_equal(sleeve_streams["value_manager"], draws["portfolio:trend_value"])
+    np.testing.assert_array_equal(
+        sleeve_streams["prefixed_stream_manager"], draws["stream:trend_core"]
+    )
 
 
 def test_legacy_four_stream_api_remains_compatible() -> None:

--- a/tests/test_n_manager_streams_1908.py
+++ b/tests/test_n_manager_streams_1908.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pa_core.sim import (
+    build_cov_matrix,
+    build_generic_cov_matrix,
+    draw_named_returns,
+    map_sleeve_alpha_streams,
+    simulate_alpha_streams,
+)
+
+
+def test_generic_covariance_supports_manager_universe_shape() -> None:
+    stream_names = ("idx", "H", "E", "M", "trend_growth", "trend_value")
+    sigmas = {
+        "idx": 0.035,
+        "H": 0.010,
+        "E": 0.018,
+        "M": 0.020,
+        "trend_growth": 0.025,
+        "trend_value": 0.022,
+    }
+    correlations = {
+        (left, right): 0.05
+        for i, left in enumerate(stream_names)
+        for right in stream_names[i + 1 :]
+    }
+    correlations[("trend_growth", "trend_value")] = 0.35
+
+    cov = build_generic_cov_matrix(stream_names, sigmas, correlations)
+
+    assert cov.shape == (6, 6)
+    np.testing.assert_allclose(cov, cov.T)
+    assert np.linalg.eigvalsh(cov).min() >= -1e-12
+    assert cov[4, 5] == pytest.approx(sigmas["trend_growth"] * sigmas["trend_value"] * 0.35)
+
+
+def test_named_return_draws_map_sleeves_to_alpha_sources() -> None:
+    stream_names = ("idx", "H", "E", "M", "portfolio:trend_growth", "portfolio:trend_value")
+    correlations = {
+        (left, right): 0.0 for i, left in enumerate(stream_names) for right in stream_names[i + 1 :]
+    }
+    cov = build_generic_cov_matrix(
+        stream_names,
+        {
+            "idx": 0.01,
+            "H": 0.02,
+            "E": 0.03,
+            "M": 0.04,
+            "portfolio:trend_growth": 0.05,
+            "portfolio:trend_value": 0.06,
+        },
+        correlations,
+    )
+
+    draws = draw_named_returns(
+        n_months=3,
+        n_sim=4,
+        stream_names=stream_names,
+        means={name: idx * 0.001 for idx, name in enumerate(stream_names)},
+        cov=cov,
+        seed=1908,
+    )
+    sleeve_streams = map_sleeve_alpha_streams(
+        {
+            "growth_manager": "portfolio:trend_growth",
+            "value_manager": "trend_value",
+        },
+        draws,
+    )
+
+    assert set(draws) == set(stream_names)
+    assert draws["portfolio:trend_growth"].shape == (4, 3)
+    np.testing.assert_array_equal(sleeve_streams["growth_manager"], draws["portfolio:trend_growth"])
+    np.testing.assert_array_equal(sleeve_streams["value_manager"], draws["portfolio:trend_value"])
+
+
+def test_legacy_four_stream_api_remains_compatible() -> None:
+    cov = build_cov_matrix(
+        0.05,
+        0.0,
+        0.0,
+        0.1,
+        0.1,
+        0.0,
+        0.03,
+        0.01,
+        0.02,
+        0.02,
+    )
+
+    draws = simulate_alpha_streams(
+        5,
+        cov,
+        0.001,
+        0.002,
+        0.003,
+        0.004,
+        seed=1908,
+    )
+
+    assert cov.shape == (4, 4)
+    assert draws.shape == (5, 4)


### PR DESCRIPTION
Closes #1908

## Summary
- add a generic covariance builder for index plus an arbitrary alpha-stream universe
- add named return draws and sleeve alpha-source mapping for manager/portfolio streams
- keep legacy H/E/M covariance and draw APIs covered by regression tests

## Validation
- python -m pytest tests/test_n_manager_streams_1908.py tests/test_simulations.py tests/test_covariance_psd.py tests/test_orchestrator_sweep_covariance.py -q
- python -m ruff check pa_core/sim/covariance.py pa_core/sim/paths.py pa_core/sim/__init__.py tests/test_n_manager_streams_1908.py
- python -m ruff format --check pa_core/sim/covariance.py pa_core/sim/paths.py pa_core/sim/__init__.py tests/test_n_manager_streams_1908.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Monte Carlo simulation to handle flexible N-stream universes with configurable, validated covariance construction (including optional shrinkage and automatic PSD repair when needed).
  * Added named return simulation that draws and returns results per stream name.
  * Added sleeve-to-alpha mapping to link configured sleeve identifiers to the correct underlying alpha streams.

* **Tests**
  * Added end-to-end coverage for generic covariance building, named return drawing, and sleeve-to-alpha mapping, plus compatibility checks for the legacy four-stream API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->