### PR TITLE
Add bundled sample paths to asset dashboard pages

### DIFF
--- a/dashboard/pages/1_Asset_Library.py
+++ b/dashboard/pages/1_Asset_Library.py
@@ -33,12 +33,13 @@ def main() -> None:
     apply_theme(theme_path)
     st.markdown("**Upload asset return data**")
     sample_path = bundled_asset_timeseries_path()
+    sample_available = sample_path.exists()
     use_sample = st.checkbox(
         "Use bundled sample asset data (no upload needed)",
         value=False,
         help="Loads the shipped wide-format return template so you can explore calibration immediately.",
     )
-    if sample_path.exists():
+    if sample_available:
         st.download_button(
             "Download asset return template",
             sample_path.read_bytes(),
@@ -54,6 +55,9 @@ def main() -> None:
     )
     if uploaded is None and not use_sample:
         st.info("Upload asset return data or use the bundled sample to begin.")
+        return
+    if uploaded is None and use_sample and not sample_available:
+        st.error("Bundled sample asset data is unavailable. Upload asset return data instead.")
         return
     cleanup_tmp_path = False
     tmp_path = str(sample_path)

--- a/dashboard/pages/1_Asset_Library.py
+++ b/dashboard/pages/1_Asset_Library.py
@@ -20,6 +20,7 @@ try:
 except Exception:  # pragma: no cover - conservative fallback
     _BARE_MODE = True
 from dashboard.app import apply_theme, render_settings_sidebar
+from dashboard.utils import bundled_asset_timeseries_path
 from pa_core.presets import AlphaPreset, PresetLibrary
 
 # Create logger for this module
@@ -31,6 +32,19 @@ def main() -> None:
     _, theme_path = render_settings_sidebar()
     apply_theme(theme_path)
     st.markdown("**Upload asset return data**")
+    sample_path = bundled_asset_timeseries_path()
+    use_sample = st.checkbox(
+        "Use bundled sample asset data (no upload needed)",
+        value=False,
+        help="Loads the shipped wide-format return template so you can explore calibration immediately.",
+    )
+    if sample_path.exists():
+        st.download_button(
+            "Download asset return template",
+            sample_path.read_bytes(),
+            file_name=sample_path.name,
+            mime="text/csv",
+        )
     st.caption("Drag and drop a CSV or Excel file, or click to browse.")
     uploaded = st.file_uploader(
         "Drag-and-drop CSV/XLSX",
@@ -38,19 +52,29 @@ def main() -> None:
         help="CSV and Excel files are supported.",
         label_visibility="collapsed",
     )
-    if uploaded is None:
+    if uploaded is None and not use_sample:
+        st.info("Upload asset return data or use the bundled sample to begin.")
         return
-    data = uploaded.getvalue()
-    size_kb = len(data) / 1024
-    st.caption(f"Selected file: {uploaded.name} ({size_kb:.1f} KB)")
+    cleanup_tmp_path = False
+    tmp_path = str(sample_path)
+    if uploaded is not None:
+        data = uploaded.getvalue()
+        size_kb = len(data) / 1024
+        st.caption(f"Selected file: {uploaded.name} ({size_kb:.1f} KB)")
 
-    # Persist the uploaded file to a temp path for pandas/Excel readers
-    suffix = Path(uploaded.name).suffix
-    fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+        # Persist the uploaded file to a temp path for pandas/Excel readers
+        suffix = Path(uploaded.name).suffix
+        fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+        cleanup_tmp_path = True
+    else:
+        data = b""
+        fd = -1
+        st.caption(f"Using bundled sample: {sample_path.name}")
     try:
-        with os.fdopen(fd, "wb") as tmp:
-            tmp.write(data)
-            tmp.flush()  # Ensure data is written to disk
+        if uploaded is not None:
+            with os.fdopen(fd, "wb") as tmp:
+                tmp.write(data)
+                tmp.flush()  # Ensure data is written to disk
 
         st.markdown("---")
         st.subheader("Column Mapping & Parse Options")
@@ -277,7 +301,8 @@ def main() -> None:
                 lib.load_json_str(text)
 
     finally:
-        Path(tmp_path).unlink(missing_ok=True)
+        if cleanup_tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import tempfile
 from pathlib import Path
 
@@ -105,16 +104,10 @@ def main() -> None:
         return
 
     if uploaded is not None:
