### PR TITLE
Improve dashboard empty-state guidance

### DIFF
--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -26,7 +26,12 @@ from dashboard.components.llm_settings import (
     resolve_llm_provider_config,
 )
 from dashboard.glossary import tooltip
-from dashboard.utils import remember_current_scenario, run_sleeve_frontier, run_sleeve_suggestions
+from dashboard.utils import (
+    friendly_validation_error_message,
+    remember_current_scenario,
+    run_sleeve_frontier,
+    run_sleeve_suggestions,
+)
 from pa_core import cli as pa_cli
 from pa_core.backend import SUPPORTED_BACKENDS
 from pa_core.config import load_config
@@ -2167,7 +2172,7 @@ def main() -> None:
                 st.session_state.wizard_step = 5  # Go to review step
                 st.rerun()
         except Exception as e:
-            st.sidebar.error(f"Error loading config: {e}")
+            st.sidebar.error(friendly_validation_error_message(e))
 
     # Main wizard interface
     current_step = st.session_state.wizard_step
@@ -2253,7 +2258,11 @@ def main() -> None:
             if idx is not None:
                 # Convert config to YAML and run simulation
                 yaml_data = _build_yaml_from_config(config)
-                model_config = load_config(yaml_data)
+                try:
+                    model_config = load_config(yaml_data)
+                except Exception as exc:
+                    st.error(friendly_validation_error_message(exc))
+                    st.stop()
                 with _temp_yaml_file(yaml_data) as cfg_path:
                     # Write index data to a secure temp file
                     fd, idx_path = tempfile.mkstemp(suffix=".csv")
@@ -2279,7 +2288,10 @@ def main() -> None:
                             pa_cli.main(args)
                         sim_ok = True
                     except Exception as exc:
-                        st.error(f"❌ Simulation failed: {exc}")
+                        st.error(
+                            "Simulation could not complete from the current dashboard inputs. "
+                            f"{friendly_validation_error_message(exc)}"
+                        )
                     finally:
                         # Cleanup index temp file
                         try:

--- a/dashboard/pages/4_Results.py
+++ b/dashboard/pages/4_Results.py
@@ -23,7 +23,7 @@ from dashboard.app import (
 from dashboard.components.comparison_llm import render_comparison_llm_panel
 from dashboard.components.explain_results import render_explain_results_panel
 from dashboard.glossary import tooltip
-from dashboard.utils import current_results_path
+from dashboard.utils import RESULTS_EMPTY_STATE_MESSAGE, current_results_path
 from pa_core.contracts import (
     SUMMARY_AGENT_COLUMN,
     SUMMARY_ANN_RETURN_COLUMN,
@@ -197,7 +197,7 @@ def main() -> None:
     xlsx, theme_path = render_settings_sidebar(_default_results_path())
     apply_theme(theme_path)
     if not Path(xlsx).exists():
-        st.warning(f"File {xlsx} not found")
+        st.info(RESULTS_EMPTY_STATE_MESSAGE)
         st.stop()
     summary, paths = load_data(xlsx)
 

--- a/dashboard/pages/5_Scenario_Grid.py
+++ b/dashboard/pages/5_Scenario_Grid.py
@@ -18,6 +18,7 @@ from dashboard.utils import (
     build_alpha_shares_payload,
     build_sample_model_config,
     bump_session_token,
+    friendly_validation_error_message,
     load_bundled_sample_index,
     make_grid_cache_key,
 )
@@ -475,13 +476,10 @@ def main() -> None:
                 )
             except Exception:
                 pass
-        except ValidationError:
-            st.error(
-                "The sample scenario-grid settings could not be validated. "
-                "Refresh the defaults or use Scenario Wizard to build a configuration."
-            )
+        except ValidationError as exc:
+            st.error(friendly_validation_error_message(exc))
         except ValueError as exc:
-            st.error(f"Invalid configuration: {exc}")
+            st.error(friendly_validation_error_message(exc))
         except RuntimeError as exc:
             st.error(f"Simulation failed: {exc}")
 

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -21,6 +21,7 @@ from dashboard.utils import (
     config_capital_defaults,
     current_index_returns,
     current_scenario_config,
+    friendly_validation_error_message,
     load_bundled_sample_index,
 )
 from pa_core.config import ModelConfig
@@ -266,13 +267,10 @@ def main() -> None:
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             )
 
