### PR TITLE
Strengthen reproducibility: hash config + warn on missing seed

### DIFF
--- a/docs/contracts/run-record.md
+++ b/docs/contracts/run-record.md
@@ -48,3 +48,16 @@ captures from two channels:
 onto `manifest.json` / `run_end.json` as additive optional keys. They are absent
 from `MANIFEST_REQUIRED_FIELDS`, so `validate_manifest_payload` remains backward
 compatible with legacy manifests that predate these fields.
+
+## Reproducibility
+
+`manifest.json` ties every board number to a versioned config + seed + data
+hash:
+
+- `config_hash` (additive optional field) is the SHA-256 of the config file
+  bytes, recorded alongside the per-file `data_files` hashes so the exact config
+  that produced a run can be verified even if the file is later edited.
+- A run without an explicit `--seed` (`seed=None`) uses a non-deterministic RNG
+  and cannot be reproduced. `ManifestWriter.write` emits
+  `SEED_REPRODUCIBILITY_WARNING` via the `warnings.warn(...)` channel, so the
+  warning is also captured into the run-record `warnings` list above.

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -184,13 +184,13 @@ class _WarningCollector:
         return [dict(rec) for rec in self.records]
 
 
-def _read_config_snapshot(path: str | Path) -> tuple[str, bytes]:
+def _read_config_snapshot(path: str | Path) -> tuple[str | None, bytes | None]:
     try:
         raw = Path(path).read_bytes()
         return raw.decode(), raw
     except (FileNotFoundError, OSError, PermissionError, UnicodeDecodeError):
         logger.debug("Unable to read config snapshot from %s", path)
-        return "", b""
+        return None, None
 
 
 def _hash_index_series(index_series: "pd.Series") -> str:
