### PR TITLE
Codex bootstrap for #2016

### DIFF
--- a/agents/codex-2016.md
+++ b/agents/codex-2016.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #2016 -->

--- a/tests/test_llm_import_and_no_network.py
+++ b/tests/test_llm_import_and_no_network.py
@@ -9,12 +9,28 @@ import sys
 
 def test_import_pa_core_llm_no_network(socket_connect_guard):
     attempts, blocked = socket_connect_guard
+    original_llm_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "pa_core.llm" or name.startswith("pa_core.llm.")
+    }
 
-    for name in list(sys.modules):
-        if name == "pa_core.llm" or name.startswith("pa_core.llm."):
-            sys.modules.pop(name)
+    try:
+        for name in list(sys.modules):
+            if name == "pa_core.llm" or name.startswith("pa_core.llm."):
+                sys.modules.pop(name)
 
-    importlib.import_module("pa_core.llm")
+        importlib.import_module("pa_core.llm")
+    finally:
+        for name in list(sys.modules):
+            if name == "pa_core.llm" or name.startswith("pa_core.llm."):
+                sys.modules.pop(name)
+        sys.modules.update(original_llm_modules)
+        for name, module in original_llm_modules.items():
+            parent_name, _, child_name = name.rpartition(".")
+            parent = sys.modules.get(parent_name)
+            if parent is not None and child_name:
+                setattr(parent, child_name, module)
 
     assert socket.socket.connect is blocked
     assert attempts == []

--- a/tests/test_llm_import_and_no_network.py
+++ b/tests/test_llm_import_and_no_network.py
@@ -9,6 +9,9 @@ import sys
 
 def test_import_pa_core_llm_no_network(socket_connect_guard):
     attempts, blocked = socket_connect_guard
