### PR TITLE
Fix sample dashboard financing mode

### DIFF
--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -11,15 +11,16 @@ import io
 import pandas as pd  # type: ignore[reportMissingImports]
 import streamlit as st
 import yaml
+from pydantic import ValidationError
 
 from dashboard.app import apply_theme, render_settings_sidebar
 from dashboard.utils import (
     build_alpha_shares_payload,
+    build_sample_model_config,
     bump_session_token,
     load_bundled_sample_index,
     make_grid_cache_key,
 )
-from pa_core.config import ModelConfig
 from pa_core.contracts import (
     SUMMARY_AGENT_COLUMN,
     SUMMARY_ANN_RETURN_COLUMN,
@@ -236,12 +237,7 @@ def main() -> None:
                     st.error(f"Bundled sample data could not be loaded: {exc}")
                     return
 
-            base_cfg = ModelConfig.model_validate(
-                {
-                    "Number of simulations": 1000,
-                    "Number of months": 12,
-                }
-            )
+            base_cfg = build_sample_model_config()
             cfg = base_cfg.model_copy(
                 update={
                     "analysis_mode": "alpha_shares",
@@ -421,7 +417,7 @@ def main() -> None:
                 options=y_vals,
                 index=0,
                 format_func=(
-                    lambda v: (f"${v:,.0f} mm" if y_col == "external_pa_dollars_mm" else f"{v:.2f}")
+                    lambda v: f"${v:,.0f} mm" if y_col == "external_pa_dollars_mm" else f"{v:.2f}"
                 ),
             )
             if st.button("Promote to session"):
@@ -481,6 +477,11 @@ def main() -> None:
                 )
             except Exception:
                 pass
+        except ValidationError:
+            st.error(
+                "The sample scenario-grid settings could not be validated. "
+                "Refresh the defaults or use Scenario Wizard to build a configuration."
+            )
         except ValueError as exc:
             st.error(f"Invalid configuration: {exc}")
         except RuntimeError as exc:

--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -237,18 +237,16 @@ def main() -> None:
                     st.error(f"Bundled sample data could not be loaded: {exc}")
                     return
 
-            base_cfg = build_sample_model_config()
-            cfg = base_cfg.model_copy(
-                update={
-                    "analysis_mode": "alpha_shares",
-                    "external_pa_alpha_min_pct": float(ext_min),
-                    "external_pa_alpha_max_pct": float(ext_max),
-                    "external_pa_alpha_step_pct": float(ext_step),
-                    "active_share_min_pct": float(act_min),
-                    "active_share_max_pct": float(act_max),
-                    "active_share_step_pct": float(act_step),
-                }
+            cfg = build_sample_model_config(
+                analysis_mode="alpha_shares",
+                external_pa_alpha_min_pct=float(ext_min),
+                external_pa_alpha_max_pct=float(ext_max),
+                external_pa_alpha_step_pct=float(ext_step),
+                active_share_min_pct=float(act_min),
+                active_share_max_pct=float(act_max),
+                active_share_step_pct=float(act_step),
             )
+            base_cfg = cfg
 
             cache_key = make_grid_cache_key(cfg, index_series, int(seed), y_axis_mode)
             cached = _get_grid_cache(cache_key)

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -170,18 +170,19 @@ def main() -> None:
                     "Provide an index CSV, enable bundled sample data, or run a scenario first."
                 )
 
-            base_cfg = build_sample_model_config(
-                **{
-                    "Number of simulations": int(n_sims),
-                    "Number of months": int(n_months),
-                    "Total fund capital (mm)": float(total_cap),
-                    "External PA capital (mm)": float(ext_cap),
-                    "Active Extension capital (mm)": float(act_cap),
-                    "Internal PA capital (mm)": float(int_cap),
-                    "External PA alpha fraction": float(theta),
-                    "Active share": float(active_share),
-                }
-            )
+            config_overrides = {
+                "Number of simulations": int(n_sims),
+                "Number of months": int(n_months),
+                "Total fund capital (mm)": float(total_cap),
+                "External PA capital (mm)": float(ext_cap),
+                "Active Extension capital (mm)": float(act_cap),
+                "Internal PA capital (mm)": float(int_cap),
+                "External PA alpha fraction": float(theta),
+                "Active share": float(active_share),
+            }
+            if session_cfg is not None and not use_sample:
+                config_overrides["financing_mode"] = session_cfg.financing_mode
+            base_cfg = build_sample_model_config(**config_overrides)
 
             stressed_cfg = apply_stress_preset(base_cfg, cast(str, preset))
 

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -13,9 +13,11 @@ from typing import cast
 
 import pandas as pd
 import streamlit as st
+from pydantic import ValidationError
 
 from dashboard.app import apply_theme, render_settings_sidebar
 from dashboard.utils import (
+    build_sample_model_config,
     config_capital_defaults,
     current_index_returns,
     current_scenario_config,
@@ -168,8 +170,8 @@ def main() -> None:
                     "Provide an index CSV, enable bundled sample data, or run a scenario first."
                 )
 
-            base_cfg = ModelConfig.model_validate(
-                {
+            base_cfg = build_sample_model_config(
+                **{
                     "Number of simulations": int(n_sims),
                     "Number of months": int(n_months),
                     "Total fund capital (mm)": float(total_cap),
@@ -263,6 +265,11 @@ def main() -> None:
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             )
 
+        except ValidationError:  # pragma: no cover - runtime UX
+            st.error(
+                "The sample stress-test settings could not be validated. "
+                "Refresh the defaults or run a scenario first."
+            )
         except Exception as exc:  # pragma: no cover - runtime UX
             st.error(str(exc))
 

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -81,6 +81,7 @@ def config_capital_defaults(config: ModelConfig | None) -> dict[str, float]:
 # Bundled index-returns dataset shipped with the repo so first-run users can run
 # an end-to-end example without uploading their own file (see issue #1900).
 SAMPLE_INDEX_FILENAME = "sp500tr_fred_divyield.csv"
+SAMPLE_FINANCING_MODE = "per_path"
 
 
 def bundled_sample_index_path() -> Path:
@@ -104,6 +105,17 @@ def load_bundled_sample_index() -> pd.Series:
     """
     path = bundled_sample_index_path()
     return load_index_returns(path)
+
+
+def build_sample_model_config(**overrides: Any) -> ModelConfig:
+    """Return a ModelConfig for bundled-sample dashboard paths."""
+    data: dict[str, Any] = {
+        "Number of simulations": 1000,
+        "Number of months": 12,
+        "financing_mode": SAMPLE_FINANCING_MODE,
+    }
+    data.update(overrides)
+    return ModelConfig.model_validate(data)
 
 
 def build_alpha_shares_payload(

--- a/tests/test_dashboard_sample_data.py
+++ b/tests/test_dashboard_sample_data.py
@@ -14,6 +14,8 @@ import pandas as pd
 
 from dashboard.utils import (
     SAMPLE_INDEX_FILENAME,
+    SAMPLE_FINANCING_MODE,
+    build_sample_model_config,
     bundled_sample_index_path,
     load_bundled_sample_index,
 )
@@ -53,3 +55,25 @@ def test_bundled_sample_runs_through_orchestrator_end_to_end() -> None:
     _, summary = orch.run(seed=42)
     assert summary is not None
     assert not summary.empty
+
+
+def test_sample_run_config_validates() -> None:
+    """Stress Lab and Scenario Grid sample config paths must not dead-end."""
+    stress_config = build_sample_model_config(
+        **{
+            "Number of simulations": 1000,
+            "Number of months": 12,
+            "Total fund capital (mm)": 1000.0,
+            "External PA capital (mm)": 200.0,
+            "Active Extension capital (mm)": 200.0,
+            "Internal PA capital (mm)": 200.0,
+            "External PA alpha fraction": 0.5,
+            "Active share": 0.5,
+        }
+    )
+    grid_config = build_sample_model_config()
+
+    assert stress_config.financing_mode == SAMPLE_FINANCING_MODE
+    assert grid_config.financing_mode == SAMPLE_FINANCING_MODE
+    assert stress_config.financing_mode in {"per_path", "broadcast"}
+    assert grid_config.financing_mode in {"per_path", "broadcast"}

--- a/tests/test_dashboard_sample_data.py
+++ b/tests/test_dashboard_sample_data.py
@@ -71,9 +71,24 @@ def test_sample_run_config_validates() -> None:
             "Active share": 0.5,
         }
     )
-    grid_config = build_sample_model_config()
+    grid_config = build_sample_model_config(
+        analysis_mode="alpha_shares",
+        external_pa_alpha_min_pct=25.0,
+        external_pa_alpha_max_pct=75.0,
+        external_pa_alpha_step_pct=5.0,
+        active_share_min_pct=20.0,
+        active_share_max_pct=100.0,
+        active_share_step_pct=5.0,
+    )
 
     assert stress_config.financing_mode == SAMPLE_FINANCING_MODE
     assert grid_config.financing_mode == SAMPLE_FINANCING_MODE
     assert stress_config.financing_mode in {"per_path", "broadcast"}
     assert grid_config.financing_mode in {"per_path", "broadcast"}
+    assert grid_config.analysis_mode == "alpha_shares"
+    assert grid_config.external_pa_alpha_min_pct == 25.0
+    assert grid_config.external_pa_alpha_max_pct == 75.0
+    assert grid_config.external_pa_alpha_step_pct == 5.0
+    assert grid_config.active_share_min_pct == 20.0
+    assert grid_config.active_share_max_pct == 100.0
+    assert grid_config.active_share_step_pct == 5.0


### PR DESCRIPTION
Closes #2018

## Summary
- Add a shared bundled-sample ModelConfig builder that supplies financing_mode=per_path.
- Route Stress Lab and Scenario Grid sample config construction through the shared builder.
- Replace raw pydantic validation leakage on those sample paths with concise dashboard messages.
- Add a regression proving the Stress Lab and Scenario Grid sample configs validate with a real financing mode.

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_dashboard_sample_data.py::test_sample_run_config_validates -q
- Deliberate break: removed financing_mode from the shared sample builder and confirmed test_sample_run_config_validates failed with the missing-field ValidationError, then restored the fix.
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_dashboard_sample_data.py::test_sample_run_config_validates tests/test_dashboard_sample_data.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check dashboard/utils.py dashboard/pages/5_Scenario_Grid.py dashboard/pages/6_Stress_Lab.py tests/test_dashboard_sample_data.py
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check dashboard/utils.py dashboard/pages/5_Scenario_Grid.py dashboard/pages/6_Stress_Lab.py tests/test_dashboard_sample_data.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling in the Scenario Grid and Stress Lab flows, showing clearer, validation-focused messages when sample configuration inputs are invalid.
  * Standardized how bundled sample configurations are constructed, ensuring the expected financing mode is applied consistently.
* **Tests**
  * Added coverage to verify bundled sample configuration generation produces valid settings (including financing mode) and preserves key analysis parameters for both scenario-grid and stress-test paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->