### PR TITLE
Format dashboard/app.py caption (post-#2224 lint-format debt)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -265,7 +265,9 @@ def main() -> None:
     # Group the tools so first-timers can tell run paths from inputs/outputs, and
     # where each run's results appear.
     st.markdown("**Run a scenario**")
-    st.caption("Stress Lab & Scenario Grid show results in-page; the Scenario Wizard writes to the Results page.")
+    st.caption(
+        "Stress Lab & Scenario Grid show results in-page; the Scenario Wizard writes to the Results page."
+    )
     st.page_link("pages/6_Stress_Lab.py", label="Stress Lab (presets)")
     st.page_link("pages/5_Scenario_Grid.py", label="Scenario Grid & Frontier (beta)")
     st.page_link("pages/3_Scenario_Wizard.py", label="Scenario Wizard")


### PR DESCRIPTION
## Summary
- Black-reformats the Scenario Wizard caption in `dashboard/app.py` that fails main CI `lint-format` (run 31914675704 on `bc68b1c`).
- Addresses verifier Anthropic CONCERNS on merged PR #2224 (lint-format failure floors verdict).

## Context
Orphan sweep / closer round discovered main `Python CI / lint-format` failing on `dashboard/app.py` after #2224 merged. No linked source issue; this is bounded post-merge hygiene for #2224 verifier disposition.

## Validation
- `uv run black --check --line-length 100 dashboard/app.py`
- `git diff --check`

## Test plan
- [ ] CI `Python CI / lint-format` passes on this head
- [ ] Re-run or await verifier disposition on #2224 after merge

Relates to #2224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted the home-page scenario guidance caption for improved code readability without changing its text or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->