### PR TITLE
Document advisory and unwired model fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ in every generated board pack (see `pa_core/reporting/disclaimers.py`):
 - The model is forward-looking and has not been backtested.
 - `risk_metrics` is advisory: it selects which metrics are reported, not how the simulation runs.
 - `Scenario.sleeves` is currently unwired and does not affect simulation results.
+- Legacy beta-sleeve financing costs are floored at zero; only `internal_pa_financing_*` supports negative financing as positive carry.
+- `analysis_mode='single_with_sensitivity'` is for single-run CLI sensitivity, not parameter sweeps; use `--sensitivity` with a single scenario instead of routing it through the sweep engine.
 
 ## Optional LLM Features
 

--- a/docs/guides/PARAMETER_GUIDE.md
+++ b/docs/guides/PARAMETER_GUIDE.md
@@ -245,6 +245,27 @@ capital share — the same contribution machinery used by every other sleeve —
 the cost is charged against the modeled InternalPA capital, not the
 institution's whole capital.
 
+**Beta-sleeve financing floor:** legacy financing costs for the Base,
+InternalBeta, ExternalPA, and ActiveExt beta legs are floored at zero, so a
+negative value does not model positive carry for those sleeves. Use the
+`internal_pa_financing_*` fields above when you need negative financing to raise
+the InternalPA sleeve return.
+
+### Advisory and unwired inputs
+
+Several schema fields are accepted for compatibility or reporting control but
+do not change the simulation engine:
+
+- `risk_metrics` controls which metrics are reported or displayed. It does not
+  alter return generation, sleeve construction, or portfolio aggregation.
+- `Scenario.sleeves` is validated by the scenario schema, including the capital
+  share sum check, but engine runs still read sleeve allocations from
+  `ModelConfig` fields and `agents`.
+- `analysis_mode: single_with_sensitivity` is a single-run CLI/orchestrator
+  mode. The parameter sweep engine supports `returns`, `capital`,
+  `alpha_shares`, and `vol_mult`; use `pa run --sensitivity` with a single
+  scenario rather than routing `single_with_sensitivity` through sweep configs.
+
 ## Quick Start Configuration for First-Time Users
 
 For your first run, consider these conservative assumptions:

--- a/pa_core/reporting/disclaimers.py
+++ b/pa_core/reporting/disclaimers.py
@@ -22,8 +22,12 @@ MODEL_LIMITATIONS: tuple[str, ...] = (
     "The model is forward-looking and has not been backtested.",
     "`risk_metrics` is advisory: it selects which metrics are reported, "
     "not how the simulation runs.",
-    "`Scenario.sleeves` is currently unwired and does not affect simulation "
-    "results.",
+    "`Scenario.sleeves` is currently unwired and does not affect simulation results.",
+    "Legacy beta-sleeve financing costs are floored at zero; only "
+    "`internal_pa_financing_*` supports negative financing as positive carry.",
+    "`analysis_mode='single_with_sensitivity'` is for single-run CLI "
+    "sensitivity, not parameter sweeps; use `--sensitivity` with a single "
+    "scenario instead of routing it through the sweep engine.",
 )
 
 

--- a/tests/test_model_limitations_1923.py
+++ b/tests/test_model_limitations_1923.py
@@ -32,6 +32,10 @@ def test_limitations_cover_required_caveats():
         "not been backtested",
         "risk_metrics",
         "scenario.sleeves",
+        "floored at zero",
+        "positive carry",
+        "single_with_sensitivity",
+        "sweep engine",
     ):
         assert phrase in blob, f"missing caveat: {phrase}"
 
@@ -48,6 +52,19 @@ def test_readme_documents_limitations():
     next_section = readme.index("\n## ", section_start + 1)
     section = readme[section_start:next_section]
     assert limitations_markdown() in section
+
+
+def test_parameter_guide_documents_advisory_and_unwired_fields():
+    guide = (_REPO_ROOT / "docs/guides/PARAMETER_GUIDE.md").read_text()
+    for phrase in (
+        "`risk_metrics` controls which metrics are reported",
+        "`Scenario.sleeves` is validated by the scenario schema",
+        "legacy financing costs",
+        "floored at zero",
+        "`analysis_mode: single_with_sensitivity`",
+        "parameter sweep engine supports `returns`, `capital`,",
+    ):
+        assert phrase in guide
 
 
 def test_board_pack_includes_limitations_slide():


### PR DESCRIPTION
Closes #1916

## Summary
- extend shared model limitations with beta-financing floor and single-run sensitivity caveats
- mirror the caveats in README and the practitioner parameter guide
- add regression coverage for the advisory/unwired field documentation

## Validation
- python -m pytest tests/test_model_limitations_1923.py -q
- python -m ruff check pa_core/reporting/disclaimers.py tests/test_model_limitations_1923.py
- python -m ruff format --check pa_core/reporting/disclaimers.py tests/test_model_limitations_1923.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that legacy beta-sleeve financing costs are floored at zero; use `internal_pa_financing_*` fields for negative financing support.
  * Clarified `analysis_mode='single_with_sensitivity'` is for single-run CLI sensitivity analysis, not parameter sweeps.
  * Documented advisory fields that affect reporting and validation but do not change simulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->