-        tmp_path: Path | None = None
-        try:
-            fd, tmp_name = tempfile.mkstemp(suffix=".yaml")
-            tmp_path = Path(tmp_name)
-            with os.fdopen(fd, "wb") as tmp:
-                tmp.write(uploaded.getvalue())
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir) / "uploaded.yaml"
+            tmp_path.write_bytes(uploaded.getvalue())
             scenario = load_scenario(tmp_path)
-        finally:
-            if tmp_path is not None:
-                tmp_path.unlink(missing_ok=True)
     else:
         st.caption(f"Using bundled sample: {sample_portfolio_path.name}")
         scenario = load_scenario(sample_portfolio_path)

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -106,10 +107,10 @@ def main() -> None:
     if uploaded is not None:
         tmp_path: Path | None = None
         try:
-            with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
-                tmp_path = Path(tmp.name)
+            fd, tmp_name = tempfile.mkstemp(suffix=".yaml")
+            tmp_path = Path(tmp_name)
+            with os.fdopen(fd, "wb") as tmp:
                 tmp.write(uploaded.getvalue())
-                tmp.flush()
             scenario = load_scenario(tmp_path)
         finally:
             if tmp_path is not None:

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -81,13 +81,14 @@ def main() -> None:
         )
 
     sample_portfolio_path = bundled_portfolio_template_path()
+    sample_portfolio_available = sample_portfolio_path.exists()
     uploaded = st.file_uploader("Upload Asset Library YAML", type=["yaml", "yml"])
     use_sample_portfolio = st.checkbox(
         "Load bundled sample portfolio",
         value=False,
         help="Loads the starter scenario YAML so you can build weights without uploading a file.",
     )
-    if sample_portfolio_path.exists():
+    if sample_portfolio_available:
         st.download_button(
             "Download starter portfolio YAML",
             sample_portfolio_path.read_text(),
@@ -96,6 +97,9 @@ def main() -> None:
         )
     if uploaded is None and not use_sample_portfolio:
         st.info("Upload an asset library YAML or load the bundled sample portfolio to begin.")
+        return
+    if uploaded is None and use_sample_portfolio and not sample_portfolio_available:
+        st.error("Bundled starter portfolio is unavailable. Upload an asset library YAML instead.")
         return
 
     if uploaded is not None:

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tempfile
+from pathlib import Path
 
 import streamlit as st
 import yaml
@@ -103,10 +104,16 @@ def main() -> None:
         return
 
     if uploaded is not None:
-        with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp:
-            tmp.write(uploaded.getvalue())
-            tmp.flush()  # Ensure data is written to disk
-            scenario = load_scenario(tmp.name)
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+                tmp_path = Path(tmp.name)
+                tmp.write(uploaded.getvalue())
+                tmp.flush()
+            scenario = load_scenario(tmp_path)
+        finally:
+            if tmp_path is not None:
+                tmp_path.unlink(missing_ok=True)
     else:
         st.caption(f"Using bundled sample: {sample_portfolio_path.name}")
         scenario = load_scenario(sample_portfolio_path)

--- a/dashboard/pages/2_Portfolio_Builder.py
+++ b/dashboard/pages/2_Portfolio_Builder.py
@@ -8,7 +8,11 @@ import streamlit as st
 import yaml
 
 from dashboard.app import apply_theme, render_settings_sidebar
-from dashboard.utils import apply_promoted_alpha_shares, normalize_share
+from dashboard.utils import (
+    apply_promoted_alpha_shares,
+    bundled_portfolio_template_path,
+    normalize_share,
+)
 from pa_core.portfolio import PortfolioAggregator
 from pa_core.schema import Portfolio, load_scenario
 
@@ -76,15 +80,32 @@ def main() -> None:
             help="Optional. Included in the exported YAML under alpha_shares metadata.",
         )
 
+    sample_portfolio_path = bundled_portfolio_template_path()
     uploaded = st.file_uploader("Upload Asset Library YAML", type=["yaml", "yml"])
-    if uploaded is None:
-        st.info("Upload an asset library YAML to begin.")
+    use_sample_portfolio = st.checkbox(
+        "Load bundled sample portfolio",
+        value=False,
+        help="Loads the starter scenario YAML so you can build weights without uploading a file.",
+    )
+    if sample_portfolio_path.exists():
+        st.download_button(
+            "Download starter portfolio YAML",
+            sample_portfolio_path.read_text(),
+            file_name=sample_portfolio_path.name,
+            mime="application/x-yaml",
+        )
+    if uploaded is None and not use_sample_portfolio:
+        st.info("Upload an asset library YAML or load the bundled sample portfolio to begin.")
         return
 
