### PR TITLE
Fix feasible wizard capital defaults

### DIFF
--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -89,6 +89,22 @@ _DEFAULT_MARGIN_BUFFER_SHARE = 0.01
 _MAX_DEFAULT_INTERNAL_PA_SHARE = 0.96
 
 
+def _load_margin_schedule_from_path(
+    schedule_path: str | Path | None,
+) -> tuple[pd.DataFrame | None, Path | None]:
+    if not schedule_path:
+        return None, None
+
+    path = Path(str(schedule_path))
+    if not path.exists():
+        return None, None
+
+    try:
+        return load_margin_schedule(path), path
+    except Exception:
+        return None, None
+
+
 def _default_capital_allocation(
     *,
     total_fund_capital: float,
@@ -115,15 +131,22 @@ def _default_capital_allocation(
     external = min(external, total)
     active = min(active, max(0.0, total - external))
 
-    use_schedule = financing_model == "schedule" and (margin_schedule is not None or schedule_path)
+    resolved_schedule = margin_schedule
+    resolved_schedule_path: Path | None = None
+    if resolved_schedule is None:
+        resolved_schedule, resolved_schedule_path = _load_margin_schedule_from_path(schedule_path)
+
+    use_schedule = financing_model == "schedule" and (
+        resolved_schedule is not None or resolved_schedule_path is not None
+    )
     effective_financing_model = "schedule" if use_schedule else "simple_proxy"
     margin_requirement = calculate_margin_requirement(
         reference_sigma=reference_sigma,
         volatility_multiple=volatility_multiple,
         total_capital=total,
         financing_model=effective_financing_model,
-        margin_schedule=margin_schedule,
-        schedule_path=schedule_path,
+        margin_schedule=resolved_schedule,
+        schedule_path=resolved_schedule_path,
         term_months=term_months,
     )
     margin_buffer = total * _DEFAULT_MARGIN_BUFFER_SHARE
@@ -892,12 +915,18 @@ def _render_step_2_capital(config: Any) -> Any:
 
     ss = st.session_state
     financing_settings = ss.get("financing_settings", {})
+    schedule_df, schedule_path = _load_margin_schedule_from_path(
+        financing_settings.get("schedule_path")
+    )
+    if financing_settings.get("schedule_path") and schedule_path is None:
+        financing_settings["schedule_path"] = None
     default_allocation = _default_capital_allocation(
         total_fund_capital=config.total_fund_capital,
         reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
         volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
         financing_model=str(financing_settings.get("financing_model", "simple_proxy")),
-        schedule_path=financing_settings.get("schedule_path"),
+        margin_schedule=schedule_df,
+        schedule_path=schedule_path,
         term_months=float(financing_settings.get("term_months", 1.0)),
     )
     col1, col2 = st.columns(2)
@@ -942,7 +971,8 @@ def _render_step_2_capital(config: Any) -> Any:
             reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
             volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
             financing_model=str(financing_settings.get("financing_model", "simple_proxy")),
-            schedule_path=financing_settings.get("schedule_path"),
+            margin_schedule=schedule_df,
+            schedule_path=schedule_path,
             term_months=float(financing_settings.get("term_months", 1.0)),
             external_pa_capital=config.external_pa_capital,
             active_ext_capital=config.active_ext_capital,
@@ -998,13 +1028,13 @@ def _render_step_2_capital(config: Any) -> Any:
         config.external_pa_capital + config.active_ext_capital + config.internal_pa_capital
     )
     effective_financing_model = str(financing_settings.get("financing_model", "simple_proxy"))
-    schedule_path = financing_settings.get("schedule_path")
-    use_schedule_margin = effective_financing_model == "schedule" and schedule_path
+    use_schedule_margin = effective_financing_model == "schedule" and schedule_df is not None
     margin_requirement = calculate_margin_requirement(
         reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
         volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
         total_capital=config.total_fund_capital,
         financing_model="schedule" if use_schedule_margin else "simple_proxy",
+        margin_schedule=schedule_df if use_schedule_margin else None,
         schedule_path=schedule_path if use_schedule_margin else None,
         term_months=float(financing_settings.get("term_months", 1.0)),
     )

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -95,6 +95,9 @@ def _default_capital_allocation(
     reference_sigma: float = 0.01,
     volatility_multiple: float = 3.0,
     financing_model: str = "simple_proxy",
+    margin_schedule: pd.DataFrame | None = None,
+    schedule_path: str | Path | None = None,
+    term_months: float = 1.0,
     external_pa_capital: float | None = None,
     active_ext_capital: float | None = None,
 ) -> dict[str, float]:
@@ -112,12 +115,16 @@ def _default_capital_allocation(
     external = min(external, total)
     active = min(active, max(0.0, total - external))
 
-    effective_financing_model = "simple_proxy" if financing_model == "schedule" else financing_model
+    use_schedule = financing_model == "schedule" and (margin_schedule is not None or schedule_path)
+    effective_financing_model = "schedule" if use_schedule else "simple_proxy"
     margin_requirement = calculate_margin_requirement(
         reference_sigma=reference_sigma,
         volatility_multiple=volatility_multiple,
         total_capital=total,
         financing_model=effective_financing_model,
+        margin_schedule=margin_schedule,
+        schedule_path=schedule_path,
+        term_months=term_months,
     )
     margin_buffer = total * _DEFAULT_MARGIN_BUFFER_SHARE
     max_internal_after_margin = max(0.0, total - margin_requirement - margin_buffer)
@@ -890,6 +897,8 @@ def _render_step_2_capital(config: Any) -> Any:
         reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
         volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
         financing_model=str(financing_settings.get("financing_model", "simple_proxy")),
+        schedule_path=financing_settings.get("schedule_path"),
+        term_months=float(financing_settings.get("term_months", 1.0)),
     )
     col1, col2 = st.columns(2)
 
@@ -933,6 +942,8 @@ def _render_step_2_capital(config: Any) -> Any:
             reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
             volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
             financing_model=str(financing_settings.get("financing_model", "simple_proxy")),
+            schedule_path=financing_settings.get("schedule_path"),
+            term_months=float(financing_settings.get("term_months", 1.0)),
             external_pa_capital=config.external_pa_capital,
             active_ext_capital=config.active_ext_capital,
         )
