### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/runtime_ac_merge_guard.js
+++ b/.github/scripts/runtime_ac_merge_guard.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const RUNTIME_AC_REQUIRED_LABELS = new Set([
+  'runtime-ac',
+  'runtime-verification',
+  'acceptance-criteria',
+  'verification-spec',
+  'verification-plan',
+  'ac-checks',
+  'runtime-checks',
+]);
+
+function labelName(label) {
+  if (typeof label === 'string') {
+    return label;
+  }
+  if (label && typeof label.name === 'string') {
+    return label.name;
+  }
+  return '';
+}
+
+function normalizeLabelName(label) {
+  return labelName(label).trim().toLowerCase();
+}
+
+function runtimeAcRequirement(labels = []) {
+  const matched = [];
+  const seen = new Set();
+
+  for (const label of labels || []) {
+    const normalized = normalizeLabelName(label);
+    if (!normalized) {
+      continue;
+    }
+    const colonIndex = normalized.indexOf(':');
+    const suffix =
+      colonIndex >= 0 && colonIndex < normalized.length - 1
+        ? normalized.slice(colonIndex + 1).trim()
+        : '';
+    if (
+      RUNTIME_AC_REQUIRED_LABELS.has(normalized) ||
+      (suffix && RUNTIME_AC_REQUIRED_LABELS.has(suffix))
+    ) {
+      if (!seen.has(normalized)) {
+        matched.push(normalized);
+        seen.add(normalized);
+      }
+    }
+  }
+
+  return {
+    required: matched.length > 0,
+    labels: matched,
+  };
+}
+
+function hasRuntimeAcRequirement(labels = []) {
+  return runtimeAcRequirement(labels).required;
+}
+
+// Workflow callers should pass the withRetry function produced by createTokenAwareRetry.
+async function fetchPullRequestLabels({ github, owner, repo, prNumber, withRetry }) {
+  if (!github || !github.rest || !github.rest.issues) {
+    throw new Error('GitHub client is required to evaluate runtime AC merge labels.');
+  }
+  const call = (client = github) =>
+    client.rest.issues.listLabelsOnIssue({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+
+  try {
+    const response = withRetry ? await withRetry(call) : await call();
+    return Array.isArray(response && response.data) ? response.data : [];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to evaluate runtime AC merge labels for PR #${prNumber}: ${message}`,
+    );
+  }
+}
+
+async function assertRuntimeAcMergeAllowed({
+  github,
+  core,
+  owner,
+  repo,
+  prNumber,
+  labels,
+  withRetry,
+  source = 'external merge lane',
+} = {}) {
+  if (!owner || !repo || !prNumber) {
+    throw new Error('owner, repo, and prNumber are required for runtime AC merge guard.');
+  }
+
+  const labelItems = Array.isArray(labels)
+    ? labels
+    : await fetchPullRequestLabels({ github, owner, repo, prNumber, withRetry });
+  const requirement = runtimeAcRequirement(labelItems);
+
+  if (!requirement.required) {
+    if (core && typeof core.info === 'function') {
+      core.info(`Runtime AC merge guard passed for PR #${prNumber}.`);
+    }
+    return {
+      allowed: true,
+      labels: [],
+    };
+  }
+
+  const labelList = requirement.labels.join(', ');
+  const message =
+    `Runtime AC merge guard blocked ${source} for PR #${prNumber}: ` +
+    `label(s) ${labelList} require local Orchestrator runtime acceptance checks. ` +
+    'Merge through Code/Orchestrator/merge_guard.py after the runtime AC spec passes.';
+
+  if (core && typeof core.warning === 'function') {
+    core.warning(message);
+  }
+
+  const error = new Error(message);
+  error.code = 'runtime_ac_merge_blocked';
+  error.labels = requirement.labels;
+  throw error;
+}
+
+module.exports = {
+  RUNTIME_AC_REQUIRED_LABELS,
+  assertRuntimeAcMergeAllowed,
+  hasRuntimeAcRequirement,
+  normalizeLabelName,
+  runtimeAcRequirement,
+};

--- a/.github/workflows/agents-73-codex-belt-conveyor.yml
+++ b/.github/workflows/agents-73-codex-belt-conveyor.yml
@@ -192,6 +192,7 @@ jobs:
             .github/scripts/agent_registry.js
             .github/scripts/error_classifier.js
             .github/scripts/github-api-with-retry.js
+            .github/scripts/runtime_ac_merge_guard.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
 
@@ -440,6 +441,7 @@ jobs:
           script: |
             const fs = require('fs');
             const retryHelperPath = './.github/scripts/github-api-with-retry.js';
+            const { assertRuntimeAcMergeAllowed } = require('./.github/scripts/runtime_ac_merge_guard.js');
             const retryHelpers = fs.existsSync(retryHelperPath)
               ? require(retryHelperPath)
               : {
@@ -451,6 +453,15 @@ jobs:
             const prNumber = Number('${{ inputs.pr_number }}');
             const { owner, repo } = context.repo;
             try {
+              await assertRuntimeAcMergeAllowed({
+                github,
+                core,
+                owner,
+                repo,
+                prNumber,
+                withRetry,
+                source: 'agents-73-codex-belt-conveyor',
+              });
               await withRetry(() => github.rest.pulls.merge({ owner, repo, pull_number: prNumber, merge_method: 'squash' }));
               core.setOutput('merged', 'true');
             } catch (error) {

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -1552,6 +1552,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/scripts/github-api-with-retry.js
+            .github/scripts/runtime_ac_merge_guard.js
             .github/scripts/token_load_balancer.js
           sparse-checkout-cone-mode: false
       - name: Merge labelled agent PRs (guarded)
@@ -1563,6 +1564,7 @@ jobs:
             const fs = require('fs');
             const label = 'automerge';
             const retryPath = './.github/scripts/github-api-with-retry.js';
+            const { assertRuntimeAcMergeAllowed } = require('./.github/scripts/runtime_ac_merge_guard.js');
             const { createTokenAwareRetry } = fs.existsSync(retryPath)
               ? require(retryPath)
               : {
@@ -1731,6 +1733,15 @@ jobs:
                           note = 'Refusing auto-merge: linked issue/PR has unchecked tasks.';
                         } else {
                           try {
+                            await assertRuntimeAcMergeAllowed({
+                              github,
+                              core,
+                              owner,
+                              repo,
+                              prNumber,
+                              withRetry,
+                              source: 'agents-81-gate-followups guarded merge',
+                            });
                             const response = await withRetry((client) => client.rest.pulls.merge({ owner, repo, pull_number: prNumber, merge_method: 'squash' }));
                             if (response && response.data && response.data.merged) {
                               status = 'merged';

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -111,7 +111,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           steps.eligibility.outputs.should-run == 'true' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6deed4d3937adab2370b4ddf96046ed295efe68f" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@d68de1904bcdbe16bfe2462b73aa18f41f8a0a47" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -180,7 +180,7 @@ jobs:
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request' &&
           steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6deed4d3937adab2370b4ddf96046ed295efe68f" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@d68de1904bcdbe16bfe2462b73aa18f41f8a0a47" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -32,6 +32,7 @@ This document describes all labels that trigger automated workflows or affect CI
 | `security:bypass-guard` | Issue or PR labeled | Bypasses prompt-injection guard after explicit approval
 | `agents:allow-change` | PR labeled | Allows guarded automation changes that require explicit permission
 | `automerge` | PR labeled | Marks a completed agent PR for guarded automerge
+| `runtime-ac` / runtime verification labels | PR labeled | Blocks external auto-merge until local Orchestrator runtime AC checks pass
 | `status:in-progress` | Issue labeled | Marks an issue claimed by the belt dispatcher/worker
 | `from:<agent>` | PR labeled | Records the automation agent that produced the PR
 | `runner:<agent>` | Issue labeled | Selects an auto-pilot runner without triggering issue intake
@@ -620,6 +621,31 @@ These labels trigger the post-merge verifier workflow on a merged PR.
 
 **Consumers:** `.github/scripts/agents-guard.js`,
 `.github/workflows/maint-auto-label-dep-prs.yml`.
+
+---
+
+### Runtime AC merge labels
+
+**Labels:** `runtime-ac`, `runtime-verification`, `acceptance-criteria`,
+`verification-spec`, `verification-plan`, `ac-checks`, `runtime-checks`
+
+**Applies to:** Pull Requests
+
+**Trigger:** Runtime acceptance criteria or verification labels applied to a PR.
+Prefixed labels such as `verify:runtime-ac` are treated the same as
+`runtime-ac`.
+
+**Effect:**
+1. Blocks external merge lanes from merging the PR directly.
+2. Requires maintainers to merge through the local Orchestrator runtime AC guard
+   after the runtime acceptance spec passes.
+3. Fails closed if an external merge lane cannot read PR labels.
+
+**Consumers:** `.github/scripts/runtime_ac_merge_guard.js`,
+`.github/workflows/agents-73-codex-belt-conveyor.yml`,
+`.github/workflows/reusable-70-orchestrator-main.yml`,
+`.github/workflows/maint-71-merge-sync-prs.yml`,
+`templates/consumer-repo/.github/workflows/agents-81-gate-followups.yml`.
 
 ---
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-81-gate-followups.yml: Gate followups hub - consolidates keepalive and autofix followups
- agents-73-codex-belt-conveyor.yml: Codex belt conveyor - orchestrates belt worker execution and handles completion
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)
- runtime_ac_merge_guard.js: Blocks external merge lanes for PRs that require local Orchestrator runtime acceptance checks
- LABELS.md: Label definitions and usage

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `c2537cc959f2ce05926c4639d25b90678abc97bc`
**Template hash:** `3ce6094b89bb`
**Sync branch:** `sync/workflows-3ce6094b89bb`
**Consumer repo:** `stranske/Portable-Alpha-Extension-Model`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Portable-Alpha-Extension-Model","source_repository":"stranske/Workflows","source_sha":"c2537cc959f2ce05926c4639d25b90678abc97bc","template_hash":"3ce6094b89bb","sync_branch":"sync/workflows-3ce6094b89bb","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27840856176","run_attempt":"1","changes_count":5} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced runtime AC merge labels that enforce local Orchestrator runtime verification checks on external pull requests. These labels block automatic merge until all runtime checks pass successfully, ensuring code quality standards are consistently maintained before any external PR can merge.

* **Documentation**
  * Added comprehensive documentation for runtime AC merge labels, including details about merge enforcement behavior, label trigger mechanisms with prefix support, and integration with existing merge workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->