-    with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp:
-        tmp.write(uploaded.getvalue())
-        tmp.flush()  # Ensure data is written to disk
-        scenario = load_scenario(tmp.name)
+    if uploaded is not None:
+        with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp:
+            tmp.write(uploaded.getvalue())
+            tmp.flush()  # Ensure data is written to disk
+            scenario = load_scenario(tmp.name)
+    else:
+        st.caption(f"Using bundled sample: {sample_portfolio_path.name}")
+        scenario = load_scenario(sample_portfolio_path)
 
     if not scenario.assets:
         st.warning("No assets found in file.")

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -12,7 +12,7 @@ from typing import Any
 import pandas as pd
 
 from pa_core.config import ModelConfig, normalize_share
-from pa_core.data import load_index_returns
+from pa_core.data import DataImportAgent, load_index_returns
 from pa_core.sleeve_suggestor import generate_sleeve_frontier, suggest_sleeve_sizes
 
 # Keep dashboard normalization aligned with core config behavior.
@@ -137,6 +137,13 @@ def config_capital_defaults(config: ModelConfig | None) -> dict[str, float]:
 # an end-to-end example without uploading their own file (see issue #1900).
 SAMPLE_INDEX_FILENAME = "sp500tr_fred_divyield.csv"
 SAMPLE_FINANCING_MODE = "per_path"
+SAMPLE_ASSET_TIMESERIES_FILENAME = "asset_timeseries_wide_returns.csv"
+SAMPLE_PORTFOLIO_TEMPLATE_FILENAME = "scenario_template.yaml"
+
+
+def _repo_template_path(filename: str) -> Path:
+    """Return a repo-shipped dashboard template path."""
+    return Path(__file__).resolve().parents[1] / "templates" / filename
 
 
 def bundled_sample_index_path() -> Path:
@@ -160,6 +167,22 @@ def load_bundled_sample_index() -> pd.Series:
     """
     path = bundled_sample_index_path()
     return load_index_returns(path)
+
+
+def bundled_asset_timeseries_path() -> Path:
+    """Return the bundled wide-format asset time-series CSV path."""
+    return _repo_template_path(SAMPLE_ASSET_TIMESERIES_FILENAME)
+
+
+def bundled_portfolio_template_path() -> Path:
+    """Return the starter scenario YAML used by Portfolio Builder samples."""
+    return _repo_template_path(SAMPLE_PORTFOLIO_TEMPLATE_FILENAME)
+
+
+def load_bundled_asset_returns() -> pd.DataFrame:
+    """Return parsed bundled asset returns for no-upload dashboard previews."""
+    importer = DataImportAgent(min_obs=1)
+    return importer.load(bundled_asset_timeseries_path())
 
 
 def build_sample_model_config(**overrides: Any) -> ModelConfig:
@@ -324,4 +347,9 @@ __all__ = [
     "SAMPLE_INDEX_FILENAME",
     "bundled_sample_index_path",
     "load_bundled_sample_index",
+    "SAMPLE_ASSET_TIMESERIES_FILENAME",
+    "SAMPLE_PORTFOLIO_TEMPLATE_FILENAME",
+    "bundled_asset_timeseries_path",
+    "bundled_portfolio_template_path",
+    "load_bundled_asset_returns",
 ]

--- a/tests/test_dashboard_sample_paths.py
+++ b/tests/test_dashboard_sample_paths.py
@@ -1,0 +1,69 @@
+"""No-upload dashboard sample paths for Asset Library and Portfolio Builder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from dashboard.utils import (
+    SAMPLE_ASSET_TIMESERIES_FILENAME,
+    SAMPLE_PORTFOLIO_TEMPLATE_FILENAME,
+    bundled_asset_timeseries_path,
+    bundled_portfolio_template_path,
+    load_bundled_asset_returns,
+)
+from pa_core.schema import load_scenario
+from tests.test_portfolio_builder_page import FakeStreamlit, _Asset, _Scenario, _load_module
+
+
+def test_asset_library_bundled_sample_returns_are_usable() -> None:
+    path = bundled_asset_timeseries_path()
+    parsed = load_bundled_asset_returns()
+
+    assert path.exists()
+    assert path.name == SAMPLE_ASSET_TIMESERIES_FILENAME
+    assert isinstance(parsed, pd.DataFrame)
+    assert {"date", "id", "return"}.issubset(parsed.columns)
+    assert parsed["id"].nunique() > 1
+    assert not parsed["return"].isna().any()
+
+
+def test_portfolio_builder_bundled_sample_template_loads_assets() -> None:
+    path = bundled_portfolio_template_path()
+    scenario = load_scenario(path)
+
+    assert path.exists()
+    assert path.name == SAMPLE_PORTFOLIO_TEMPLATE_FILENAME
+    assert scenario.assets
+    assert scenario.portfolios
+
+
+def test_dashboard_pages_expose_no_upload_sample_affordances() -> None:
+    asset_source = Path("dashboard/pages/1_Asset_Library.py").read_text()
+    portfolio_source = Path("dashboard/pages/2_Portfolio_Builder.py").read_text()
+
+    assert "Use bundled sample asset data (no upload needed)" in asset_source
+    assert "Download asset return template" in asset_source
+    assert "Load bundled sample portfolio" in portfolio_source
+    assert "Download starter portfolio YAML" in portfolio_source
+
+
+def test_portfolio_builder_loads_bundled_sample_without_upload(monkeypatch) -> None:
+    fake_st = FakeStreamlit("streamlit", number_inputs=[0.5, 0.5, 1.0, 0.0])
+    fake_st._checkbox_values = [True]
+    module = _load_module(monkeypatch, fake_st)
+
+    loaded_paths: list[Any] = []
+
+    def fake_load_scenario(path: Any) -> _Scenario:
+        loaded_paths.append(path)
+        return _Scenario([_Asset("A"), _Asset("B")], correlations="corr")
+
+    module["main"].__globals__["load_scenario"] = fake_load_scenario
+    module["main"]()
+
+    assert loaded_paths == [bundled_portfolio_template_path()]
+    assert ("checkbox", "Load bundled sample portfolio") in fake_st.calls
+    assert not any(call[0] == "info" for call in fake_st.calls)

