### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.20
+RUFF_VERSION=0.15.22
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.1.0
+MYPY_VERSION=2.3.0
 PYTEST_VERSION=9.1.1
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.15.0
+COVERAGE_VERSION=7.15.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,10 +142,10 @@ llm = [
 
 # Development dependencies
 dev = [
-    "ruff==0.15.20",
+    "ruff==0.15.22",
     "black>=26.5.1",
     "isort>=8.0.1",
-    "mypy>=2.1.0",
+    "mypy==2.3.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
     "pytest-xdist>=3.8.0",
@@ -156,7 +156,7 @@ dev = [
     # no-emit-package below so a frozen SHA in the lock cannot conflict with the
     # unpinned URL.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
-    "coverage==7.15.0",
+    "coverage==7.15.2",
     "hypothesis>=6.115.1",
     "pre-commit",
     "bandit",

--- a/requirements.lock
+++ b/requirements.lock
@@ -96,7 +96,7 @@ comm==0.2.3
     # via
     #   ipykernel
     #   ipywidgets
-coverage==7.15.0
+coverage==7.15.2
     # via
     #   portable-alpha-extension-model (pyproject.toml)
     #   pytest-cov
@@ -684,7 +684,7 @@ rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.20
+ruff==0.15.22
     # via portable-alpha-extension-model (pyproject.toml)
 secretstorage==3.5.0 ; platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'
     # via keyring


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 5 version updates:
  - ruff: ==0.15.20 -> ==0.15.22
  - mypy: >=2.1.0 -> ==2.3.0
  - coverage: ==7.15.0 -> ==7.15.2
  - requirements.lock:coverage: 7.15.0 -> ==7.15.2
  - requirements.lock:ruff: 0.15.20 -> ==0.15.22

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling to newer pinned versions.
  * Standardized the type-checking tool to a specific version for more consistent development and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->