### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.14
+RUFF_VERSION=0.15.17
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0
-PYTEST_VERSION=9.0.3
+PYTEST_VERSION=9.1.0
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.14.0
+COVERAGE_VERSION=7.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,11 +142,11 @@ llm = [
 
 # Development dependencies
 dev = [
-    "ruff>=0.15.14",
+    "ruff==0.15.17",
     "black>=26.5.1",
     "isort>=8.0.1",
     "mypy>=2.1.0",
-    "pytest==9.0.3",
+    "pytest==9.1.0",
     "pytest-cov==7.1.0",
     "pytest-xdist>=3.8.0",
     # Shared app behavior baseline harness (pulls pytest-regressions). Tracked
@@ -156,7 +156,7 @@ dev = [
     # no-emit-package below so a frozen SHA in the lock cannot conflict with the
     # unpinned URL.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
-    "coverage>=7.14.0",
+    "coverage==7.14.1",
     "hypothesis>=6.115.1",
     "pre-commit",
     "bandit",

--- a/requirements.lock
+++ b/requirements.lock
@@ -92,7 +92,7 @@ comm==0.2.3
     # via
     #   ipykernel
     #   ipywidgets
-coverage==7.14.0
+coverage==7.14.1
     # via
     #   portable-alpha-extension-model (pyproject.toml)
     #   pytest-cov
@@ -560,7 +560,7 @@ pypdf==6.13.2
     # via portable-alpha-extension-model (pyproject.toml)
 pyproject-hooks==1.2.0
     # via build
-pytest==9.0.3
+pytest==9.1.0
     # via
     #   portable-alpha-extension-model (pyproject.toml)
     #   app-baseline-kit
@@ -669,7 +669,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.14
+ruff==0.15.17
     # via portable-alpha-extension-model (pyproject.toml)
 secretstorage==3.5.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via keyring


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 6 version updates:
  - ruff: >=0.15.14 -> ==0.15.17
  - pytest: ==9.0.3 -> ==9.1.0
  - coverage: >=7.14.0 -> ==7.14.1
  - requirements.lock:coverage: 7.14.0 -> ==7.14.1
  - requirements.lock:pytest: 9.0.3 -> ==9.1.0
  - requirements.lock:ruff: 0.15.14 -> ==0.15.17

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`