@@ -986,15 +997,16 @@ def _render_step_2_capital(config: Any) -> Any:
     total_allocated = (
         config.external_pa_capital + config.active_ext_capital + config.internal_pa_capital
     )
+    effective_financing_model = str(financing_settings.get("financing_model", "simple_proxy"))
+    schedule_path = financing_settings.get("schedule_path")
+    use_schedule_margin = effective_financing_model == "schedule" and schedule_path
     margin_requirement = calculate_margin_requirement(
         reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
         volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
         total_capital=config.total_fund_capital,
-        financing_model=(
-            "simple_proxy"
-            if str(financing_settings.get("financing_model", "simple_proxy")) == "schedule"
-            else str(financing_settings.get("financing_model", "simple_proxy"))
-        ),
+        financing_model="schedule" if use_schedule_margin else "simple_proxy",
+        schedule_path=schedule_path if use_schedule_margin else None,
+        term_months=float(financing_settings.get("term_months", 1.0)),
     )
     margin_buffer = config.total_fund_capital - margin_requirement - config.internal_pa_capital
     buffer_pct = margin_buffer / config.total_fund_capital if config.total_fund_capital else 0.0

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -83,6 +83,58 @@ _CONFIG_CHAT_PREVIEW_KEY = "wizard_config_chat_preview"
 _CONFIG_CHAT_PREVIEW_PATCH_KEY = "preview_patch"
 _CONFIG_CHAT_PREVIEW_UNIFIED_DIFF_KEY = "preview_unified_diff"
 _CONFIG_CHAT_PREVIEW_SIDEBYSIDE_DIFF_KEY = "preview_sidebyside_diff"
