### PR TITLE
Follow-up for #1925: clear schema Black format debt

### DIFF
--- a/pa_core/schema.py
+++ b/pa_core/schema.py
@@ -157,9 +157,7 @@ class Scenario(BaseModel):
     # 'Model Limitations & Caveats'.
     sleeves: Dict[str, Sleeve] | None = Field(
         default=None,
-        description=(
-            "Currently unwired: validated but does not affect simulation results."
-        ),
+        description=("Currently unwired: validated but does not affect simulation results."),
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary

- Fixes the post-merge verifier concern from PR #1971 by applying Black formatting to `pa_core/schema.py`.
- This is a bounded follow-up for source issue #1925 after the verifier capped #1971 at CONCERNS because the merge-commit CI `lint-format` job failed.

## Evidence

- #1971 merged at `a6a374fb1a1c2b6639fa1a3de3a58f0e4f3deab5` with `verify:compare`.
- Agents Verifier report on #1971 returned CONCERNS because merge-commit CI failed.
- CI job `Python CI / lint-format` in run `27577355824` failed only because `black --check --line-length 100 --exclude '(\\.venv|\\.workflows-lib|node_modules)' .` would reformat `pa_core/schema.py`.\n\n## Validation\n\n- `python -m black --check --line-length 100 --exclude '(\\.venv|\\.workflows-lib|node_modules)' .` -> passed\n- `python -m ruff check pa_core/schema.py` -> passed\n- `python -m ruff format --check pa_core/schema.py` -> passed\n- `python -m mypy --config-file pyproject.toml --exclude .workflows-lib pa_core/schema.py` -> passed\n\nRefs #1925\nFollow-up for #1971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code formatting updates to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->