-        except ValidationError:  # pragma: no cover - runtime UX
-            st.error(
-                "The sample stress-test settings could not be validated. "
-                "Refresh the defaults or run a scenario first."
-            )
+        except ValidationError as exc:  # pragma: no cover - runtime UX
+            st.error(friendly_validation_error_message(exc))
         except Exception as exc:  # pragma: no cover - runtime UX
-            st.error(str(exc))
+            st.error(friendly_validation_error_message(exc))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/dashboard/pages/6_Stress_Lab.py
+++ b/dashboard/pages/6_Stress_Lab.py
@@ -270,7 +270,7 @@ def main() -> None:
         except ValidationError as exc:  # pragma: no cover - runtime UX
             st.error(friendly_validation_error_message(exc))
         except Exception as exc:  # pragma: no cover - runtime UX
-            st.error(friendly_validation_error_message(exc))
+            st.error(f"Stress Lab run failed: {exc}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/dashboard/pages/7_Run_Logs.py
+++ b/dashboard/pages/7_Run_Logs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import streamlit as st
 
+from dashboard.utils import RUN_LOGS_EMPTY_STATE_MESSAGE
 from pa_core.contracts import (
     MANIFEST_FILENAME,
     RUN_END_FILENAME,
@@ -18,7 +19,7 @@ st.title("Run Logs 🧾")
 
 runs_dir = Path(RUNS_DIR_NAME)
 if not runs_dir.exists():
-    st.info("No runs directory found yet. Launch a run with --log-json to create logs.")
+    st.info(RUN_LOGS_EMPTY_STATE_MESSAGE)
     st.stop()
 
 run_ids = sorted([p.name for p in runs_dir.iterdir() if p.is_dir()], reverse=True)

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -17,9 +17,62 @@ from pa_core.sleeve_suggestor import generate_sleeve_frontier, suggest_sleeve_si
 
 # Keep dashboard normalization aligned with core config behavior.
 
+RESULTS_EMPTY_STATE_MESSAGE = (
+    "No results yet - complete a run in the Scenario Wizard, Scenario Grid, or Stress Lab "
+    "to generate output."
+)
+RUN_LOGS_EMPTY_STATE_MESSAGE = "No runs yet - run a scenario and its history will appear here."
+
 CURRENT_SCENARIO_CONFIG_KEY = "dashboard_current_scenario_config"
 CURRENT_RESULTS_PATH_KEY = "dashboard_current_results_path"
 CURRENT_INDEX_RETURNS_KEY = "dashboard_current_index_returns"
+
+_CONFIG_FIELD_LABELS = {
+    "financing_mode": "Financing draw mode",
+    "financing_model": "Financing model",
+    "financing_schedule_path": "Financing schedule file",
+    "N_SIMULATIONS": "Number of simulations",
+    "Number of simulations": "Number of simulations",
+    "N_MONTHS": "Number of months",
+    "Number of months": "Number of months",
+    "risk_metrics": "Risk metrics",
+    "total_fund_capital": "Total fund capital",
+    "external_pa_capital": "External PA capital",
+    "active_ext_capital": "Active extension capital",
+    "internal_pa_capital": "Internal PA capital",
+}
+
+
+def friendly_validation_error_message(exc: BaseException) -> str:
+    """Return an operator-facing message for config validation failures."""
+
+    validation_exc = exc.__cause__ if exc.__cause__ is not None else exc
+    fields: list[str] = []
+    errors = getattr(validation_exc, "errors", None)
+    if callable(errors):
+        for error in errors():
+            loc = error.get("loc", ())
+            field = str(loc[-1]) if loc else ""
+            label = _CONFIG_FIELD_LABELS.get(field)
+            if label and label not in fields:
+                fields.append(label)
+
+    raw = str(exc)
+    for field, label in _CONFIG_FIELD_LABELS.items():
+        if field in raw and label not in fields:
+            fields.append(label)
+
+    if not fields:
+        return (
+            "The scenario settings need a correction before the dashboard can run them. "
+            "Review the highlighted inputs and try again."
+        )
+
+    field_list = ", ".join(fields)
+    return (
+        f"The scenario settings need a correction before the dashboard can run them: "
+        f"{field_list}. Choose or update the highlighted inputs, then try again."
+    )
 
 
 def remember_current_scenario(

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -18,10 +18,12 @@ from pa_core.sleeve_suggestor import generate_sleeve_frontier, suggest_sleeve_si
 # Keep dashboard normalization aligned with core config behavior.
 
 RESULTS_EMPTY_STATE_MESSAGE = (
-    "No results yet - complete a run in the Scenario Wizard, Scenario Grid, or Stress Lab "
-    "to generate output."
+    "No results yet - complete a run in the Scenario Wizard, then return here to inspect "
+    "the generated workbook."
 )
-RUN_LOGS_EMPTY_STATE_MESSAGE = "No runs yet - run a scenario and its history will appear here."
+RUN_LOGS_EMPTY_STATE_MESSAGE = (
+    "No run logs yet - enable JSON logging for a run, then return here to inspect its history."
+)
 
 CURRENT_SCENARIO_CONFIG_KEY = "dashboard_current_scenario_config"
 CURRENT_RESULTS_PATH_KEY = "dashboard_current_results_path"

--- a/tests/test_dashboard_empty_states.py
+++ b/tests/test_dashboard_empty_states.py
@@ -12,18 +12,21 @@ from pa_core.config import ModelConfig, load_config
 
 def test_results_empty_state_uses_operator_guidance() -> None:
     assert RESULTS_EMPTY_STATE_MESSAGE == (
-        "No results yet - complete a run in the Scenario Wizard, Scenario Grid, "
-        "or Stress Lab to generate output."
+        "No results yet - complete a run in the Scenario Wizard, then return here "
+        "to inspect the generated workbook."
     )
     assert "Outputs.xlsx" not in RESULTS_EMPTY_STATE_MESSAGE
     assert "File " not in RESULTS_EMPTY_STATE_MESSAGE
+    assert "Scenario Grid" not in RESULTS_EMPTY_STATE_MESSAGE
+    assert "Stress Lab" not in RESULTS_EMPTY_STATE_MESSAGE
 
 
-def test_run_logs_empty_state_hides_cli_flag() -> None:
+def test_run_logs_empty_state_mentions_json_logging_without_cli_flag() -> None:
     assert RUN_LOGS_EMPTY_STATE_MESSAGE == (
-        "No runs yet - run a scenario and its history will appear here."
+        "No run logs yet - enable JSON logging for a run, then return here to inspect its history."
     )
     assert "--log-json" not in RUN_LOGS_EMPTY_STATE_MESSAGE
+    assert "JSON logging" in RUN_LOGS_EMPTY_STATE_MESSAGE
 
 
 def test_validation_error_translator_uses_human_field_label() -> None:

--- a/tests/test_dashboard_empty_states.py
+++ b/tests/test_dashboard_empty_states.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from dashboard.utils import (
+    RESULTS_EMPTY_STATE_MESSAGE,
+    RUN_LOGS_EMPTY_STATE_MESSAGE,
+    friendly_validation_error_message,
+)
+from pa_core.config import ModelConfig, load_config
+
+
+def test_results_empty_state_uses_operator_guidance() -> None:
+    assert RESULTS_EMPTY_STATE_MESSAGE == (
+        "No results yet - complete a run in the Scenario Wizard, Scenario Grid, "
+        "or Stress Lab to generate output."
+    )
+    assert "Outputs.xlsx" not in RESULTS_EMPTY_STATE_MESSAGE
+    assert "File " not in RESULTS_EMPTY_STATE_MESSAGE
+
+
+def test_run_logs_empty_state_hides_cli_flag() -> None:
+    assert RUN_LOGS_EMPTY_STATE_MESSAGE == (
+        "No runs yet - run a scenario and its history will appear here."
+    )
+    assert "--log-json" not in RUN_LOGS_EMPTY_STATE_MESSAGE
+
+
+def test_validation_error_translator_uses_human_field_label() -> None:
+    with pytest.raises(Exception) as exc_info:
+        ModelConfig.model_validate({"Number of simulations": 1, "Number of months": 1})
+
+    message = friendly_validation_error_message(exc_info.value)
+
+    assert "Financing draw mode" in message
+    assert "financing_mode" not in message
+    assert "pydantic.dev" not in message
+
+
+def test_validation_error_translator_handles_load_config_wrapped_errors() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        load_config({"Number of simulations": 1, "Number of months": 1})
+
+    message = friendly_validation_error_message(exc_info.value)
+
+    assert "Financing draw mode" in message
+    assert "financing_mode" not in message
+    assert "pydantic.dev" not in message

--- a/tests/test_dashboard_run_logs_page.py
+++ b/tests/test_dashboard_run_logs_page.py
@@ -78,7 +78,11 @@ def test_run_logs_no_runs_directory(monkeypatch, tmp_path: Path) -> None:
         runpy.run_path(str(_page_path()))
 
     assert any(
-        call == ("info", "No runs yet - run a scenario and its history will appear here.")
+        call
+        == (
+            "info",
+            "No run logs yet - enable JSON logging for a run, then return here to inspect its history.",
+        )
         for call in fake_st.calls
     )
 

--- a/tests/test_dashboard_run_logs_page.py
+++ b/tests/test_dashboard_run_logs_page.py
@@ -78,11 +78,7 @@ def test_run_logs_no_runs_directory(monkeypatch, tmp_path: Path) -> None:
         runpy.run_path(str(_page_path()))
 
     assert any(
-        call
-        == (
-            "info",
-            "No runs directory found yet. Launch a run with --log-json to create logs.",
-        )
+        call == ("info", "No runs yet - run a scenario and its history will appear here.")
         for call in fake_st.calls
     )
 


### PR DESCRIPTION
Closes #2021

## Summary
- replace Results and Run Logs developer-facing empty states with operator guidance
- add a shared dashboard validation-error translator for known config fields
- route Scenario Wizard, Scenario Grid, and Stress Lab validation failures through the friendly copy

## Validation
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run pytest tests/test_dashboard_empty_states.py tests/test_dashboard_run_logs_page.py tests/test_scenario_grid.py tests/test_stress_lab.py tests/test_wizard_helpers.py -q
- deliberate break: temporarily restored `File Outputs.xlsx not found`; tests/test_dashboard_empty_states.py::test_results_empty_state_uses_operator_guidance failed, then fix restored
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff check dashboard/utils.py dashboard/pages/3_Scenario_Wizard.py dashboard/pages/4_Results.py dashboard/pages/5_Scenario_Grid.py dashboard/pages/6_Stress_Lab.py dashboard/pages/7_Run_Logs.py tests/test_dashboard_empty_states.py tests/test_dashboard_run_logs_page.py
- UV_CACHE_DIR=/tmp/pd-workloop-uv-cache uv run ruff format --check dashboard/utils.py dashboard/pages/3_Scenario_Wizard.py dashboard/pages/4_Results.py dashboard/pages/5_Scenario_Grid.py dashboard/pages/6_Stress_Lab.py dashboard/pages/7_Run_Logs.py tests/test_dashboard_empty_states.py tests/test_dashboard_run_logs_page.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-friendly, field-specific validation error messaging across the Scenario Wizard, Scenario Grid, and Stress Lab.
* **Bug Fixes**
  * Standardized “empty state” guidance on Results and Run Logs (replacing warnings/hardcoded text with consistent messages).
  * Improved simulation and stress-test failure messaging to avoid raw exception text.
* **Tests**
  * Added/updated pytest coverage to verify exact empty-state text and validation-message translation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->