+_DEFAULT_EXTERNAL_PA_SHARE = 0.02
+_DEFAULT_ACTIVE_EXT_SHARE = 0.02
+_DEFAULT_MARGIN_BUFFER_SHARE = 0.01
+_MAX_DEFAULT_INTERNAL_PA_SHARE = 0.96
+
+
+def _default_capital_allocation(
+    *,
+    total_fund_capital: float,
+    reference_sigma: float = 0.01,
+    volatility_multiple: float = 3.0,
+    financing_model: str = "simple_proxy",
+    external_pa_capital: float | None = None,
+    active_ext_capital: float | None = None,
+) -> dict[str, float]:
+    total = max(0.0, float(total_fund_capital))
+    external = (
+        max(0.0, float(external_pa_capital))
+        if external_pa_capital is not None
+        else total * _DEFAULT_EXTERNAL_PA_SHARE
+    )
+    active = (
+        max(0.0, float(active_ext_capital))
+        if active_ext_capital is not None
+        else total * _DEFAULT_ACTIVE_EXT_SHARE
+    )
+    external = min(external, total)
+    active = min(active, max(0.0, total - external))
+
+    effective_financing_model = "simple_proxy" if financing_model == "schedule" else financing_model
+    margin_requirement = calculate_margin_requirement(
+        reference_sigma=reference_sigma,
+        volatility_multiple=volatility_multiple,
+        total_capital=total,
+        financing_model=effective_financing_model,
+    )
+    margin_buffer = total * _DEFAULT_MARGIN_BUFFER_SHARE
+    max_internal_after_margin = max(0.0, total - margin_requirement - margin_buffer)
+    max_internal_by_share = total * _MAX_DEFAULT_INTERNAL_PA_SHARE
+    remaining_after_other_sleeves = max(0.0, total - external - active)
+    internal = min(
+        remaining_after_other_sleeves,
+        max_internal_after_margin,
+        max_internal_by_share,
+    )
+    return {
+        "external_pa_capital": external,
+        "active_ext_capital": active,
+        "internal_pa_capital": internal,
+        "margin_requirement": margin_requirement,
+        "margin_buffer": total - margin_requirement - internal,
+    }
 
 
 def _config_chat_history() -> list[dict[str, Any]]:
@@ -832,6 +884,13 @@ def _render_step_2_capital(config: Any) -> Any:
     st.subheader("Step 2: Capital Allocation")
 
     ss = st.session_state
+    financing_settings = ss.get("financing_settings", {})
+    default_allocation = _default_capital_allocation(
+        total_fund_capital=config.total_fund_capital,
+        reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
+        volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
+        financing_model=str(financing_settings.get("financing_model", "simple_proxy")),
+    )
     col1, col2 = st.columns(2)
 
     with col1:
@@ -851,7 +910,7 @@ def _render_step_2_capital(config: Any) -> Any:
             "External PA Capital [$M]",
             min_value=0.0,
             max_value=config.total_fund_capital,
-            value=ss.get(_EXTERNAL_CAPITAL_KEY, config.external_pa_capital),
+            value=ss.get(_EXTERNAL_CAPITAL_KEY, default_allocation["external_pa_capital"]),
             step=5.0,
             format="%.1f",
             help="Capital allocated to external portable alpha managers",
@@ -862,21 +921,25 @@ def _render_step_2_capital(config: Any) -> Any:
             "Active Extension Capital [$M]",
             min_value=0.0,
             max_value=config.total_fund_capital,
-            value=ss.get(_ACTIVE_CAPITAL_KEY, config.active_ext_capital),
+            value=ss.get(_ACTIVE_CAPITAL_KEY, default_allocation["active_ext_capital"]),
             step=5.0,
             format="%.1f",
             help="Capital for active equity overlay strategies",
             key=_ACTIVE_CAPITAL_KEY,
         )
 
