### PR TITLE
Format offline web closure test

### DIFF
--- a/tests/test_web_no_external_cdn.py
+++ b/tests/test_web_no_external_cdn.py
@@ -226,9 +226,7 @@ def test_pure_pypi_wheel_closure_is_vendored() -> None:
         if _lock_key(requirement.name) in packages
     )
     pyodide_seed_names.update({"micropip", "packaging"})
-    _, pyodide_metadata_requirements = _expanded_pyodide_seed_names(
-        pyodide_seed_names, packages
-    )
+    _, pyodide_metadata_requirements = _expanded_pyodide_seed_names(pyodide_seed_names, packages)
     queue.extend(
         _lock_key(requirement.name)
         for requirement in pyodide_metadata_requirements


### PR DESCRIPTION
## Summary

Follow-up for #2052 / merged PR #2053 verifier CONCERNS.

The provider comparison accepted the rich/offline dependency implementation functionally, but Anthropic correctly flagged that the post-merge ci.yml lint-format job failed. This PR applies the Black-only formatting change needed for tests/test_web_no_external_cdn.py on current main.

## Validation

- UV_CACHE_DIR=/tmp/paem-uv-cache uv run black --check --line-length 100 --exclude "(\.workflows-lib|node_modules)" .
- UV_CACHE_DIR=/tmp/paem-uv-cache uv run pytest tests/test_web_no_external_cdn.py::test_pyodide_wheel_closure_is_vendored tests/test_web_no_external_cdn.py::test_pure_pypi_wheel_closure_is_vendored tests/test_web_no_external_cdn.py::test_offline_source_manifest_lists_every_app_module -q
- git diff --check

Closes #2052 after this follow-up merges and verifier passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reformatted internal test code for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->