+    pa_core_pkg = sys.modules.get("pa_core")
+    had_pa_core_llm_attr = hasattr(pa_core_pkg, "llm") if pa_core_pkg is not None else False
+    original_pa_core_llm_attr = getattr(pa_core_pkg, "llm", None) if had_pa_core_llm_attr else None
     original_llm_modules = {
         name: module
         for name, module in sys.modules.items()
@@ -31,6 +34,12 @@ def test_import_pa_core_llm_no_network(socket_connect_guard):
             parent = sys.modules.get(parent_name)
             if parent is not None and child_name:
                 setattr(parent, child_name, module)
+        pa_core_pkg = sys.modules.get("pa_core")
+        if pa_core_pkg is not None and not original_llm_modules:
+            if had_pa_core_llm_attr:
+                setattr(pa_core_pkg, "llm", original_pa_core_llm_attr)
+            else:
+                pa_core_pkg.__dict__.pop("llm", None)
 
     assert socket.socket.connect is blocked
     assert attempts == []


### PR DESCRIPTION
detached-net: launchd wrapper failed; retrying in current shell with detached auth
### Keepalive: ON
<!-- meta:issue:2016 -->

### Source Issue #2016: Fix LLM config-patch test isolation after import-safety reimport

Base: main
Head: codex/issue-2016

Source: https://github.com/stranske/Portable-Alpha-Extension-Model/issues/2016

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Portable Alpha's LLM import-safety test can leave pytest with two loaded instances of `pa_core.llm.config_patch_chain` when it evicts `pa_core.llm*` from `sys.modules` and reimports the package. If `tests/test_llm_import_and_no_network.py` runs before `tests/test_llm_config_patch_chain.py`, pytest collection keeps `run_config_patch_chain` from the first module instance, while dotted-path monkeypatching updates the second module instance. The config-patch trace helper test then fails even though it passes in isolation.

Observed during the Orchestrator repo-review deeper review on 2026-06-22:

```text
uv run pytest tests/test_llm_import_and_no_network.py tests/test_llm_config_patch_chain.py -q
1 failed, 7 passed

FAILED tests/test_llm_config_patch_chain.py::test_run_config_patch_chain_skips_tracing_when_helpers_unavailable
AssertionError: assert 'https://smith.langchain.com/r/real-run-123' is None
```

This is a test-isolation regression around the LLM/config-chat surface, not evidence that the whole LLM/reference-pack workflow is missing.

#### Tasks
- [ ] Update `tests/test_llm_import_and_no_network.py` to restore the original `pa_core.llm*` module objects after the import-safety check, or update `tests/test_llm_config_patch_chain.py` to monkeypatch the module instance actually used by `run_config_patch_chain`.
- [ ] Add or preserve an order-regression check for the import-safety plus config-patch-chain sequence.
- [ ] Keep `socket_connect_guard` assertions intact so the import path remains network-free.

#### Acceptance Criteria
- [ ] `uv run pytest tests/test_llm_import_and_no_network.py tests/test_llm_config_patch_chain.py -q` passes.
- [ ] `uv run pytest tests/test_llm_provider_missing_keys.py tests/test_llm_import_and_no_network.py tests/test_llm_config_patch_chain.py -q` passes.
- [ ] `uv run pytest tests/test_dashboard_llm_settings.py tests/test_result_explain.py tests/test_llm_compare_runs.py tests/test_langsmith_fleet.py tests/test_llm_prompts.py tests/test_dashboard_explain_results.py tests/test_dashboard_comparison_llm.py tests/test_reference_packs.py -q` remains green.
- [ ] No default test path makes a real network call or requires live LLM credentials.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

Portable Alpha's LLM import-safety test can leave pytest with two loaded instances of `pa_core.llm.config_patch_chain` when it evicts `pa_core.llm*` from `sys.modules` and reimports the package. If `tests/test_llm_import_and_no_network.py` runs before `tests/test_llm_config_patch_chain.py`, pytest collection keeps `run_config_patch_chain` from the first module instance, while dotted-path monkeypatching updates the second module instance. The config-patch trace helper test then fails even though it passes in isolation.

Observed during the Orchestrator repo-review deeper review on 2026-06-22:

```text
uv run pytest tests/test_llm_import_and_no_network.py tests/test_llm_config_patch_chain.py -q
1 failed, 7 passed

FAILED tests/test_llm_config_patch_chain.py::test_run_config_patch_chain_skips_tracing_when_helpers_unavailable
AssertionError: assert 'https://smith.langchain.com/r/real-run-123' is None
```

This is a test-isolation regression around the LLM/config-chat surface, not evidence that the whole LLM/reference-pack workflow is missing.

## Scope

Make the LLM import/no-network and config-patch-chain tests robust when `pa_core.llm` modules are evicted and reimported. Preserve the existing behavior that LangSmith trace URLs are ignored when tracing helpers are unavailable.

## Non-Goals

Do not enable live provider calls in default tests. Do not remove the import-safety/no-network coverage. Do not change production provider defaults unless the test isolation fix proves a production import-path bug.

## Tasks

- [ ] Update `tests/test_llm_import_and_no_network.py` to restore the original `pa_core.llm*` module objects after the import-safety check, or update `tests/test_llm_config_patch_chain.py` to monkeypatch the module instance actually used by `run_config_patch_chain`.
- [ ] Add or preserve an order-regression check for the import-safety plus config-patch-chain sequence.
- [ ] Keep `socket_connect_guard` assertions intact so the import path remains network-free.

## Acceptance Criteria

- [ ] `uv run pytest tests/test_llm_import_and_no_network.py tests/test_llm_config_patch_chain.py -q` passes.
- [ ] `uv run pytest tests/test_llm_provider_missing_keys.py tests/test_llm_import_and_no_network.py tests/test_llm_config_patch_chain.py -q` passes.
- [ ] `uv run pytest tests/test_dashboard_llm_settings.py tests/test_result_explain.py tests/test_llm_compare_runs.py tests/test_langsmith_fleet.py tests/test_llm_prompts.py tests/test_dashboard_explain_results.py tests/test_dashboard_comparison_llm.py tests/test_reference_packs.py -q` remains green.
- [ ] No default test path makes a real network call or requires live LLM credentials.

## Implementation Notes

The focused LLM/reference-pack suite passed separately:

```text
uv run pytest tests/test_dashboard_llm_settings.py tests/test_result_explain.py tests/test_llm_compare_runs.py tests/test_langsmith_fleet.py tests/test_llm_prompts.py tests/test_dashboard_explain_results.py tests/test_dashboard_comparison_llm.py tests/test_reference_packs.py -q
170 passed
```

The direct helper behavior also passed in isolation:

```text
uv run pytest tests/test_llm_config_patch_chain.py::test_run_config_patch_chain_skips_tracing_when_helpers_unavailable -q
1 passed
```



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a brief internal reference note to the Codex 2016 agent guide.
* **Tests**
  * Strengthened the “LLM import without network” test to run in a clean module state, ensuring no lingering import side effects and restoring any prior state after the test completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2016
