### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -111,7 +111,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           steps.eligibility.outputs.should-run == 'true' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6c3391d38bbc20a4577ac42b9aa6c9dc4e462c09" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@a525e6e3e2431d302073de65723c6e022f4b02fa" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -180,7 +180,7 @@ jobs:
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request' &&
           steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@6c3391d38bbc20a4577ac42b9aa6c9dc4e462c09" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@a525e6e3e2431d302073de65723c6e022f4b02fa" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}

--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `cd5687d7ae00a31b9cb6ddbf94cfb94c0e4fdf69`
**Template hash:** `57b9e3dbcb23`
**Sync branch:** `sync/workflows-57b9e3dbcb23`
**Consumer repo:** `stranske/Portable-Alpha-Extension-Model`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Portable-Alpha-Extension-Model","source_repository":"stranske/Workflows","source_sha":"cd5687d7ae00a31b9cb6ddbf94cfb94c0e4fdf69","template_hash":"57b9e3dbcb23","sync_branch":"sync/workflows-57b9e3dbcb23","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28213448656","run_attempt":"1","changes_count":2} -->