@@ -843,7 +843,11 @@ def main(
 
             outputs = _build_outputs_map(_collect_artifacts())
             artifact = RunArtifact(
-                config=config_snapshot,
+                config=(
+                    config_snapshot
+                    if config_snapshot is not None
+                    else Path(args.config).read_text()
+                ),
                 index_hash=index_hash,
                 seed=args.seed,
                 manifest=manifest_data,

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -1251,6 +1251,7 @@ def main(
             data_files.append(args.output)
         mw.write(
             config_path=args.config,
+            config_snapshot=config_snapshot,
             data_files=data_files,
             seed=args.seed,
             substream_ids=substream_ids,
@@ -1726,6 +1727,7 @@ def main(
             data_files.append(str(out_path))
         mw.write(
             config_path=args.config,
+            config_snapshot=config_snapshot,
             data_files=data_files,
             seed=args.seed,
             substream_ids=substream_ids,

--- a/pa_core/cli.py
+++ b/pa_core/cli.py
@@ -184,12 +184,13 @@ class _WarningCollector:
         return [dict(rec) for rec in self.records]
 
 
-def _read_config_snapshot(path: str | Path) -> str:
+def _read_config_snapshot(path: str | Path) -> tuple[str, bytes]:
     try:
-        return Path(path).read_text()
-    except (FileNotFoundError, OSError, PermissionError):
+        raw = Path(path).read_bytes()
+        return raw.decode(), raw
+    except (FileNotFoundError, OSError, PermissionError, UnicodeDecodeError):
         logger.debug("Unable to read config snapshot from %s", path)
-        return ""
+        return "", b""
 
 
 def _hash_index_series(index_series: "pd.Series") -> str:
@@ -690,7 +691,7 @@ def main(
     run_id: str | None = None
     artifact_candidates: list[Path] = []
     manifest_path: Path | None = None
-    config_snapshot = _read_config_snapshot(args.config)
+    config_snapshot, config_snapshot_bytes = _read_config_snapshot(args.config)
 
     def _record_artifact(path: str | Path | None) -> None:
         if not path:
@@ -1252,6 +1253,7 @@ def main(
         mw.write(
             config_path=args.config,
             config_snapshot=config_snapshot,
+            config_snapshot_bytes=config_snapshot_bytes,
             data_files=data_files,
             seed=args.seed,
             substream_ids=substream_ids,
@@ -1728,6 +1730,7 @@ def main(
         mw.write(
             config_path=args.config,
             config_snapshot=config_snapshot,
+            config_snapshot_bytes=config_snapshot_bytes,
             data_files=data_files,
             seed=args.seed,
             substream_ids=substream_ids,

--- a/pa_core/contracts.py
+++ b/pa_core/contracts.py
@@ -46,6 +46,7 @@ MANIFEST_REQUIRED_FIELDS: Sequence[str] = (
     "cli_args",
 )
 MANIFEST_OPTIONAL_FIELDS: Sequence[str] = (
+    "config_hash",
     "backend",
     "run_log",
     "previous_run",
@@ -161,6 +162,7 @@ class ManifestPayload(TypedDict, total=False):
     config: Mapping[str, Any]
     data_files: Mapping[str, str]
     cli_args: Mapping[str, Any]
+    config_hash: str | None
     backend: str | None
     run_log: str | None
     previous_run: str | None

--- a/pa_core/manifest.py
+++ b/pa_core/manifest.py
@@ -51,10 +51,15 @@ class ManifestWriter:
             h.update(fh.read())
         return h.hexdigest()
 
+    @staticmethod
+    def _hash_text(text: str) -> str:
+        return hashlib.sha256(text.encode()).hexdigest()
+
     def write(
         self,
         *,
         config_path: str | Path,
+        config_snapshot: str | None = None,
         data_files: Sequence[str | Path],
         seed: int | None,
         substream_ids: Mapping[str, str] | None = None,
@@ -81,12 +86,15 @@ class ManifestWriter:
             ).strip()
         except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             commit = "unknown"
-        cfg = yaml.safe_load(Path(config_path).read_text())
-        config_hash = self._hash_file(config_path) if Path(config_path).exists() else None
+        cfg_text = config_snapshot if config_snapshot is not None else Path(config_path).read_text()
+        cfg = yaml.safe_load(cfg_text)
+        config_hash = self._hash_text(cfg_text)
         hashes = {str(Path(p)): self._hash_file(p) for p in data_files if Path(p).exists()}
         timing = dict(run_timing) if run_timing else None
         if seed is None:
-            _warnings.warn(SEED_REPRODUCIBILITY_WARNING, stacklevel=2)
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("always", UserWarning)
+                _warnings.warn(SEED_REPRODUCIBILITY_WARNING, UserWarning, stacklevel=2)
         manifest = Manifest(
             git_commit=commit,
             timestamp=datetime.now(timezone.utc).isoformat(),

--- a/pa_core/manifest.py
+++ b/pa_core/manifest.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+import warnings as _warnings
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 import yaml
+
+#: Emitted (and recorded in the manifest) when a run has no explicit seed.
+SEED_REPRODUCIBILITY_WARNING = (
+    "Run executed without an explicit --seed (seed=None): results use a "
+    "non-deterministic RNG and cannot be reproduced. Pass --seed to make the "
+    "run reproducible."
+)
 
 
 @dataclass
@@ -20,6 +28,7 @@ class Manifest:
     config: Mapping[str, Any]
     data_files: Mapping[str, str]
     cli_args: Mapping[str, Any]
+    config_hash: str | None = None
     backend: str | None = None
     run_log: str | None = None
     previous_run: str | None = None
@@ -73,8 +82,11 @@ class ManifestWriter:
         except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             commit = "unknown"
         cfg = yaml.safe_load(Path(config_path).read_text())
+        config_hash = self._hash_file(config_path) if Path(config_path).exists() else None
         hashes = {str(Path(p)): self._hash_file(p) for p in data_files if Path(p).exists()}
         timing = dict(run_timing) if run_timing else None
+        if seed is None:
+            _warnings.warn(SEED_REPRODUCIBILITY_WARNING, stacklevel=2)
         manifest = Manifest(
             git_commit=commit,
             timestamp=datetime.now(timezone.utc).isoformat(),
@@ -83,6 +95,7 @@ class ManifestWriter:
             config=cfg,
             data_files=hashes,
             cli_args=dict(cli_args),
+            config_hash=config_hash,
             backend=backend,
             run_log=str(run_log) if run_log else None,
             previous_run=str(previous_run) if previous_run else None,

--- a/pa_core/manifest.py
+++ b/pa_core/manifest.py
@@ -52,14 +52,15 @@ class ManifestWriter:
         return h.hexdigest()
 
     @staticmethod
-    def _hash_text(text: str) -> str:
-        return hashlib.sha256(text.encode()).hexdigest()
+    def _hash_bytes(data: bytes) -> str:
+        return hashlib.sha256(data).hexdigest()
 
     def write(
         self,
         *,
         config_path: str | Path,
         config_snapshot: str | None = None,
+        config_snapshot_bytes: bytes | None = None,
         data_files: Sequence[str | Path],
         seed: int | None,
         substream_ids: Mapping[str, str] | None = None,
@@ -86,9 +87,18 @@ class ManifestWriter:
             ).strip()
         except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             commit = "unknown"
-        cfg_text = config_snapshot if config_snapshot is not None else Path(config_path).read_text()
+        if config_snapshot is not None:
+            cfg_text = config_snapshot
+            cfg_bytes = (
+                config_snapshot_bytes
+                if config_snapshot_bytes is not None
+                else config_snapshot.encode()
+            )
+        else:
+            cfg_bytes = Path(config_path).read_bytes()
+            cfg_text = cfg_bytes.decode()
         cfg = yaml.safe_load(cfg_text)
-        config_hash = self._hash_text(cfg_text)
+        config_hash = self._hash_bytes(cfg_bytes)
         hashes = {str(Path(p)): self._hash_file(p) for p in data_files if Path(p).exists()}
         timing = dict(run_timing) if run_timing else None
         if seed is None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -169,6 +169,32 @@ def test_manifest_hashes_startup_config_snapshot(tmp_path):
     assert manifest["config_hash"] == hashlib.sha256(config_snapshot.encode()).hexdigest()
 
 
+def test_manifest_hashes_startup_config_snapshot_bytes(tmp_path):
+    import hashlib
+
+    from pa_core.manifest import ManifestWriter
+
+    cfg_path = tmp_path / "cfg.yaml"
+    config_snapshot_bytes = b"N_SIMULATIONS: 1\r\nN_MONTHS: 1\r\n"
+    cfg_path.write_bytes(config_snapshot_bytes)
+    config_snapshot = config_snapshot_bytes.decode()
+    cfg_path.write_text(yaml.safe_dump({"N_SIMULATIONS": 999, "N_MONTHS": 1}))
+
+    out = tmp_path / "manifest.json"
+    ManifestWriter(out).write(
+        config_path=cfg_path,
+        config_snapshot=config_snapshot,
+        config_snapshot_bytes=config_snapshot_bytes,
+        data_files=[],
+        seed=123,
+        cli_args={"config": str(cfg_path)},
+    )
+
+    manifest = json.loads(out.read_text())
+    assert manifest["config"]["N_SIMULATIONS"] == 1
+    assert manifest["config_hash"] == hashlib.sha256(config_snapshot_bytes).hexdigest()
+
+
 def test_manifest_warns_without_seed(tmp_path, recwarn):
     from pa_core.manifest import SEED_REPRODUCIBILITY_WARNING
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -209,8 +209,7 @@ def test_config_snapshot_read_failure_uses_manifest_file_fallback(tmp_path):
     assert config_snapshot is None
     assert config_snapshot_bytes is None
 
-    cfg_text = yaml.safe_dump({"N_SIMULATIONS": 2, "N_MONTHS": 1})
-    cfg_path.write_text(cfg_text)
+    cfg_path.write_text(yaml.safe_dump({"N_SIMULATIONS": 2, "N_MONTHS": 1}))
     out = tmp_path / "manifest.json"
 
     ManifestWriter(out).write(
@@ -224,7 +223,7 @@ def test_config_snapshot_read_failure_uses_manifest_file_fallback(tmp_path):
 
     manifest = json.loads(out.read_text())
     assert manifest["config"]["N_SIMULATIONS"] == 2
-    assert manifest["config_hash"] == hashlib.sha256(cfg_text.encode()).hexdigest()
+    assert manifest["config_hash"] == hashlib.sha256(cfg_path.read_bytes()).hexdigest()
 
 
 def test_manifest_warns_without_seed(tmp_path, recwarn):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -68,11 +68,7 @@ def test_manifest_records_index_data_quality(tmp_path):
     cfg_path.write_text(yaml.safe_dump(cfg))
     idx_csv = tmp_path / "index.csv"
     idx_csv.write_text(
-        "Date,Monthly_TR\n"
-        "2020-01-31,0.01\n"
-        "2020-02-29,0.02\n"
-        "2020-03-31,0.03\n"
-        "2020-04-30,#DIV/0!\n"
+        "Date,Monthly_TR\n2020-01-31,0.01\n2020-02-29,0.02\n2020-03-31,0.03\n2020-04-30,#DIV/0!\n"
     )
     out_file = tmp_path / "out.xlsx"
 
@@ -120,6 +116,59 @@ def test_manifest_records_run_log(tmp_path, monkeypatch):
     if not run_log.is_absolute():
         run_log = tmp_path / run_log
     assert run_log.exists()
+
+
+def test_manifest_records_config_hash(tmp_path):
+    import hashlib
+
+    cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    idx_csv = Path(__file__).resolve().parents[1] / "data" / "sp500tr_fred_divyield.csv"
+    out_file = tmp_path / "out.xlsx"
+
+    main(
+        [
+            "--config",
+            str(cfg_path),
+            "--index",
+            str(idx_csv),
+            "--output",
+            str(out_file),
+            "--seed",
+            "123",
+        ]
+    )
+
+    manifest = json.loads(out_file.with_name("manifest.json").read_text())
+    expected = hashlib.sha256(cfg_path.read_bytes()).hexdigest()
+    assert manifest["config_hash"] == expected
+
+
+def test_manifest_warns_without_seed(tmp_path, recwarn):
+    from pa_core.manifest import SEED_REPRODUCIBILITY_WARNING
+
+    cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    idx_csv = Path(__file__).resolve().parents[1] / "data" / "sp500tr_fred_divyield.csv"
+    out_file = tmp_path / "out.xlsx"
+
+    main(
+        [
+            "--config",
+            str(cfg_path),
+            "--index",
+            str(idx_csv),
+            "--output",
+            str(out_file),
+        ]
+    )
+
+    messages = [str(w.message) for w in recwarn.list]
+    assert any(SEED_REPRODUCIBILITY_WARNING in m for m in messages)
+    manifest = json.loads(out_file.with_name("manifest.json").read_text())
+    assert manifest["seed"] is None
 
 
 def test_manifest_records_previous_run(tmp_path):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -195,6 +195,38 @@ def test_manifest_hashes_startup_config_snapshot_bytes(tmp_path):
     assert manifest["config_hash"] == hashlib.sha256(config_snapshot_bytes).hexdigest()
 
 
+def test_config_snapshot_read_failure_uses_manifest_file_fallback(tmp_path):
+    import hashlib
+
+    from pa_core.cli import _read_config_snapshot
+    from pa_core.manifest import ManifestWriter
+
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_bytes(b"\xff\xfe")
+
+    config_snapshot, config_snapshot_bytes = _read_config_snapshot(cfg_path)
+
+    assert config_snapshot is None
+    assert config_snapshot_bytes is None
+
+    cfg_text = yaml.safe_dump({"N_SIMULATIONS": 2, "N_MONTHS": 1})
+    cfg_path.write_text(cfg_text)
+    out = tmp_path / "manifest.json"
+
+    ManifestWriter(out).write(
+        config_path=cfg_path,
+        config_snapshot=config_snapshot,
+        config_snapshot_bytes=config_snapshot_bytes,
+        data_files=[],
+        seed=123,
+        cli_args={"config": str(cfg_path)},
+    )
+
+    manifest = json.loads(out.read_text())
+    assert manifest["config"]["N_SIMULATIONS"] == 2
+    assert manifest["config_hash"] == hashlib.sha256(cfg_text.encode()).hexdigest()
+
+
 def test_manifest_warns_without_seed(tmp_path, recwarn):
     from pa_core.manifest import SEED_REPRODUCIBILITY_WARNING
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -145,6 +145,30 @@ def test_manifest_records_config_hash(tmp_path):
     assert manifest["config_hash"] == expected
 
 
+def test_manifest_hashes_startup_config_snapshot(tmp_path):
+    import hashlib
+
+    from pa_core.manifest import ManifestWriter
+
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump({"N_SIMULATIONS": 1, "N_MONTHS": 1}))
+    config_snapshot = cfg_path.read_text()
+    cfg_path.write_text(yaml.safe_dump({"N_SIMULATIONS": 999, "N_MONTHS": 1}))
+
+    out = tmp_path / "manifest.json"
+    ManifestWriter(out).write(
+        config_path=cfg_path,
+        config_snapshot=config_snapshot,
+        data_files=[],
+        seed=123,
+        cli_args={"config": str(cfg_path)},
+    )
+
+    manifest = json.loads(out.read_text())
+    assert manifest["config"]["N_SIMULATIONS"] == 1
+    assert manifest["config_hash"] == hashlib.sha256(config_snapshot.encode()).hexdigest()
+
+
 def test_manifest_warns_without_seed(tmp_path, recwarn):
     from pa_core.manifest import SEED_REPRODUCIBILITY_WARNING
 
@@ -169,6 +193,36 @@ def test_manifest_warns_without_seed(tmp_path, recwarn):
     assert any(SEED_REPRODUCIBILITY_WARNING in m for m in messages)
     manifest = json.loads(out_file.with_name("manifest.json").read_text())
     assert manifest["seed"] is None
+
+
+def test_manifest_records_seed_warning_on_repeated_seedless_runs(tmp_path):
+    from pa_core.contracts import RUN_RECORD_FILENAME
+    from pa_core.manifest import SEED_REPRODUCIBILITY_WARNING
+
+    cfg = {"N_SIMULATIONS": 1, "N_MONTHS": 1, "financing_mode": "broadcast"}
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    idx_csv = Path(__file__).resolve().parents[1] / "data" / "sp500tr_fred_divyield.csv"
+    out_one = tmp_path / "run_one" / "out.xlsx"
+    out_two = tmp_path / "run_two" / "out.xlsx"
+    out_one.parent.mkdir()
+    out_two.parent.mkdir()
+
+    for out_file in (out_one, out_two):
+        main(
+            [
+                "--config",
+                str(cfg_path),
+                "--index",
+                str(idx_csv),
+                "--output",
+                str(out_file),
+            ]
+        )
+
+    run_record = json.loads(out_two.with_name(RUN_RECORD_FILENAME).read_text())
+    messages = [str(w.get("message", "")) for w in run_record["warnings"]]
+    assert any(SEED_REPRODUCIBILITY_WARNING in message for message in messages)
 
 
 def test_manifest_records_previous_run(tmp_path):


### PR DESCRIPTION
Closes #1925

## Summary
Strengthen run reproducibility by tying every board number to a versioned config + seed + data hash.

- **`config_hash` in `manifest.json`** — SHA-256 of the config file bytes, recorded alongside the per-file `data_files` hashes. Lets the exact config that produced a run be verified even if the file is later edited.
- **Seedless-run warning** — a run without an explicit `--seed` (`seed=None`) uses a non-deterministic RNG and cannot be reproduced. `ManifestWriter.write` now emits `SEED_REPRODUCIBILITY_WARNING` via the `warnings.warn(...)` channel, so it is also captured into the run-record `warnings` list.

## Changes
- `pa_core/manifest.py`: compute `config_hash`; add `Manifest.config_hash`; emit the seedless warning.
- `pa_core/contracts.py`: add `config_hash` to `MANIFEST_OPTIONAL_FIELDS` and `ManifestPayload` (additive — `validate_manifest_payload` stays backward-compatible with legacy manifests).
- `tests/test_manifest.py`: focused tests for `config_hash` and the seedless warning.
- `docs/contracts/run-record.md`: document the reproducibility fields.

## Validation
- `pytest tests/test_manifest.py` → 6 passed (4 existing + 2 new).
- `pytest tests/test_contracts.py tests/test_run_record_warnings.py tests/test_logging_and_manifest.py` → 14 passed.
- `ruff check` / `ruff format --check` clean on changed files.
- Deliberate-break check: neutering `config_hash`/the warning fails both new tests; restoring passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded run-record guidance with a new “Reproducibility” section explaining how `manifest.json` records exact configuration details and seed-related behavior.

* **New Features**
  * `manifest.json` now includes `config_hash` (SHA-256) derived from the exact configuration content used.
  * Run artifacts can include a configuration snapshot (text and/or raw bytes).
  * Runs without an explicit seed now emit a reproducibility warning and record it in the run record.

* **Tests**
  * Added coverage to verify `config_hash` generation across config sources and to ensure seedless warning behavior is emitted and persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->