--- a/tests/test_dashboard_sample_paths.py
+++ b/tests/test_dashboard_sample_paths.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import runpy
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import pytest
 
 from dashboard.utils import (
     SAMPLE_ASSET_TIMESERIES_FILENAME,
@@ -15,7 +17,13 @@ from dashboard.utils import (
     load_bundled_asset_returns,
 )
 from pa_core.schema import load_scenario
-from tests.test_portfolio_builder_page import FakeStreamlit, _Asset, _Scenario, _load_module
+from tests.test_portfolio_builder_page import (
+    FakeStreamlit,
+    _Asset,
+    _patch_module_global,
+    _Scenario,
+    _load_module,
+)
 
 
 def test_asset_library_bundled_sample_returns_are_usable() -> None:
@@ -67,3 +75,49 @@ def test_portfolio_builder_loads_bundled_sample_without_upload(monkeypatch) -> N
     assert loaded_paths == [bundled_portfolio_template_path()]
     assert ("checkbox", "Load bundled sample portfolio") in fake_st.calls
     assert not any(call[0] == "info" for call in fake_st.calls)
+
+
+def test_asset_library_reports_missing_bundled_sample_when_selected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    module = runpy.run_path("dashboard/pages/1_Asset_Library.py", run_name="page")
+    st_mod = module["st"]
+    messages: list[str] = []
+
+    module["main"].__globals__["render_settings_sidebar"] = lambda: (None, "theme.yaml")
+    module["main"].__globals__["apply_theme"] = lambda *_args, **_kwargs: None
+    module["main"].__globals__["bundled_asset_timeseries_path"] = lambda: (
+        tmp_path / "missing_asset_timeseries.csv"
+    )
+    monkeypatch.setattr(st_mod, "title", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(st_mod, "markdown", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(st_mod, "checkbox", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(st_mod, "caption", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(st_mod, "file_uploader", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(st_mod, "error", lambda message: messages.append(message))
+
+    module["main"]()
+
+    assert messages == [
+        "Bundled sample asset data is unavailable. Upload asset return data instead."
+    ]
+
+
+def test_portfolio_builder_reports_missing_bundled_sample_when_selected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_st = FakeStreamlit("streamlit")
+    fake_st._checkbox_values = [True]
+    module = _load_module(monkeypatch, fake_st)
+    _patch_module_global(
+        module,
+        "bundled_portfolio_template_path",
+        lambda: tmp_path / "missing_starter_portfolio.yaml",
+    )
+
+    module["main"]()
+
+    assert (
+        "error",
+        "Bundled starter portfolio is unavailable. Upload an asset library YAML instead.",
+    ) in fake_st.calls

--- a/tests/test_dashboard_sample_paths.py
+++ b/tests/test_dashboard_sample_paths.py
@@ -28,10 +28,10 @@ from tests.test_portfolio_builder_page import (
 
 def test_asset_library_bundled_sample_returns_are_usable() -> None:
     path = bundled_asset_timeseries_path()
-    parsed = load_bundled_asset_returns()
 
     assert path.exists()
     assert path.name == SAMPLE_ASSET_TIMESERIES_FILENAME
+    parsed = load_bundled_asset_returns()
     assert isinstance(parsed, pd.DataFrame)
     assert {"date", "id", "return"}.issubset(parsed.columns)
     assert parsed["id"].nunique() > 1
@@ -40,10 +40,10 @@ def test_asset_library_bundled_sample_returns_are_usable() -> None:
 
 def test_portfolio_builder_bundled_sample_template_loads_assets() -> None:
     path = bundled_portfolio_template_path()
-    scenario = load_scenario(path)
 
     assert path.exists()
     assert path.name == SAMPLE_PORTFOLIO_TEMPLATE_FILENAME
+    scenario = load_scenario(path)
     assert scenario.assets
     assert scenario.portfolios
 

--- a/tests/test_portfolio_builder_page.py
+++ b/tests/test_portfolio_builder_page.py
@@ -44,6 +44,7 @@ class FakeStreamlit(ModuleType):
         self._number_inputs = list(number_inputs or [])
         self._file_uploader = file_uploader
         self._button_value = button_value
+        self._checkbox_values: list[bool] = []
         self.sidebar = _FakeSidebar(self.calls)
 
     def title(self, message: str) -> None:
@@ -51,6 +52,9 @@ class FakeStreamlit(ModuleType):
 
     def info(self, message: str) -> None:
         self.calls.append(("info", message))
+
+    def caption(self, message: str) -> None:
+        self.calls.append(("caption", message))
 
     def warning(self, message: str) -> None:
         self.calls.append(("warning", message))
@@ -77,6 +81,12 @@ class FakeStreamlit(ModuleType):
     def file_uploader(self, label: str, **kwargs: Any) -> Any | None:
         self.calls.append(("file_uploader", label))
         return self._file_uploader
+
+    def checkbox(self, label: str, **kwargs: Any) -> bool:
+        self.calls.append(("checkbox", label))
+        if self._checkbox_values:
+            return self._checkbox_values.pop(0)
+        return bool(kwargs.get("value", False))
 
     def button(self, label: str) -> bool:
         self.calls.append(("button", label))
@@ -164,7 +174,14 @@ def test_portfolio_builder_requires_upload(monkeypatch: pytest.MonkeyPatch) -> N
 
     module["main"]()
 
-    assert any(call == ("info", "Upload an asset library YAML to begin.") for call in fake_st.calls)
+    assert any(
+        call
+        == (
+            "info",
+            "Upload an asset library YAML or load the bundled sample portfolio to begin.",
+        )
+        for call in fake_st.calls
+    )
 
 
 def test_portfolio_builder_empty_assets_warns(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_portfolio_builder_page.py
+++ b/tests/test_portfolio_builder_page.py
@@ -194,6 +194,55 @@ def test_portfolio_builder_empty_assets_warns(monkeypatch: pytest.MonkeyPatch) -
     assert any(call == ("warning", "No assets found in file.") for call in fake_st.calls)
 
 
+def test_portfolio_builder_closes_uploaded_temp_before_loading(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_st = FakeStreamlit("streamlit", file_uploader=_Upload(b"assets: []"))
+    module = _load_module(monkeypatch, fake_st)
+    temp_path = tmp_path / "uploaded.yaml"
+    observed_paths: list[Path] = []
+
+    class _FakeNamedTemporaryFile:
+        def __init__(self, **_kwargs: Any) -> None:
+            self.name = str(temp_path)
+            self.closed = False
+
+        def __enter__(self) -> "_FakeNamedTemporaryFile":
+            return self
+
+        def __exit__(self, *_exc: Any) -> bool:
+            self.closed = True
+            return False
+
+        def write(self, payload: bytes) -> int:
+            temp_path.write_bytes(payload)
+            return len(payload)
+
+        def flush(self) -> None:
+            return None
+
+    fake_temp = _FakeNamedTemporaryFile()
+    monkeypatch.setattr(
+        module["main"].__globals__["tempfile"],
+        "NamedTemporaryFile",
+        lambda **kwargs: fake_temp,
+    )
+
+    def fake_load_scenario(path: Path) -> _Scenario:
+        observed_paths.append(path)
+        assert path.exists()
+        assert fake_temp.closed
+        return _Scenario([])
+
+    _patch_module_global(module, "load_scenario", fake_load_scenario)
+
+    module["main"]()
+
+    assert len(observed_paths) == 1
+    assert not observed_paths[0].exists()
+    assert any(call == ("warning", "No assets found in file.") for call in fake_st.calls)
+
+
 def test_portfolio_builder_zero_weights_warns(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_st = FakeStreamlit(
         "streamlit",

--- a/tests/test_portfolio_builder_page.py
+++ b/tests/test_portfolio_builder_page.py
@@ -199,39 +199,12 @@ def test_portfolio_builder_closes_uploaded_temp_before_loading(
 ) -> None:
     fake_st = FakeStreamlit("streamlit", file_uploader=_Upload(b"assets: []"))
     module = _load_module(monkeypatch, fake_st)
-    temp_path = tmp_path / "uploaded.yaml"
     observed_paths: list[Path] = []
-
-    class _FakeNamedTemporaryFile:
-        def __init__(self, **_kwargs: Any) -> None:
-            self.name = str(temp_path)
-            self.closed = False
-
-        def __enter__(self) -> "_FakeNamedTemporaryFile":
-            return self
-
-        def __exit__(self, *_exc: Any) -> bool:
-            self.closed = True
-            return False
-
-        def write(self, payload: bytes) -> int:
-            temp_path.write_bytes(payload)
-            return len(payload)
-
-        def flush(self) -> None:
-            return None
-
-    fake_temp = _FakeNamedTemporaryFile()
-    monkeypatch.setattr(
-        module["main"].__globals__["tempfile"],
-        "NamedTemporaryFile",
-        lambda **kwargs: fake_temp,
-    )
 
     def fake_load_scenario(path: Path) -> _Scenario:
         observed_paths.append(path)
         assert path.exists()
-        assert fake_temp.closed
+        assert path.read_bytes() == b"assets: []"
         return _Scenario([])
 
     _patch_module_global(module, "load_scenario", fake_load_scenario)


### PR DESCRIPTION
Closes #2026

## Summary
- add shared helpers for bundled asset-return and portfolio template paths
- add no-upload sample/template affordances to Asset Library and Portfolio Builder
- cover the sample paths with tests/test_dashboard_sample_paths.py

## Validation
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run pytest tests/test_dashboard_sample_paths.py tests/test_dashboard_asset_library.py tests/test_portfolio_builder_page.py -q
- deliberate break: renamed the Portfolio Builder sample affordance and confirmed tests/test_dashboard_sample_paths.py::test_dashboard_pages_expose_no_upload_sample_affordances failed, then restored it
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff check dashboard/utils.py dashboard/pages/1_Asset_Library.py dashboard/pages/2_Portfolio_Builder.py tests/test_dashboard_sample_paths.py tests/test_portfolio_builder_page.py
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff format --check dashboard/utils.py dashboard/pages/1_Asset_Library.py dashboard/pages/2_Portfolio_Builder.py tests/test_dashboard_sample_paths.py tests/test_portfolio_builder_page.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * **Asset Library:** Added an offline option to “Use bundled sample asset data,” including a CSV “Download asset return template” when available.
  * **Portfolio Builder:** Added “Load bundled sample portfolio,” plus a “Download starter portfolio YAML” button when available.
* **Bug Fixes**
  * Refined no-upload behavior and improved messages when bundled sample files are missing.
  * Improved uploaded-file handling to ensure temporary inputs are properly cleaned up and available during loading.
* **Tests**
  * Added coverage for bundled flows, UI affordances, missing-file errors, and temp-file close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->