### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,12 +143,12 @@ llm = [
 # Development dependencies
 dev = [
     "ruff==0.15.22",
-    "black>=26.5.1",
-    "isort>=8.0.1",
+    "black==26.5.1",
+    "isort==8.0.1",
     "mypy==2.3.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "pytest-xdist>=3.8.0",
+    "pytest-xdist==3.8.0",
     # Shared app behavior baseline harness (pulls pytest-regressions). Tracked
     # as an unpinned `@main` git direct reference so it picks up upstream
     # baseline_kit improvements (e.g. the py.typed marker) instead of staying
@@ -162,7 +162,7 @@ dev = [
     "bandit",
     "types-PyYAML",
     "flake8",
-    "docformatter>=1.7.8",
+    "docformatter==1.7.8",
     "packaging",
 ]
 


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 4 version updates:
  - black: >=26.5.1 -> ==26.5.1
  - isort: >=8.0.1 -> ==8.0.1
  - pytest-xdist: >=3.8.0 -> ==3.8.0
  - docformatter: >=1.7.8 -> ==1.7.8

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`