### PR TITLE
Adopt shared design-system kit + home run-path discoverability (#2041)

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[theme]
+# Pairs with the shared design-system kit (design-system/ds_streamlit.inject_theme()).
+base = "light"

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -11,6 +11,8 @@ import pandas as pd
 import streamlit as st
 
 from dashboard.glossary import GLOSSARY
+from dashboard.theme import apply_theme as apply_ds_theme
+from dashboard.theme import ds
 from dashboard.utils import bundled_sample_index_path
 from pa_core.contracts import (
     ALL_RETURNS_SHEET_NAME,
@@ -239,6 +241,8 @@ def main() -> None:
         # cosmetic, so a repeat call must not break the page.
         pass
 
+    apply_ds_theme()
+
     st.title("Portable Alpha Dashboard")
     st.write("Select a page from the sidebar or use the links below to begin.")
 
@@ -246,12 +250,30 @@ def main() -> None:
         for term, definition in GLOSSARY.items():
             st.markdown(f"**{term}** – {definition}")
 
+    # Primary "start here" cue: the fastest path to a complete result is a
+    # one-click bundled-sample run on Stress Lab (#2041 home discoverability).
+    _ds = ds()
+    if _ds is not None:
+        _ds.notice(
+            "info",
+            "New here? Start with Stress Lab",
+            "Tick “Use bundled sample data” on Stress Lab (or Scenario Grid) to run a "
+            "complete example in one click — no upload needed.",
+        )
+    st.page_link("pages/6_Stress_Lab.py", label="▶ Start here — Stress Lab (one-click example)")
+
+    # Group the tools so first-timers can tell run paths from inputs/outputs, and
+    # where each run's results appear.
+    st.markdown("**Run a scenario**")
+    st.caption("Stress Lab & Scenario Grid show results in-page; the Scenario Wizard writes to the Results page.")
+    st.page_link("pages/6_Stress_Lab.py", label="Stress Lab (presets)")
+    st.page_link("pages/5_Scenario_Grid.py", label="Scenario Grid & Frontier (beta)")
+    st.page_link("pages/3_Scenario_Wizard.py", label="Scenario Wizard")
+
+    st.markdown("**Inputs & outputs**")
     st.page_link("pages/1_Asset_Library.py", label="Asset Library")
     st.page_link("pages/2_Portfolio_Builder.py", label="Portfolio Builder")
-    st.page_link("pages/3_Scenario_Wizard.py", label="Scenario Wizard")
-    st.page_link("pages/4_Results.py", label="Results")
-    st.page_link("pages/5_Scenario_Grid.py", label="Scenario Grid & Frontier (beta)")
-    st.page_link("pages/6_Stress_Lab.py", label="Stress Lab (presets)")
+    st.page_link("pages/4_Results.py", label="Results (Scenario Wizard output)")
 
     _render_getting_started()
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -260,7 +260,7 @@ def main() -> None:
             "Tick “Use bundled sample data” on Stress Lab (or Scenario Grid) to run a "
             "complete example in one click — no upload needed.",
         )
-    st.page_link("pages/6_Stress_Lab.py", label="▶ Start here — Stress Lab (one-click example)")
+    st.page_link("pages/6_Stress_Lab.py", label="Start here → Stress Lab (one-click example)")
 
     # Group the tools so first-timers can tell run paths from inputs/outputs, and
     # where each run's results appear.

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -857,7 +857,7 @@ def _render_progress_bar(current_step: int, total_steps: int = 5) -> None:
 def _render_step_1_analysis_mode(config: Any) -> Any:
     """Step 1: Analysis Mode Selection."""
     st.subheader("Step 1: Analysis Mode & Basic Settings")
-    st.caption("Results will appear on the **Results** page after you complete the run in Step 5.")
+    st.caption("Results will appear on the **Results** page after the run completes.")
 
     col1, col2 = st.columns(2)
 

--- a/dashboard/pages/3_Scenario_Wizard.py
+++ b/dashboard/pages/3_Scenario_Wizard.py
@@ -19,6 +19,7 @@ import yaml
 from dashboard import cli as dashboard_cli
 from dashboard import validation_ui
 from dashboard.app import _DEF_XLSX, apply_theme, render_settings_sidebar
+from dashboard.theme import apply_theme as apply_ds_theme
 from dashboard.components.config_chat import render_config_chat_panel
 from dashboard.components.llm_settings import (
     default_api_key,
@@ -856,6 +857,7 @@ def _render_progress_bar(current_step: int, total_steps: int = 5) -> None:
 def _render_step_1_analysis_mode(config: Any) -> Any:
     """Step 1: Analysis Mode Selection."""
     st.subheader("Step 1: Analysis Mode & Basic Settings")
+    st.caption("Results will appear on the **Results** page after you complete the run in Step 5.")
 
     col1, col2 = st.columns(2)
 
@@ -2340,4 +2342,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point
+    apply_ds_theme()
     main()

--- a/dashboard/theme.py
+++ b/dashboard/theme.py
@@ -1,0 +1,35 @@
+"""Adopt the shared design system (vendored at ../design-system).
+
+Streamlit injects CSS per page-run and it does not persist across pages, so call
+``apply_theme()`` once near the top of every page/entry-point. It is a safe no-op
+when the kit is absent (bare/test environments).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DS_DIR = Path(__file__).resolve().parents[1] / "design-system"
+if _DS_DIR.is_dir() and str(_DS_DIR) not in sys.path:
+    sys.path.insert(0, str(_DS_DIR))
+
+try:  # the kit is vendored by the Workflows design-system sync (sync-manifest.yml)
+    import ds_streamlit as _ds
+except Exception:  # pragma: no cover - kit unavailable in bare/test mode
+    _ds = None
+
+
+def apply_theme() -> None:
+    """Inject the shared Ink & Air theme. No-op if the design-system kit is absent."""
+    if _ds is not None:
+        try:
+            _ds.inject_theme()
+        except Exception:
+            # Theming is cosmetic; never let it break a page render.
+            pass
+
+
+def ds():
+    """Return the design-system Streamlit helper module (or None if unavailable)."""
+    return _ds

--- a/dashboard/theme.py
+++ b/dashboard/theme.py
@@ -7,17 +7,22 @@ when the kit is absent (bare/test environments).
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
+_LOGGER = logging.getLogger(__name__)
 _DS_DIR = Path(__file__).resolve().parents[1] / "design-system"
-if _DS_DIR.is_dir() and str(_DS_DIR) not in sys.path:
-    sys.path.insert(0, str(_DS_DIR))
+_ds = None
 
-try:  # the kit is vendored by the Workflows design-system sync (sync-manifest.yml)
-    import ds_streamlit as _ds
-except Exception:  # pragma: no cover - kit unavailable in bare/test mode
-    _ds = None
+if _DS_DIR.is_dir():
+    if str(_DS_DIR) not in sys.path:
+        sys.path.insert(0, str(_DS_DIR))
+    try:  # the kit is vendored by the Workflows design-system sync (sync-manifest.yml)
+        import ds_streamlit as _ds
+    except ModuleNotFoundError as exc:  # pragma: no cover - kit unavailable in bare/test mode
+        if exc.name != "ds_streamlit":
+            raise
 
 
 def apply_theme() -> None:
@@ -27,7 +32,7 @@ def apply_theme() -> None:
             _ds.inject_theme()
         except Exception:
             # Theming is cosmetic; never let it break a page render.
-            pass
+            _LOGGER.exception("Failed to inject shared Streamlit theme")
 
 
 def ds():

--- a/web/index.html
+++ b/web/index.html
@@ -24,10 +24,11 @@
       __paRenderBC.onmessage = async (e) => {
         const m = e.data;
         if (!m || m.kind !== "request") return;
+        let div;
         try {
           const figjson = JSON.parse(m.figStr);
           const o = m.opts || {};
-          const div = document.createElement("div");
+          div = document.createElement("div");
           div.style.cssText =
             "position:fixed;left:-9999px;top:-9999px;width:" +
             (o.width || 960) +
@@ -45,11 +46,18 @@
             width: o.width || 960,
             height: o.height || 540,
           });
-          Plotly.purge(div);
-          div.remove();
           __paRenderBC.postMessage({ kind: "response", id: m.id, url });
         } catch (err) {
           __paRenderBC.postMessage({ kind: "response", id: m.id, error: String(err) });
+        } finally {
+          if (div) {
+            try {
+              Plotly.purge(div);
+            } catch (purgeErr) {
+              console.warn("Failed to purge Plotly render node", purgeErr);
+            }
+            div.remove();
+          }
         }
       };
 

--- a/web/index.html
+++ b/web/index.html
@@ -64,6 +64,7 @@ dashboard/components/config_chat.py
 dashboard/components/explain_results.py
 dashboard/components/llm_settings.py
 dashboard/glossary.py
+dashboard/theme.py
 dashboard/pages/1_Asset_Library.py
 dashboard/pages/2_Portfolio_Builder.py
 dashboard/pages/3_Scenario_Wizard.py


### PR DESCRIPTION
## Adopt the shared design-system kit (reference adoption) + close #2041

First **adoption** of the fleet design-system kit (`design-system/`, synced from Workflows) — until now every consumer *vendored* the kit but none *imported* it. This wires it into Portable-Alpha and closes the home run-path discoverability finding (#2041).

### What changed
- **`dashboard/theme.py`** — a small adopter that puts `design-system/` on `sys.path`, imports `ds_streamlit`, and exposes `apply_theme()` / `ds()`. Safe no-op if the kit is absent (bare/test mode). Aliased on import (`apply_theme as apply_ds_theme`) because the app already has a `pa_core` `apply_theme(path)`.
- **`.streamlit/config.toml`** — `[theme] base = "light"` to pair with `ds_streamlit.inject_theme()`.
- **`dashboard/app.py` (home)** — inject the theme; add a primary **"▶ Start here — Stress Lab (one-click example)"** CTA via `ds.notice(...)`; group links into **Run a scenario** vs **Inputs & outputs**; disclose where each run's output appears (in-page vs the Results page). (#2041)
- **`dashboard/pages/3_Scenario_Wizard.py`** — inject the theme; Step-1 note: "Results will appear on the **Results** page after you complete the run." (#2041)

### Verification
- Browser-verified (headless Chromium): home renders the themed `ds-notice` CTA + grouped links + output disclosure; Wizard Step 1 shows the Results-routing note; no errors.
- `66 passed` across the dashboard/home/page/wizard test files (`test_dashboard*`, `test_dashboard_pages`, `test_dashboard_empty_states`, `test_dashboard_dead_ux_1907`, `test_wizard_*`).

### Follow-up (mechanical, templated by this PR)
The remaining pages are unthemed for now; each needs the same one-liner to be fully consistent:
```python
from dashboard.theme import apply_theme as apply_ds_theme
# ...in the page's __main__ block (or after set_page_config on Run_Logs):
apply_ds_theme()
```
Pages: `1_Asset_Library`, `2_Portfolio_Builder`, `4_Results`, `5_Scenario_Grid`, `6_Stress_Lab`, `7_Run_Logs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set the app to a light default theme and applied a shared dashboard design system for consistent styling.
* **UI/UX**
  * Refreshed the home page navigation into clearer sections, updated link labels, and added an onboarding prompt for bundled sample data.
  * Improved Scenario Wizard messaging to clarify when results appear.
* **Bug Fixes / Reliability**
  * Improved in-browser rendering cleanup to better prevent leftover off-screen content and reduce secondary render errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->