-        # Calculate remaining capital
-        remaining = (
-            config.total_fund_capital - config.external_pa_capital - config.active_ext_capital
+        internal_default = _default_capital_allocation(
+            total_fund_capital=config.total_fund_capital,
+            reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
+            volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
+            financing_model=str(financing_settings.get("financing_model", "simple_proxy")),
+            external_pa_capital=config.external_pa_capital,
+            active_ext_capital=config.active_ext_capital,
         )
         config.internal_pa_capital = st.number_input(
             "Internal PA Capital [$M]",
             min_value=0.0,
-            value=ss.get(_INTERNAL_CAPITAL_KEY, max(0.0, remaining)),
+            value=ss.get(_INTERNAL_CAPITAL_KEY, internal_default["internal_pa_capital"]),
             step=5.0,
             format="%.1f",
             help="Capital managed internally for portable alpha",
@@ -923,6 +986,29 @@ def _render_step_2_capital(config: Any) -> Any:
     total_allocated = (
         config.external_pa_capital + config.active_ext_capital + config.internal_pa_capital
     )
+    margin_requirement = calculate_margin_requirement(
+        reference_sigma=float(financing_settings.get("reference_sigma", 0.01)),
+        volatility_multiple=float(financing_settings.get("volatility_multiple", 3.0)),
+        total_capital=config.total_fund_capital,
+        financing_model=(
+            "simple_proxy"
+            if str(financing_settings.get("financing_model", "simple_proxy")) == "schedule"
+            else str(financing_settings.get("financing_model", "simple_proxy"))
+        ),
+    )
+    margin_buffer = config.total_fund_capital - margin_requirement - config.internal_pa_capital
+    buffer_pct = margin_buffer / config.total_fund_capital if config.total_fund_capital else 0.0
+
+    buffer_text = (
+        f"Buffer after margin: ${margin_buffer:.1f}M ({buffer_pct:.1%}) "
+        f"after ${margin_requirement:.1f}M estimated margin"
+    )
+    if margin_buffer < 0:
+        st.error(buffer_text)
+    elif buffer_pct < 0.1:
+        st.warning(buffer_text)
+    else:
+        st.success(buffer_text)
 
     if abs(total_allocated - config.total_fund_capital) > 0.01:
         st.error(

--- a/tests/test_dashboard_advanced_settings.py
+++ b/tests/test_dashboard_advanced_settings.py
@@ -174,8 +174,25 @@ def test_wizard_default_allocation_is_feasible(tmp_path: Path) -> None:
         )
 
         assert model_config.financing_model == "schedule"
-        assert margin_requirement == 100.0
+        assert margin_requirement == pytest.approx(100.0)
         assert model_config.internal_pa_capital <= model_config.total_fund_capital * 0.96
         assert buffer_after_margin >= 0
     finally:
         st.session_state.clear()
+
+
+def test_wizard_default_allocation_ignores_stale_schedule_path(tmp_path: Path) -> None:
+    helpers = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
+    default_allocation = helpers["_default_capital_allocation"]
+
+    allocation = default_allocation(
+        total_fund_capital=1000.0,
+        reference_sigma=0.01,
+        volatility_multiple=3.0,
+        financing_model="schedule",
+        schedule_path=tmp_path / "missing-schedule.csv",
+        term_months=1.0,
+    )
+
+    assert allocation["margin_requirement"] == pytest.approx(30.0)
+    assert allocation["internal_pa_capital"] == pytest.approx(960.0)

--- a/tests/test_dashboard_advanced_settings.py
+++ b/tests/test_dashboard_advanced_settings.py
@@ -8,11 +8,16 @@ home page sets a real page title instead of the Streamlit default ("app").
 
 from __future__ import annotations
 
+import runpy
 from typing import Any
 
 import pytest
+import streamlit as st
 
 import dashboard.app as app
+from pa_core.config import load_config
+from pa_core.validators import calculate_margin_requirement
+from pa_core.wizard_schema import AnalysisMode, get_default_config
 
 
 class _FakeExpander:
@@ -122,3 +127,34 @@ def test_home_page_sets_real_title(fake_st: FakeStreamlit) -> None:
     page_configs = [e for e in fake_st.events if e[0] == "set_page_config"]
     assert len(page_configs) == 1
     assert page_configs[0][1].get("page_title") == "Portable Alpha Dashboard"
+
+
+def test_wizard_default_allocation_is_feasible() -> None:
+    helpers = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
+    default_allocation = helpers["_default_capital_allocation"]
+    build_yaml = helpers["_build_yaml_from_config"]
+
+    st.session_state.clear()
+    try:
+        config = get_default_config(AnalysisMode.RETURNS)
+        allocation = default_allocation(total_fund_capital=config.total_fund_capital)
+        config.external_pa_capital = allocation["external_pa_capital"]
+        config.active_ext_capital = allocation["active_ext_capital"]
+        config.internal_pa_capital = allocation["internal_pa_capital"]
+
+        yaml_dict = build_yaml(config)
+        model_config = load_config(yaml_dict)
+        margin_requirement = calculate_margin_requirement(
+            reference_sigma=model_config.reference_sigma,
+            volatility_multiple=model_config.volatility_multiple,
+            total_capital=model_config.total_fund_capital,
+            financing_model=model_config.financing_model,
+        )
+        buffer_after_margin = (
+            model_config.total_fund_capital - margin_requirement - model_config.internal_pa_capital
+        )
+
+        assert model_config.internal_pa_capital <= model_config.total_fund_capital * 0.96
+        assert buffer_after_margin >= 0
+    finally:
+        st.session_state.clear()

--- a/tests/test_dashboard_advanced_settings.py
+++ b/tests/test_dashboard_advanced_settings.py
@@ -9,6 +9,7 @@ home page sets a real page title instead of the Streamlit default ("app").
 from __future__ import annotations
 
 import runpy
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -129,15 +130,31 @@ def test_home_page_sets_real_title(fake_st: FakeStreamlit) -> None:
     assert page_configs[0][1].get("page_title") == "Portable Alpha Dashboard"
 
 
-def test_wizard_default_allocation_is_feasible() -> None:
+def test_wizard_default_allocation_is_feasible(tmp_path: Path) -> None:
     helpers = runpy.run_path("dashboard/pages/3_Scenario_Wizard.py")
     default_allocation = helpers["_default_capital_allocation"]
     build_yaml = helpers["_build_yaml_from_config"]
+    schedule_path = tmp_path / "margin_schedule.csv"
+    schedule_path.write_text("term,multiplier\n1,10\n", encoding="utf-8")
 
     st.session_state.clear()
     try:
         config = get_default_config(AnalysisMode.RETURNS)
-        allocation = default_allocation(total_fund_capital=config.total_fund_capital)
+        st.session_state["financing_settings"] = {
+            "financing_model": "schedule",
+            "reference_sigma": 0.01,
+            "volatility_multiple": 3.0,
+            "schedule_path": str(schedule_path),
+            "term_months": 1.0,
+        }
+        allocation = default_allocation(
+            total_fund_capital=config.total_fund_capital,
+            reference_sigma=0.01,
+            volatility_multiple=3.0,
+            financing_model="schedule",
+            schedule_path=schedule_path,
+            term_months=1.0,
+        )
         config.external_pa_capital = allocation["external_pa_capital"]
         config.active_ext_capital = allocation["active_ext_capital"]
         config.internal_pa_capital = allocation["internal_pa_capital"]
@@ -149,11 +166,15 @@ def test_wizard_default_allocation_is_feasible() -> None:
             volatility_multiple=model_config.volatility_multiple,
             total_capital=model_config.total_fund_capital,
             financing_model=model_config.financing_model,
+            schedule_path=model_config.financing_schedule_path,
+            term_months=model_config.financing_term_months,
         )
         buffer_after_margin = (
             model_config.total_fund_capital - margin_requirement - model_config.internal_pa_capital
         )
 
+        assert model_config.financing_model == "schedule"
+        assert margin_requirement == 100.0
         assert model_config.internal_pa_capital <= model_config.total_fund_capital * 0.96
         assert buffer_after_margin >= 0
     finally:


### PR DESCRIPTION
## Summary
- make Scenario Wizard first-run capital defaults reserve margin headroom while seeding non-zero external PA and active-extension sleeves
- add a Step 2 buffer-after-margin indicator before users reach Run Simulation
- add the named regression test for default wizard allocation feasibility

Closes #2020

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_dashboard_advanced_settings.py::test_wizard_default_allocation_is_feasible -q`
- deliberate break: reset external/active defaults to 0.1% and internal PA to all remaining capital; named test failed with the expected margin + internal PA validation error; restored fix
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_dashboard_advanced_settings.py::test_wizard_default_allocation_is_feasible tests/test_dashboard_advanced_settings.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_wizard_helpers.py tests/test_dashboard_advanced_settings.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check dashboard/pages/3_Scenario_Wizard.py tests/test_dashboard_advanced_settings.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check dashboard/pages/3_Scenario_Wizard.py tests/test_dashboard_advanced_settings.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the Scenario Wizard “Capital Allocation” defaults by deriving external, active, and internal PA amounts from total fund capital with margin-and-buffer-aware clamping for feasibility.
  * Updated Step 2 to keep internal PA defaults consistent with the recalculated financing model inputs (instead of a simple remaining-capital fallback).
  * Added margin-buffer feedback, showing status and highlighting when buffers are negative or below a 10% threshold.

* **Tests**
  * Added automated checks ensuring the wizard’s default allocation is margin-feasible, matches expected margin requirement behavior, and is not affected by a stale schedule path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->